### PR TITLE
Helm M-[ issue

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -26,7 +26,7 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-;;; Codef
+;;; Code:
 
 (require 'cl)
 


### PR DESCRIPTION
This plagued ergoemacs-mode for a long time... But I fixed it :)

See Issue #321.

You may want to be careful of M-[ M-O and ESC in the future as well. Emacs suggests you don't bind these keys at all:

http://www.gnu.org/software/emacs/manual/html_node/elisp/Translation-Keymaps.html

<quote>
... it is better to avoid binding commands to key sequences where the end of the key sequence is a prefix of a key translation. The main such problematic suffixes/prefixes are <ESC>, M-O (which is really <ESC> O) and M-[ (which is really <ESC> [).
</quote>
