### PR TITLE
add helm-apropos-at-point

### DIFF
--- a/helm-config.el
+++ b/helm-config.el
@@ -47,7 +47,7 @@
 ;;
 (defvar helm-command-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "a")         'helm-c-apropos)
+    (define-key map (kbd "a")         'helm-apropos-at-point)
     (define-key map (kbd "e")         'helm-c-etags-select)
     (define-key map (kbd "l")         'helm-locate)
     (define-key map (kbd "s")         'helm-surfraw)

--- a/helm-elisp.el
+++ b/helm-elisp.el
@@ -369,6 +369,24 @@ a double quote or between."
                     helm-c-source-helm-attributes))
           :buffer "*helm apropos*")))
 
+;;;###autoload
+(defun helm-apropos-at-point (prefix)
+  "Preconfigured helm to describe commands, functions, variables and faces.
+When prefix is given, initial input is the symbol at point. "
+  (interactive "P")
+  (let ((default (thing-at-point 'symbol)))
+    (helm :sources
+          (mapcar (lambda (func)
+                    (funcall func default))
+                  '(helm-c-source-emacs-commands
+                    helm-c-source-emacs-functions
+                    helm-c-source-emacs-variables
+                    helm-c-source-emacs-faces
+                    helm-c-source-helm-attributes))
+          :buffer "*helm apropos*"
+          :input  (and prefix default))))
+
+
 
 ;;; Advices
 ;;


### PR DESCRIPTION
This is exactly like helm-info-at-point, with prefix initial input is the symbol at point. 

(As I also pointed in issue #154 the "default" argument to helm-elisp.el sources doesn't seem to do anything useful except complicating the code. Also, may be it is a good idea to rename helm-c-apropos into helm-apropos.)
