### PR TITLE
fix cursor in minibuffer for emacs24.3 or later

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -1590,7 +1590,7 @@ ANY-KEYMAP ANY-DEFAULT ANY-HISTORY See `helm'."
     (let ((old-overridding-local-map overriding-local-map)
           ;; #163 no cursor in minibuffer in <=Emacs-24.2.
           ;; This is not needed in emacs-24.3+
-          (cursor-in-echo-area t)
+          (cursor-in-echo-area (not (and (<= 24 emacs-major-version) (<= 3 emacs-minor-version))))
           (non-essential t)
           (old--cua cua-mode)
           (helm-maybe-use-default-as-input


### PR DESCRIPTION
Cursor does not move by minibuffer, in Emacs24.3 or later.
It is the action of it is written in the comments.
I was modified to set the value automatically from a version of Emacs.
