### PR TITLE
typo: pcomplete --> eshell-pcomplete

### DIFF
--- a/doc/Home.mdpp
+++ b/doc/Home.mdpp
@@ -828,7 +828,7 @@ is to enable it with helm support.
 >     (add-hook 'eshell-mode-hook
 >               #'(lambda ()
 >                   (define-key eshell-mode-map
->                     [remap pcomplete]
+>                     [remap eshell-pcomplete]
 >                     'helm-esh-pcomplete)))
 
 Now when hitting `TAB`, you should have helm pcompletion.


### PR DESCRIPTION
Suggested modification for the helm wiki. I guess it should be `[remap eshell-pcomplete]` instead of `[remap pcomplete]`.
