### PR TITLE
Obey prefix argument in helm-previous-line and helm-next-line.

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -3324,7 +3324,8 @@ Key arg DIRECTION can be one of:
   ;; Be sure to not use this in non--interactives calls.
   (let ((helm-move-to-line-cycle-in-source
          (and helm-move-to-line-cycle-in-source arg)))
-    (helm-move-selection-common :where 'line :direction 'previous)))
+    (dotimes (_ (if arg arg 1))
+      (helm-move-selection-common :where 'line :direction 'previous))))
 
 ;;;###autoload
 (defun helm-next-line (&optional arg)
@@ -3333,7 +3334,8 @@ Key arg DIRECTION can be one of:
   ;; Be sure to not use this in non--interactives calls.
   (let ((helm-move-to-line-cycle-in-source
          (and helm-move-to-line-cycle-in-source arg)))
-    (helm-move-selection-common :where 'line :direction 'next)))
+    (dotimes (_ (if arg arg 1))
+      (helm-move-selection-common :where 'line :direction 'next))))
 
 ;;;###autoload
 (defun helm-previous-page ()


### PR DESCRIPTION
I use prefix arguments to quickly move up and down several lines. This change makes that work within the helm buffer.
