### PR TITLE
Add shortcuts for helm-colors

### DIFF
--- a/helm-color.el
+++ b/helm-color.el
@@ -63,22 +63,68 @@
         (buffer-string)))
     (kill-buffer "*Colors*")))
 
+(defun helm-color-insert-name (candidate)
+  (interactive)
+  (with-helm-current-buffer
+    (insert (helm-colors-get-name candidate))))
+
+(defun helm-color-kill-name (candidate)
+  (interactive)
+  (kill-new (helm-colors-get-name candidate)))
+
+(defun helm-color-insert-rgb (candidate)
+  (interactive)
+  (with-helm-current-buffer
+    (insert (helm-colors-get-rgb candidate))))
+
+(defun helm-color-kill-rgb (candidate)
+  (interactive)
+  (kill-new (helm-colors-get-rgb candidate)))
+
+(defun helm-color-run-insert-name ()
+  "Insert name of color from `helm-source-colors'"
+  (interactive)
+  (with-helm-alive-p (helm-quit-and-execute-action 'helm-color-insert-name)))
+
+(defun helm-color-run-kill-name ()
+  "Kill name of color from `helm-source-colors'"
+  (interactive)
+  (with-helm-alive-p (helm-quit-and-execute-action 'helm-color-kill-name)))
+
+(defun helm-color-run-insert-rgb ()
+  "Insert RGB of color from `helm-source-colors'"
+  (interactive)
+  (with-helm-alive-p (helm-quit-and-execute-action 'helm-color-insert-rgb)))
+
+(defun helm-color-run-kill-rgb ()
+  "Kill RGB of color from `helm-source-colors'"
+  (interactive)
+  (with-helm-alive-p (helm-quit-and-execute-action 'helm-color-kill-rgb)))
+
+(defvar helm-color-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map helm-map)
+    (define-key map (kbd "C-c n") 'helm-color-run-insert-name)
+    (define-key map (kbd "C-c N") 'helm-color-run-kill-name)
+    (define-key map (kbd "C-c r") 'helm-color-run-insert-rgb)
+    (define-key map (kbd "C-c R") 'helm-color-run-kill-rgb)
+    (define-key map (kbd "C-c ?") 'helm-color-help)
+    map))
+
 (defvar helm-source-colors
-  '((name . "Colors")
+  `((name . "Colors")
     (init . helm-colors-init)
     (candidates-in-buffer)
     (get-line . buffer-substring)
+    (keymap . ,helm-color-map)
+    (persistent-help . "Kill entry in RGB format.")
+    (persistent-action . helm-color-kill-rgb)
+    (mode-line . helm-color-mode-line-string)
     (action
-     ("Copy Name" . (lambda (candidate)
-                      (kill-new (helm-colors-get-name candidate))))
-     ("Copy RGB" . (lambda (candidate)
-                     (kill-new (helm-colors-get-rgb candidate))))
-     ("Insert Name" . (lambda (candidate)
-                        (with-helm-current-buffer
-                          (insert (helm-colors-get-name candidate)))))
-     ("Insert RGB" . (lambda (candidate)
-                       (with-helm-current-buffer
-                         (insert (helm-colors-get-rgb candidate))))))))
+     ("Copy Name (C-c N)" . helm-color-kill-name)
+     ("Copy RGB (C-c R)" . helm-color-kill-rgb)
+     ("Insert Name (C-c n)" . helm-color-insert-name)
+     ("Insert RGB (C-c r)" . helm-color-insert-rgb))))
 
 (defun helm-colors-get-name (candidate)
   "Get color name."

--- a/helm-help.el
+++ b/helm-help.el
@@ -227,7 +227,7 @@ Italic     => A non--file buffer.
 \\[helm-toggle-all-marks]\t\t->Toggle all marks.
 \\[helm-mark-all]\t\t->Mark all.
 \\[helm-toggle-buffers-details]\t\t->Toggle details.
-\\[helm-buffers-toggle-show-hidden-buffers]\t\t->Show hidden buffers. 
+\\[helm-buffers-toggle-show-hidden-buffers]\t\t->Show hidden buffers.
 \\[helm-buffer-help]\t\t->Display this help.
 \n== Helm Map ==
 \\{helm-map}")
@@ -596,7 +596,7 @@ But you can also pass an argument or more after 'candidate_file' like this:
 
 e.g <command> file1 file2 ...
 
-Call `helm-find-files-eshell-command-on-file' with one prefix-arg 
+Call `helm-find-files-eshell-command-on-file' with one prefix-arg
 Otherwise you can pass one prefix-arg from the command selection buffer.
 
 With two prefix-arg before starting or from the command selection buffer
@@ -627,7 +627,7 @@ is called once for each file like this:
   "== Helm ido virtual buffers Map ==\
 \nSpecific commands for ido virtuals buffers:
 \\<helm-buffers-ido-virtual-map>
-\\[helm-ff-run-switch-other-window]\t\t->Switch other window. 
+\\[helm-ff-run-switch-other-window]\t\t->Switch other window.
 \\[helm-ff-run-switch-other-frame]\t\t->Switch other frame.
 \\[helm-ff-run-grep]\t\t->Grep file.
 \\[helm-ff-run-zgrep]\t\t->Zgrep file.
@@ -780,6 +780,27 @@ the amount of prefix args entered.
   (let ((helm-help-message helm-imenu-help-message))
     (helm-help)))
 
+;;; helm-colors
+;;
+;;
+(defvar helm-colors-help-message
+  "== Helm colors ==\
+\nSpecific commands for Helm colors:
+\\<helm-color-map>
+\\[helm-color-run-insert-name]\t\tInsert the entry'name.
+\\[helm-color-run-kill-name]\t\tKill the entry's name.
+\\[helm-color-run-insert-rgb]\t\tInsert entry in RGB format.
+\\[helm-color-run-kill-rgb]\t\tKill entry in RGB format.
+\\[helm-color-help]\t\tShow this help.
+\n== Helm Map ==
+\\{helm-map}")
+
+;;;###autoload
+(defun helm-color-help ()
+  (interactive)
+  (let ((helm-help-message helm-colors-help-message))
+    (helm-help)))
+
 ;;; helm semantic
 ;;
 ;;
@@ -814,6 +835,15 @@ the amount of prefix args entered.
 \\[helm-select-2nd-action-or-end-of-line]/\
 \\[helm-select-3rd-action]:NthAct"
     "String displayed in mode-line in `helm-source-buffers-list'"))
+
+;;;###autoload
+(defvar helm-color-mode-line-string
+  '("Colors" "\
+\\<helm-color-map>\
+\\[helm-color-help]:Help/\
+\\[helm-color-run-insert-name]:Insert name/\
+\\[helm-color-run-insert-rgb]:Insert RGB/\
+with shift: Kill"))
 
 ;;;###autoload
 (defvar helm-buffers-ido-virtual-mode-line-string
@@ -1379,7 +1409,7 @@ HELM-ATTRIBUTE should be a symbol."
   filename:candidate-containing-the-word-filename
 
   What you want is to ignore \"filename\" part and match only
-  \"candidate-containing-the-word-filename\" 
+  \"candidate-containing-the-word-filename\"
 
   So give a function matching only the part of candidate after \":\"
 


### PR DESCRIPTION
Hi,

I added some keybindings for helm colors, specifically:

C-c r - Insert RGB, with shift kill
C-c n - Insert name, with shift kill

Best,
Markus
