### PR TITLE
etags: add support for multiple tag files

### DIFF
--- a/helm-tags.el
+++ b/helm-tags.el
@@ -294,6 +294,8 @@ This function aggregates three sources of tag files:
                tag-files)
       (helm :sources 'helm-source-etags-select
             :keymap helm-etags-map
+            ;; fixme: can we first display using  \\_<foo\\_>  but insert foo on M-n?
+            ;; :default (concat "\\_<" (thing-at-point 'symbol) "\\_>")
             :default (thing-at-point 'symbol)
             :buffer "*helm etags*")
       )))


### PR DESCRIPTION
Hi,

It is often needed to work with multiple tag files and not all of them are in the current directory path, sometimes none. Emacs find-tag command allows for multiple files, helm doesn't.

This patch plugs into emacs treatment of tags. That is, besides tag file in parent directories, also look for standard emacs locations stored in tags-file-name and tags-table-list.
