### PR TITLE
remove "-face" suffix from face symbols

### DIFF
--- a/helm-bookmark.el
+++ b/helm-bookmark.el
@@ -28,7 +28,7 @@
   "Predefined configurations for `helm.el'."
   :group 'helm)
 
-(defface helm-bookmarks-su-face
+(defface helm-bookmarks-su
     '((t (:foreground "red")))
   "Face for su/sudo bookmarks."
   :group 'helm-bookmark)
@@ -149,7 +149,7 @@
 
 (defun helm-c-highlight-not-logged (files source)
   (loop for i in files
-        collect (propertize i 'face 'helm-bookmarks-su-face)))
+        collect (propertize i 'face 'helm-bookmarks-su)))
 
 (defun helm-c-highlight-bookmark (bookmarks source)
   "Used as `candidate-transformer' to colorize bookmarks.

--- a/helm-command.el
+++ b/helm-command.el
@@ -36,7 +36,7 @@ Set it to 0 to disable requires-pattern in `helm-M-x'."
 ;;; Faces
 ;;
 ;;
-(defface helm-M-x-key-face '((t (:foreground "orange" :underline t)))
+(defface helm-M-x-key '((t (:foreground "orange" :underline t)))
   "*Face used in helm-M-x to show keybinding."
   :group 'helm-command)
 
@@ -87,12 +87,12 @@ Show global bindings and local bindings according to current `major-mode'."
                        (format "%s (%s)"
                                cand (propertize
                                      local-key
-                                     'face 'helm-M-x-key-face)))
+                                     'face 'helm-M-x-key)))
                       ((string-match "^M-x" key) cand)
                       (t (format "%s (%s)"
                                  cand (propertize
                                        key
-                                       'face 'helm-M-x-key-face))))
+                                       'face 'helm-M-x-key))))
                 cand) into ls
           finally return
           (sort ls #'(lambda (x y) (string-lessp (car x) (car y)))))))

--- a/helm-gentoo.el
+++ b/helm-gentoo.el
@@ -29,7 +29,7 @@
   "Predefined configurations for `helm.el'."
   :group 'helm)
 
-(defface helm-gentoo-match-face '((t (:foreground "red")))
+(defface helm-gentoo-match '((t (:foreground "red")))
   "Face for helm-gentoo installed packages."
   :group 'traverse-faces)
 
@@ -228,7 +228,7 @@
   "Highlight all installed package."
   (loop for i in eix
         if (member i helm-c-cache-world)
-        collect (propertize i 'face 'helm-gentoo-match-face)
+        collect (propertize i 'face 'helm-gentoo-match)
         else
         collect i))
 
@@ -236,7 +236,7 @@
   (let ((local-uses (helm-c-gentoo-get-local-use)))
     (loop for i in use-flags
           if (member i local-uses)
-          collect (propertize i 'face 'helm-gentoo-match-face)
+          collect (propertize i 'face 'helm-gentoo-match)
           else
           collect i)))
 

--- a/helm-utils.el
+++ b/helm-utils.el
@@ -46,7 +46,7 @@ It is a float, usually 1024.0 but could be 1000.0 on some systems."
   :group 'helm-utils
   :type 'float)
 
-(defface helm-overlay-line-face
+(defface helm-overlay-line
     '((t (:background "IndianRed4" :underline t)))
   "Face for source header in the helm buffer."
   :group 'helm-utils)
@@ -441,7 +441,7 @@ Useful in dired buffers when there is inserted subdirs."
         (setq helm-match-line-overlay (apply 'make-overlay args))
         (apply 'move-overlay helm-match-line-overlay args)))
   (overlay-put helm-match-line-overlay
-               'face (or face 'helm-overlay-line-face))
+               'face (or face 'helm-overlay-line))
   (when rec
     (goto-char start)
     (recenter)))

--- a/helm-w3m.el
+++ b/helm-w3m.el
@@ -34,7 +34,7 @@
   "W3m related Applications and libraries for Helm."
   :group 'helm)
 
-(defface helm-w3m-bookmarks-face '((t (:foreground "cyan1" :underline t)))
+(defface helm-w3m-bookmarks '((t (:foreground "cyan1" :underline t)))
   "Face for w3m bookmarks" :group 'helm-w3m)
 
 
@@ -94,7 +94,7 @@ http://emacs-w3m.namazu.org/")
 (defun helm-c-highlight-w3m-bookmarks (bookmarks source)
   (loop for i in bookmarks
         collect (propertize
-                 i 'face 'helm-w3m-bookmarks-face
+                 i 'face 'helm-w3m-bookmarks
                  'help-echo (helm-c-w3m-bookmarks-get-value i))))
 
 


### PR DESCRIPTION
From elisp>Defining Faces

```
You should not quote the symbol FACE, and it
should not end in `-face' (that would be redundant).
```
