### PR TITLE
Don't require 'org in helm-files.el

### DIFF
--- a/helm-files.el
+++ b/helm-files.el
@@ -34,7 +34,6 @@
 (require 'dired-x)
 (require 'tramp)
 (require 'image-dired)
-(require 'org)
 
 (declare-function find-library-name "find-func.el" (library))
 (declare-function secure-hash "ext:fns.c" (algorithm object &optional start end binary))


### PR DESCRIPTION
I see only one place in the file where org-mode vars are used (namely, org-directory), and it's guarded by the check `(eq major-mode 'org-agenda-mode)`.

Meanwhile, `(require 'org)` takes 0.6 seconds on my machine. I'd rather it didn't.
