### PR TITLE
Update helm-files.el

### DIFF
--- a/helm-files.el
+++ b/helm-files.el
@@ -2691,7 +2691,6 @@ This is the starting point for nearly all actions you can do on files."
                               (default-input)
                               (t (expand-file-name (helm-current-directory)))))
          (presel        (helm-aif (or hist
-                                      (buffer-file-name (current-buffer))
                                       (and (eq major-mode 'dired-mode)
                                            default-input))
                             (if helm-ff-transformer-show-only-basename


### PR DESCRIPTION
'helm-find-files' select current directory as default.
It's useful because you can execute dired for the current directory via the the keystroke, 'helm-find-files' and 'Enter'.
I think the current default behavior selecting the current file have no merits.
