### PR TITLE
Update GNU grep installation instructions

### DIFF
--- a/doc/Home.mdpp
+++ b/doc/Home.mdpp
@@ -495,7 +495,10 @@ This version should accept the `--exclude-dir` option.
 
     Install it from homebrew with:
 
-         brew install grep
+         brew tap homebrew/dupes
+         brew install homebrew/dupes/grep
+   
+    You should also set `helm-grep-default-command` to use `ggrep` instead of `grep`.
 
 ## Helm do grep
 


### PR DESCRIPTION
- GNU grep is in `homebrew/dupes`, tap it first.
- Add note on setting `helm-grep-default-command` to use ggrep.
