### PR TITLE
Only match completely blank entries.  Fixes #279.

### DIFF
--- a/helm-ring.el
+++ b/helm-ring.el
@@ -82,7 +82,7 @@ If nil or zero (disabled), don't truncate candidate, show all."
 (defun helm-kill-ring-candidates ()
   (loop for kill in (helm-fast-remove-dups kill-ring :test 'equal)
         unless (or (< (length kill) helm-kill-ring-threshold)
-                   (string-match "^\\(\\s-\\|\t\\)+$" kill))
+                   (string-match "\\`[\n[:blank:]]+\\'" kill))
         collect kill))
 
 (defun helm-kill-ring-transformer (candidates source)


### PR DESCRIPTION
The string didn't match over new line characters.

" \n "  => 0
"Test"  => nil
"a\n "  => 2
" \na"  => 0

This change has allows strings that start or end with white space
characters to display in the helm completion list.

" \n "  => 0
"Test"  => nil
"a\n "  => nil
" \na"  => nil
