### PR TITLE
Do nothing when helm-buffer is not existed

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -2193,13 +2193,14 @@ This can be useful for e.g writing quietly a complex regexp."
 
 It will override `helm-map' with the local map of current source.
 If no map is found in current source do nothing (keep previous map)."
-  (with-helm-buffer
-    (helm-aif (assoc-default 'keymap (helm-get-current-source))
-        ;; Fix #466; we use here set-transient-map
-        ;; to not overhide other minor-mode-map's.
-        (if (fboundp 'set-transient-map)
-            (set-transient-map it)
-          (set-temporary-overlay-map it)))))
+  (when (buffer-live-p (helm-buffer-get))
+    (with-helm-buffer
+      (helm-aif (assoc-default 'keymap (helm-get-current-source))
+          ;; Fix #466; we use here set-transient-map
+          ;; to not overhide other minor-mode-map's.
+          (if (fboundp 'set-transient-map)
+              (set-transient-map it)
+            (set-temporary-overlay-map it))))))
 
 
 ;; Core: clean up


### PR DESCRIPTION
Error('no such buffer') is raised if `init` function takes time.
For example, it reads user input with `read-string` or similar
functions. Helm buffer is not created until user input and
init function are done, then `with-helm-buffer` in
`helm--maybe-update-keymap` raises error.

Following code is sample code for reproducing this issue.

``` lisp
(defun helm-sample-init ()
  (let ((dir (read-directory-name "Search Directory> ")))
    (with-current-buffer (helm-candidate-buffer 'global)
      (call-process "ls" nil t nil "-1" (expand-file-name dir)))))

(defvar helm-sample-source
  '((name . "Sample")
    (init . helm-sample-init)
    (candidates-in-buffer)))

(defun helm-sample ()
  (interactive)
  (helm :sources '(helm-sample-source) :buffer "*helm-sample*"))
```

If you executed `M-x helm-sample` then you get following error.

```
Error in post-command-hook (helm--maybe-update-keymap): (error "No buffer named *helm-sample*")
```

Please see this patch.
