### PR TITLE
Loading helm-config modifies built-in maps behind the users back

### DIFF
--- a/helm-config.el
+++ b/helm-config.el
@@ -98,6 +98,7 @@
 (declare-function undo-tree-restore-state-from-register "ext:undo-tree.el" (register))
 
 
+
 ;;; General internal variables
 ;;
 ;; Some internals variable that need to be loaded
@@ -155,21 +156,6 @@ automatically.")
 (define-key helm-command-map (kbd "C-c C-b")   'helm-browse-code)
 (define-key helm-command-map (kbd "C-x r i")   'helm-register)
 (define-key helm-command-map (kbd "C-c C-x")   'helm-c-run-external-command)
-
-;; In Emacs 23.1.50, minibuffer-local-must-match-filename-map was renamed to
-;; minibuffer-local-filename-must-match-map.
-(defvar minibuffer-local-filename-must-match-map (make-sparse-keymap)) ;; Emacs 23.1.+
-(defvar minibuffer-local-must-match-filename-map (make-sparse-keymap)) ;; Older Emacsen
-(dolist (map (list minibuffer-local-filename-completion-map
-                   minibuffer-local-completion-map
-                   minibuffer-local-must-match-filename-map
-                   minibuffer-local-filename-must-match-map
-                   minibuffer-local-map
-                   minibuffer-local-isearch-map
-                   minibuffer-local-must-match-map
-                   minibuffer-local-ns-map))
-  (define-key map "\C-r" 'helm-minibuffer-history))
-
 
 
 ;;; Menu

--- a/helm-vars.el
+++ b/helm-vars.el
@@ -164,19 +164,42 @@ This will be use with `format', so use something like \"wmctrl -xa %s\"."
   :type 'string
   :group 'helm-config)
 
-(defun helm-set-helm-command-map-prefix-key (var key)
-  "The customize set function for `helm-command-map-prefix-key'."
-  (when (boundp var)
-    (define-key global-map (read-kbd-macro (symbol-value var)) nil))
-  (set var key)
-  (define-key global-map
-      (read-kbd-macro (symbol-value var)) 'helm-command-map))
+(defcustom helm-command-prefix-key "C-x c"
+  "The key `helm-command-prefix' is bound to in the global map."
+  :type '(choice (string :tag "Key") (const :tag "no binding"))
+  :group 'helm-config
+  :set
+  (lambda (var key)
+    (when (and (boundp var) (symbol-value var))
+      (define-key (current-global-map)
+        (read-kbd-macro (symbol-value var)) nil))
+    (when key
+      (define-key (current-global-map)
+        (read-kbd-macro key) 'helm-command-prefix))
+    (set var key)))
 
-(defcustom helm-command-map-prefix-key "C-x c"
-  "The prefix key for all `helm-command-map' commands."
-  :type  'string
-  :set   'helm-set-helm-command-map-prefix-key
-  :group 'helm-config)
+(defcustom helm-minibuffer-history-key "C-r"
+  "The key `helm-minibuffer-history' is bound to in minibuffer local maps."
+  :type '(choice (string :tag "Key") (const :tag "no binding"))
+  :group 'helm-config
+  :set
+  (lambda (var key)
+    (dolist (map '(minibuffer-local-completion-map
+                   minibuffer-local-filename-completion-map
+                   minibuffer-local-filename-must-match-map ; Emacs 23.1.+
+                   minibuffer-local-isearch-map
+                   minibuffer-local-map
+                   minibuffer-local-must-match-filename-map ; Older Emacsen
+                   minibuffer-local-must-match-map
+                   minibuffer-local-ns-map))
+      (when (and (boundp map) (keymapp (symbol-value map)))
+        (when (and (boundp var) (symbol-value var))
+          (define-key (symbol-value map)
+            (read-kbd-macro (symbol-value var)) nil))
+        (when key
+          (define-key (symbol-value map)
+            (read-kbd-macro key) 'helm-minibuffer-history))))
+    (set var key)))
 
 (defcustom helm-c-browse-code-regexp-lisp
   "^ *\(def\\(un\\|subst\\|macro\\|face\\|alias\\|advice\\|struct\\|\


### PR DESCRIPTION
helm does not bind `helm` automatically. Instead the user is instructed to add the following to his init file:

```
(global-set-key (kbd "C-c h") 'helm)
```

However `helm-minibuffer-history` is bound in all built-in minibuffer local maps just by loading `helm-config` without a way to prevent this. (Users might want to use something else but `"C-r"`.)

(Doing this in every map is unnecessary anyway. It is enough to do it in `minibuffer-local-map` from which almost all minibuffer local maps inherit (at least all that are currently modified) and `minibuffer-local-isearch-map` (which binds `"C-r"` to `isearch-reverse-exit-minibuffer`, which we probably should not change).

Likewise `"C-x c"` is bound to `helm-command-map` in `global-map`. A crude way exist to change the binding but that has implications which are not obvious without reading the code.

I suggest that the code that makes these changes is removed and replaced with instructions on how to accomplish the same manually:

```
(global-set-key (kbd "C-c h") 'helm)
(global-set-key (kbd "C-x c") 'helm-command-map)
(define-key minibuffer-local-map (kbd "C-r") 'helm-minibuffer-history)
(define-key minibuffer-local-isearch-map (kbd "C-r") 'helm-minibuffer-history) ; instead we should pick a different key
```

Even better a function to do the above could be provided which has to be called explicitly by the user:

```
(defun helm-setup-default-bindings ()
  "Make the default helm bindings in `global-map` and `minibuffer-local-map`.
This binds ...
If you want to use different keys don't call this function; instead bind the commands mentioned
above manually.  If you don't know how to do so have a look at the source of this function for an
example (M-x find-function RET helm-setup-default-bindings RET)."
  ...)
```
