### PR TITLE
Updated the git clone url

### DIFF
--- a/doc/helm.tex
+++ b/doc/helm.tex
@@ -64,12 +64,12 @@
 First get the files from git repo:
 
 Helm git repo is at:\\
-\url{http://repo.or.cz/w/helm-config.git}\\
+\url{https://github.com/thierryvolpiatto/emacs-helm}\\
 You will find there tarballs of differents versions.\\
 
 To get it with git:
 \begin{verbatim}
-git clone git://repo.or.cz/helm-config.git
+git clone https://github.com/thierryvolpiatto/emacs-helm
 \end{verbatim}
 NOTE: Files are published on Emacswiki, but be aware that it is \underline{unsafe} to get files from Emacswiki,\\
 thus, helm is not maintained anymore on Emacswiki, so files found there should be deprecated.\\


### PR DESCRIPTION
I've updated the git clone url in the documentation, but I don't have `pdflatex`, so you'll have to rebuild the pdf yourself.
