### PR TITLE
When possible display the term-mode buffers current path instead of the process in the helm-buffers-list

### DIFF
--- a/helm-buffers.el
+++ b/helm-buffers.el
@@ -206,6 +206,7 @@ Should be called after others transformers i.e (boring buffers)."
         for i in buffers
         for buf = (get-buffer i)
         for proc = (get-buffer-process buf)
+        for dir = (with-current-buffer i term-ansi-at-dir)
         for size = (propertize (helm-buffer-size buf)
                                'face 'helm-buffer-size)
         for len-size = (length size)
@@ -282,8 +283,10 @@ Should be called after others transformers i.e (boring buffers)."
                                " " str-before-size size "  " mode
                                (and proc
                                     (propertize
-                                     (format " (%s %s)"
-                                             proc (process-status proc))
+                                     (if dir
+                                         (format " (%s)" dir)
+                                         (format " (%s %s)"
+                                                 proc (process-status proc)))
                                      'face 'helm-buffer-process)))
                        i)))))
 


### PR DESCRIPTION
Hi,

I have recently been trying to figure out a way to deal with using shells in emacs, and this seems to help.  It displays the current path instead of the process information in the buffer listing if it's available.  You have to set your shell up as discribed in term.el to emmit the correct escape characters to make this work.  I am using multi-term.el in this example but ansi-term will work as well.

Thanks,
Russell

Example output:

```
*terminal<1>*                16.1K  term-mode (/)
*terminal<2>*                  843  term-mode (/home/russell/projects/helm)
```
