### PR TITLE
helm-config.el: Gather lacarte menu items from current buffer.

### DIFF
--- a/helm-config.el
+++ b/helm-config.el
@@ -6216,8 +6216,10 @@ word in the function's name, e.g. \"bb\" is an abbrev for
 ;;; LaCarte
 (defvar helm-c-source-lacarte
   '((name . "Lacarte")
-    (init . (lambda () (require 'lacarte )))
-    (candidates . (lambda () (delete '(nil) (lacarte-get-overall-menu-item-alist))))
+    (init . (lambda () (require 'lacarte)))
+    (candidates . (lambda ()
+                    (with-helm-current-buffer
+                      (delete '(nil) (lacarte-get-overall-menu-item-alist)))))
     (candidate-number-limit . 9999)
     (action . helm-c-call-interactively))
   "Needs lacarte.el.


### PR DESCRIPTION
The current lacarte source is mostly useless as it not gathers the menu items from the buffer that called helm but from the helm buffer itself.
