### PR TITLE
helm-plugin depends on helm-regexp

### DIFF
--- a/helm-plugin.el
+++ b/helm-plugin.el
@@ -20,6 +20,7 @@
 (require 'cl-lib)
 (require 'helm)
 (require 'helm-utils)
+(require 'helm-regexp)
 
 (declare-function Info-index-nodes "info" (&optional file))
 (declare-function Info-goto-node "info" (&optional fork))


### PR DESCRIPTION
If helm-regexp was not loaded, helm-type-attribute 'line was not defined. Hence helm-headline plugin do not works.
