### PR TITLE
`helm-find-files' should ignore case while matching path/file name on Wi...

### DIFF
--- a/helm-files.el
+++ b/helm-files.el
@@ -2635,11 +2635,13 @@ This is the starting point for nearly all actions you can do on files."
   (declare (special org-directory))
   (let ((any-input (if (and arg helm-ff-history)
                        (helm-find-files-history)
-                       (helm-find-files-initial-input)))
-        (presel    (buffer-file-name (current-buffer))))
+                     (helm-find-files-initial-input)))
+        (presel    (buffer-file-name (current-buffer)))
+        (helm-case-fold-search
+         (if (eq system-type 'windows-nt) t helm-case-fold-search)))
     (cond ((and (eq major-mode 'org-agenda-mode)
-               org-directory
-               (not any-input))
+                org-directory
+                (not any-input))
            (setq any-input (expand-file-name org-directory)))
           ((and (eq major-mode 'dired-mode) any-input)
            (setq presel any-input)
@@ -2650,7 +2652,7 @@ This is the starting point for nearly all actions you can do on files."
     (helm-find-files-1
      any-input (if helm-ff-transformer-show-only-basename
                    (and presel (helm-c-basename presel))
-                   presel))))
+                 presel))))
 
 ;;;###autoload
 (defun helm-write-file ()


### PR DESCRIPTION
Hi Thierry,

I've found that the matching in `helm-find-files' is "smart", which makes sense in nix system, however, this behavior is very inconvenience in Windows system because you know in Windows system file names are NOT case sensitive. Let's say I want to find a file in the directory "C:/Program Files/Microsoft Visual C++/" if I type "c:/pro", I get expanded to "C:/Program Files/" which is perfectly fine, however, since there is a upper case letter ("P") in the pattern now, matching becomes case sensitive, and I have to type "Microsoft" instead of "microsoft".

I have changed this behavior and have submitted a pull request. Please feel free to change the implementation if you think you could have a better implementation.

Thanks,
York
