### PR TITLE
Add commands to invoke (multi) occur form isearch

### DIFF
--- a/helm-config.el
+++ b/helm-config.el
@@ -1680,9 +1680,9 @@ Preconfigured helm to show org headlines.
 
 ;;;***
 
-;;;### (autoloads (helm-browse-code helm-multi-occur helm-occur-from-isearch
-;;;;;;  helm-occur helm-regexp) "helm-regexp" "helm-regexp.el" (20825
-;;;;;;  24627 0 0))
+;;;### (autoloads (helm-browse-code helm-multi-occur-from-isearch
+;;;;;;  helm-multi-occur helm-occur-from-isearch helm-occur helm-regexp)
+;;;;;;  "helm-regexp" "helm-regexp.el" (20825 26373 0 0))
 ;;; Generated autoloads from helm-regexp.el
 
 (autoload 'helm-regexp "helm-regexp" "\
@@ -1711,6 +1711,16 @@ The prefix arg can be set before calling `helm-multi-occur'
 or during the buffer selection.
 
 \(fn BUFFERS)" t nil)
+
+(autoload 'helm-multi-occur-from-isearch "helm-regexp" "\
+Invoke `helm-multi-occur' from isearch.
+
+With a prefix arg, reverse the behavior of
+`helm-moccur-always-search-in-current'.
+The prefix arg can be set before calling
+`helm-multi-occur-from-isearch' or during the buffer selection.
+
+\(fn &optional ARG)" t nil)
 
 (autoload 'helm-browse-code "helm-regexp" "\
 Preconfigured helm to browse code.

--- a/helm-regexp.el
+++ b/helm-regexp.el
@@ -485,6 +485,28 @@ or during the buffer selection."
     (helm-multi-occur-1 buffers)))
 
 ;;;###autoload
+(defun helm-multi-occur-from-isearch (&optional arg)
+  "Invoke `helm-multi-occur' from isearch.
+
+With a prefix arg, reverse the behavior of
+`helm-moccur-always-search-in-current'.
+The prefix arg can be set before calling
+`helm-multi-occur-from-isearch' or during the buffer selection."
+  (interactive "p")
+  (let ((helm-moccur-always-search-in-current
+         (if (or current-prefix-arg
+                 helm-current-prefix-arg)
+             (not helm-moccur-always-search-in-current)
+           helm-moccur-always-search-in-current))
+        (input (if isearch-regexp
+                   isearch-string
+                 (regexp-quote isearch-string))))
+    (isearch-exit)
+    (helm-multi-occur-1
+     (helm-comp-read "Buffers: " (helm-buffer-list) :marked-candidates t)
+     input)))
+
+;;;###autoload
 (defun helm-browse-code ()
   "Preconfigured helm to browse code."
   (interactive)


### PR DESCRIPTION
There is a similar command in [helm-c-moccur.el](https://github.com/emacs-helm/helm-c-moccur) and it is usefull.  Could you pull it?
