### PR TITLE
add face helm-selection

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -814,8 +814,13 @@ See also `helm-set-source-filter'.")
     '((t (:background "Yellow" :foreground "black")))
   "Face for candidate number in mode-line." :group 'helm)
 
-(defvar helm-selection-face 'highlight
-  "*Face for currently selected item.")
+(defface helm-selection
+    '((t (:inherit highlight)))
+  "Face for currently selected item in the helm buffer."
+  :group 'helm)
+
+(defvar helm-selection-face 'helm-selection
+  "*Face for currently selected item in the helm buffer.")
 
 (defvar helm-buffer "*helm*"
   "Buffer showing completions.")


### PR DESCRIPTION
Add face `helm-selection` with default value `((t :inherit 'highlight))` and change the default value of variable `helm-selection-face` from `highlight` to `helm-selection`. So it looks the same as before but is easier to customize as one does not have to define a new face to do so independently of `highlight`.

By the way what are the `*-face` variables needed for? Can they be removed completely? This isn't consistent anyway: only for a few faces a variable also exists.

@bbatsov regarding `zenburn-theme`: I like `zenburn-bg-05` as `highlight` (exactly because the difference to `zenburn-bg` is rather small) however in the `helm` buffer this is not visible enough. I suggest that `zenburn-bg-1` or even something more visible is used for `helm-selection` once it is added.
