### PR TITLE
Improve StumpWM command formatting.

### DIFF
--- a/helm-misc.el
+++ b/helm-misc.el
@@ -275,8 +275,10 @@ It is added to `extended-command-history'.
     (with-current-buffer (helm-candidate-buffer 'global)
       (save-excursion
         (call-process "stumpish" nil (current-buffer) nil "commands"))
-      (while (re-search-forward "\\([^ ]+\\) \n?" nil t)
-        (replace-match "\\1\n"))
+      (while (re-search-forward "[ ]*\\([^ ]+\\)[ ]*\n?" nil t)
+        (replace-match "\n\\1\n"))
+      (delete-blank-lines)
+      (sort-lines nil (point-min) (point-max))
       (goto-char (point-max))))
 
 (defun helm-stumpwm-commands-execute (candidate)


### PR DESCRIPTION
This is patch fixes 2 minor formatting bugs in the helm stump commands module.

Origionally the output looked like:

![screenshot from 2013-09-15 08 44 42](https://f.cloud.github.com/assets/2660/1144384/8c9aba96-1d8f-11e3-9ee5-5ddbea518b1a.png)

This patch sorts and removes any whitespace around the commands:

![screenshot from 2013-09-15 08 44 09](https://f.cloud.github.com/assets/2660/1144385/a7ce7078-1d8f-11e3-936f-5bce319c37e0.png)
