### PR TITLE
improvements to case-fold when reading filenames

### DIFF
--- a/helm-files.el
+++ b/helm-files.el
@@ -1838,7 +1838,7 @@ Use it for non--interactive calls of `helm-find-files'."
         helm-samewindow)
     (helm :sources 'helm-c-source-find-files
           :input fname
-          :case-fold-search helm-read-file-name-case-fold-search
+          :case-fold-search helm-file-name-case-fold-search
           :keymap helm-find-files-map
           :preselect preselect
           :prompt "Find Files or Url: "

--- a/helm-mode.el
+++ b/helm-mode.el
@@ -69,16 +69,6 @@ See `helm-case-fold-search' for more info."
   :group 'helm-mode
   :type 'symbol)
 
-(defcustom helm-read-file-name-case-fold-search
-  (if (memq system-type
-            '(cygwin windows-nt ms-dos darwin))
-      t
-    helm-case-fold-search)
-  "Default Local setting of `helm-case-fold-search' for `helm-c-read-file-name'.
-See `helm-case-fold-search' for more info."
-  :group 'helm-mode
-  :type 'symbol)
-
 
 (defvar helm-comp-read-map
   (let ((map (make-sparse-keymap)))
@@ -620,7 +610,7 @@ See documentation of `completing-read' and `all-completions' for details."
      (initial-input (expand-file-name default-directory))
      (buffer "*Helm Completions*")
      test
-     (case-fold helm-read-file-name-case-fold-search)
+     (case-fold helm-file-name-case-fold-search)
      (preselect nil)
      (history nil)
      must-match

--- a/helm.el
+++ b/helm.el
@@ -222,6 +222,19 @@ See in helm-grep.el how it is implemented."
   :group 'helm
   :type 'symbol)
 
+
+(defcustom helm-file-name-case-fold-search
+  (if (memq system-type
+            '(cygwin windows-nt ms-dos darwin))
+      t
+    helm-case-fold-search)
+  "Local setting of `helm-case-fold-search' for reading filenames.
+
+See `helm-case-fold-search' for more info."
+  :group 'helm
+  :type 'symbol)
+
+
 (defcustom helm-reuse-last-window-split-state nil
   "Reuse the last state of window split, vertical or horizontal.
 That is when you use `helm-toggle-resplit-window' the next helm session


### PR DESCRIPTION
- more intuitive defaults based on OS
- move setting from helm-mode into helm.el (where it belongs, IMO, because it
  affects general filename reading.
- rename setting
