### PR TITLE
Gracefully handle match not found from helm-occur.

### DIFF
--- a/helm-regexp.el
+++ b/helm-regexp.el
@@ -203,8 +203,7 @@ arg METHOD can be one of buffer, buffer-other-window, buffer-other-frame."
           when (save-excursion
                  (re-search-forward reg (point-at-eol) t))
           collect (match-beginning 0) into pos-ls
-          finally (unless (null pos-ls)
-                    (goto-char (apply #'min pos-ls))))
+          finally (when pos-ls (goto-char (apply #'min pos-ls))))
     (when mark
       (set-marker (mark-marker) (point))
       (push-mark (point) 'nomsg))))


### PR DESCRIPTION
- When resuming a helm-occur session and editing the buffer, the match
  may no longer be on the same line.  This handles it more gracefully.
