### PR TITLE
C-@ key binding for helm-toggle-visible-mark

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -144,6 +144,7 @@ second call within 0.5s run `helm-swap-windows'."
     (define-key map (kbd "M-<prior>")  'helm-scroll-other-window-down)
     (define-key map (kbd "<C-M-down>") 'helm-scroll-other-window)
     (define-key map (kbd "<C-M-up>")   'helm-scroll-other-window-down)
+    (define-key map (kbd "C-@")        'helm-toggle-visible-mark)
     (define-key map (kbd "C-SPC")      'helm-toggle-visible-mark)
     (define-key map (kbd "M-SPC")      'helm-toggle-visible-mark)
     (define-key map (kbd "M-[")        nil)


### PR DESCRIPTION
so ~~taht~~ that `C-SPC` don't work on Terminal Emacs.
