### PR TITLE
Use apt-utils mode instead helm-apt-show-mode.

### DIFF
--- a/helm-apt.el
+++ b/helm-apt.el
@@ -165,26 +165,12 @@ LINE is displayed like:
 package name - description."
   (car (split-string line " - ")))
 
-(defvar helm-apt-show-current-package nil)
-(define-derived-mode helm-apt-show-mode
-    special-mode "helm-apt-show"
-    "Mode to display infos on apt packages.")
-
 (defun helm-apt-cache-show (package)
   "Show information on apt package PACKAGE."
-  (let* ((command (format helm-apt-show-command package))
-         (buf     (get-buffer-create "*helm apt show*")))
-    (helm-switch-to-buffer buf)
-    (unless (string= package helm-apt-show-current-package)
-      (let ((inhibit-read-only t))
-        (erase-buffer)
-        (save-excursion
-          (call-process-shell-command
-           command nil (current-buffer) t))))
-    (helm-apt-show-mode)
-    (set (make-local-variable 'helm-apt-show-current-package)
-         package)))
-
+  (require 'apt-utils)
+  (apt-utils-show-package-1 package)
+  )
+  
 (defun helm-apt-install (_package)
   "Run 'apt-get install' shell command on PACKAGE."
   (helm-apt-generic-action :action 'install))


### PR DESCRIPTION
Hi, thierryvolpiatto.
Old friend, still remember me?
I'm Andy Stewart, long time no see. ;)

It's better use apt-utils mode instead helm-apt-show-mode.
apt-utils is more powerful for navigate in package, search, syntax color etc....
