### PR TITLE
Allow helm-boring-file-regexp-list to match directory.

### DIFF
--- a/helm-files.el
+++ b/helm-files.el
@@ -88,7 +88,13 @@
   :group 'helm)
 
 (defcustom helm-boring-file-regexp-list
-  '("\\.git$" "\\.hg$" "\\.svn$" "\\.CVS$" "\\._darcs$" "\\.la$" "\\.o$" "~$")
+  (nconc
+   (mapcar (lambda (ext)
+             ;; match as extension or directory
+             (concat "\\." ext "\\(?:$\\|/\\)"))
+           '("git" "hg" "svn" "CVS" "_darcs" "la" "o"))
+   '("~\\(?:$\\|/\\)"))
+
   "The regexp list matching boring files."
   :group 'helm-files
   :type  '(repeat (choice regexp)))


### PR DESCRIPTION
I have (setq helm-findutils-skip-boring-files t), but files under ".git" still show up when doing "C-c /", this patch fixes the regexps to match as extension or path element.
