### PR TITLE
Make helm-marked-candidates always return candidates

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -4109,20 +4109,20 @@ Only useful for debugging."
 
 (defun helm-marked-candidates ()
   "Return marked candidates of current source if any.
-Otherwise one element list of current selection.
+Otherwise one element list of current candidate.
 
 It is analogous to `dired-get-marked-files'."
   (with-current-buffer (helm-buffer-get)
-    (let ((cands
-           (if helm-marked-candidates
-               (loop with current-src = (helm-get-current-source)
-                     for (source . real) in (reverse helm-marked-candidates)
-                     when (equal current-src source)
-                     collect (helm-coerce-selection real source))
-               (list (helm-get-selection)))))
+    (let* ((current-src (helm-get-current-source))
+           (cands
+            (if helm-marked-candidates
+                (loop for (source . real) in (reverse helm-marked-candidates)
+                      when (equal current-src source)
+                      collect (helm-coerce-selection real source))
+              (list (helm-coerce-selection (helm-get-selection) source)))))
       (helm-log-eval cands)
       cands)))
-
+      
 (defun helm-current-source-name= (name)
   (save-excursion
     (goto-char (helm-get-previous-header-pos))


### PR DESCRIPTION
Currently, the "Find Files" action differs in behavior on sources (with type `file`) that have a `coerce` property set, between the cases when you select one file, and when you select more than one file.

If you select more than one file, Find Files will correctly open the coerced ("real") files, but if you Find Files with only one file selected, it will try to open the display value of the file, without coercing first. 

`helm-marked-candidates` seems to be the right place to apply the coercion for the single candidate also, but superficially reading the helm code, there seems to be more than one place where the display value (and not the coerced/real candidate value) is being used.

I hope you'll consider this patch for inclusion anyway (-:
