### PR TITLE
Semantic source

### DIFF
--- a/helm-semantic.el
+++ b/helm-semantic.el
@@ -1,9 +1,7 @@
 ;;; helm-semantic.el --- Helm interface for Semantic
 
-;; Copyright (C) 2012 Thierry Volpiatto <thierry.volpiatto@gmail.com>
-;; Author: Thierry Volpiatto <thierry.volpiatto@gmail.com>
-;;     rubikitch <rubikitch@ruby-lang.org>
-;;     Tassilo Horn <tassilo@member.fsf.org>
+;; Copyright (C) 2012 Daniel Hackney <dan@haxney.org>
+;; Author: Daniel Hackney <dan@haxney.org>
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -20,57 +18,81 @@
 
 ;;; Commentary:
 
-;; Quick and dirty port from `anything-c-source-semantic'. No modifications have
-;; been made to be more suited to `helm'.
+;; Uses `candidates-in-buffer' for speed.
 
 ;;; Code:
 
-;; Dirty port of `anything-c-source-semantic'
-(defvar helm-semantic-candidates nil)
+(eval-when-compile
+  (require 'cl))
 
-(defun helm-semantic-construct-candidates (tags depth)
-  (when (require 'semantic nil t)
-    (apply
-     'append
-     (mapcar
-      (lambda (tag)
-        (if (listp tag)
-            (let ((type (semantic-tag-type tag))
-                  (class (semantic-tag-class tag)))
-              (if (or (and (stringp type)
-                           (or (string= type "class")
-                               (string= type "namespace")))
-                      (eq class 'function)
-                      (eq class 'variable))
-                  (cons (cons (concat (make-string (* depth 2) ?\s)
-                                      (semantic-format-tag-summarize tag nil t))
-                              tag)
-                        (helm-semantic-construct-candidates
-                         (semantic-tag-components tag) (1+ depth)))))))
-      tags))))
+(require 'semantic)
+
+(defun helm-semantic-init-candidates (tags depth)
+  "Write the contents of TAGS to the current buffer."
+  (dolist (tag tags)
+    (when (listp tag)
+      (case (semantic-tag-class tag)
+
+        ((function variable type)
+         (insert
+          (make-string (* depth 2) ?\s)
+          ;; Save the tag for later
+          (propertize (semantic-format-tag-summarize tag nil t) 'semantic-tag tag)
+          "\n")
+         ;; Recurse to children
+         (helm-semantic-init-candidates
+          (semantic-tag-components tag) (1+ depth)))
+
+        ;; Don't do anything with packages or includes for now
+        ((package include))
+        ;; Catch-all
+        (t)))))
 
 (defun helm-semantic-default-action (candidate)
-  (let ((tag (cdr (assoc candidate helm-semantic-candidates))))
+  ;; By default, helm doesn't pass on the text properties of the selection. Fix
+  ;; this.
+  (setq candidate (helm-get-selection nil 'withprop))
+  (let ((tag (get-text-property 0 'semantic-tag candidate)))
+    (push-mark)
     (semantic-go-to-tag tag)))
 
 (defvar helm-c-source-semantic
   '((name . "Semantic Tags")
     (init . (lambda ()
-              (setq helm-semantic-candidates
-                    (ignore-errors (helm-semantic-construct-candidates
-                                    (semantic-fetch-tags) 0)))))
-    (candidates . (lambda ()
-                    (if helm-semantic-candidates
-                        (mapcar 'car helm-semantic-candidates))))
+              (let ((tags (semantic-fetch-tags)))
+                (with-current-buffer (helm-candidate-buffer 'global)
+                  (helm-semantic-init-candidates tags 0)))))
+    (candidates-in-buffer)
+    (get-line . buffer-substring)
     (persistent-action . (lambda (elm)
                            (helm-semantic-default-action elm)
                            (helm-match-line-color-current-line)))
     (persistent-help . "Show this entry")
     (action . helm-semantic-default-action)
-    "Needs semantic in CEDET.
+    "Source to search tags using Semantic from CEDET."))
 
-http://cedet.sourceforge.net/semantic.shtml
-http://cedet.sourceforge.net/"))
+;;;###autoload
+(defun helm-semantic ()
+  "Preconfigured `helm' for `semantic'."
+  (interactive)
+  (helm :sources 'helm-c-source-semantic
+        :buffer "*helm semantic*"))
+
+;;;###autoload
+(defun helm-semantic-or-imenu ()
+  "Run `helm' with `semantic' or `imenu'.
+
+If `semantic-mode' is active in the current buffer, then use
+semantic for generating tags, otherwise fall back to `imenu'.
+Fill in the symbol at point by default."
+  (interactive)
+  (let ((source (if (semantic-active-p)
+                    'helm-c-source-semantic
+                  'helm-c-source-imenu)))
+    (push-mark)
+    (helm :sources source
+          :buffer "*helm semantic/imenu*"
+          :preselect (thing-at-point 'symbol))))
 
 (provide 'helm-semantic)
 


### PR DESCRIPTION
I resurrected the `semantic` source from the version used with `anything`. Could you pull it?
