### PR TITLE
Always save point to mark-ring before jumping.

### DIFF
--- a/helm-semantic.el
+++ b/helm-semantic.el
@@ -74,6 +74,7 @@
           (t))))))
 
 (defun helm-semantic-default-action (_candidate &optional persistent)
+  (helm-save-current-pos-to-mark-ring)
   ;; By default, helm doesn't pass on the text properties of the selection.
   ;; Fix this.
   (helm-log-run-hook 'helm-goto-line-before-hook)

--- a/helm-tags.el
+++ b/helm-tags.el
@@ -268,6 +268,7 @@ If no entry in cache, create one."
 (defun helm-etags-action-goto (switcher candidate)
   "Helm default action to jump to an etags entry in other window."
   (require 'etags)
+  (helm-save-current-pos-to-mark-ring)
   (helm-log-run-hook 'helm-goto-line-before-hook)
   (let* ((split (helm-etags-split-line candidate))
          (fname (cl-loop for tagf being the hash-keys of helm-etags-cache

--- a/helm-utils.el
+++ b/helm-utils.el
@@ -268,6 +268,7 @@ Default is `helm-current-buffer'."
 (defun helm-goto-line (lineno &optional noanim)
   "Goto LINENO opening only outline headline if needed.
 Animation is used unless NOANIM is non--nil."
+  (helm-save-current-pos-to-mark-ring)
   (helm-log-run-hook 'helm-goto-line-before-hook)
   (goto-char (point-min))
   (helm-goto-char (point-at-bol lineno))
@@ -282,8 +283,7 @@ To use this add it to `helm-goto-line-before-hook'."
       (point-to-register helm-save-pos-before-jump-register))))
 
 (defun helm-save-current-pos-to-mark-ring ()
-  "Save current buffer position to mark ring.
-To use this add it to `helm-goto-line-before-hook'."
+  "Save current buffer position to mark ring."
   (with-helm-current-buffer
     (unless helm-in-persistent-action
       (set-marker (mark-marker) (point))


### PR DESCRIPTION
- This is the default non-helm behaviour.
- The user should not have to configure anything to enable it.

---

I saw Tuh Do's blog entry: http://tuhdo.github.io/helm-intro.html where he configures it.  This has bitten me in the past, and I think it should be the default.
