### PR TITLE
 *hlbookmark list* buffer should be hidden

### DIFF
--- a/helm-bookmark.el
+++ b/helm-bookmark.el
@@ -123,7 +123,7 @@
     (init . (lambda ()
               (require 'bookmark)
               (helm-init-candidates-in-buffer
-               "*hlbookmark list*" (helm-c-collect-bookmarks :local t))))
+               " *hlbookmark list*" (helm-c-collect-bookmarks :local t))))
     (candidates-in-buffer)
     (filtered-candidate-transformer
      helm-c-adaptive-sort


### PR DESCRIPTION
 _hlbookmark list_ buffer rarely don't edit. I think thin buffer should be hidden.
