### PR TITLE
file-name-as-directory causes error when its argument is nil

### DIFF
--- a/helm-files.el
+++ b/helm-files.el
@@ -1428,7 +1428,7 @@ If basename contain one or more space fallback to match-plugin.
 If FNAME is a valid directory name,return FNAME unchanged."
   (setq fname (helm-ff-handle-backslash fname))
   (let ((bn      (helm-basename fname))
-        (bd      (file-name-as-directory (file-name-directory fname)))
+        (bd      (condition-case nil (file-name-as-directory (file-name-directory fname)) (error nil)))
         (dir-p   (file-directory-p fname))
         (tramp-p (loop for (m . f) in tramp-methods
                        thereis (string-match m fname))))


### PR DESCRIPTION
I stumbled upon a problem with the newest helm and emacs (version 24.3 from an ubuntu ppa). Whenever I would use helm-source-find-files in a custom helm command, like (helm :sources '(helm-source-find-files)), it would cause an error telling me about a type error with helm-find-files-get-candidates (as it is coded in helm-get-candidates when an error occurs trying to funcall the candidates-fn var).

This didn't make sense at first to me, since helm-find-files-get-candidates is clearly a function, and testing it worked fine, until I discovered that in helm-ff-transform-fname-for-completion, under certain circumstances, an error would be caused by file-name-as-directory.

So this little fix works around that problem. I am not completly sure how helm-ff-transform-fname-for-completion is supposed to work internally, so maybe this needs to be adjusted.
