### PR TITLE
Require 'helm-config in helm.el

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -29,6 +29,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'helm-config)
 
 
 ;;; Multi keys


### PR DESCRIPTION
It uses `helm-mode-line-string' which is defined in helm-config.
Without this require, helm only works with autoloads.
