### PR TITLE
Use original function instead of alias

### DIFF
--- a/helm-elisp.el
+++ b/helm-elisp.el
@@ -149,7 +149,7 @@ If `helm-turn-on-show-completion' is nil just do nothing."
                     (or
                      (and (eq (char-before) ?\ )
                           (save-excursion
-                            (skip-syntax-backward " " (point-at-bol))
+                            (skip-syntax-backward " " (line-beginning-position))
                             (memq (symbol-at-point)
                                   helm-lisp-unquoted-function-list)))
                      (and (eq (char-before) ?\')
@@ -167,7 +167,7 @@ If `helm-turn-on-show-completion' is nil just do nothing."
                     (and (eq (char-before) ?\')
                          (save-excursion
                            (forward-char (if (funcall fn-sym-p) -2 -1))
-                           (skip-syntax-backward " " (point-at-bol))
+                           (skip-syntax-backward " " (line-beginning-position))
                            (memq (symbol-at-point)
                                  helm-lisp-quoted-function-list)))
                     (eq (char-before) ?\())) ; no paren before str.
@@ -189,7 +189,7 @@ of symbol before point."
   (save-excursion
     (let (beg
           (end (point))
-          (boundary (field-beginning nil nil (point-at-bol))))
+          (boundary (field-beginning nil nil (line-beginning-position))))
       (if (re-search-backward (or regexp "\\_<") boundary t)
           (setq beg (match-end 0))
         (setq beg boundary))
@@ -324,7 +324,7 @@ If SYM is not documented, return \"Not documented\"."
                     (or force
                         (save-excursion
                           (end-of-line)
-                          (search-backward tap (point-at-bol) t)
+                          (search-backward tap (line-beginning-position) t)
                           (setq beg (point))
                           (looking-back "[^'`( ]")))
                     (expand-file-name
@@ -359,7 +359,7 @@ Filename completion happen if string start after or between a double quote."
   (let* ((tap (thing-at-point 'filename)))
     (if (and tap (save-excursion
                    (end-of-line)
-                   (search-backward tap (point-at-bol) t)
+                   (search-backward tap (line-beginning-position) t)
                    (looking-back "[^'`( ]")))
         (helm-complete-file-name-at-point)
       (helm-lisp-completion-at-point))))

--- a/helm-files.el
+++ b/helm-files.el
@@ -1299,7 +1299,7 @@ On windows system substitute from start up to \"/[[:lower:]]:/\"."
                                  (string-match-p "/[[:alpha:]]:/" match))
                              (1+ (match-beginning 0))
                              (match-beginning 0)))
-              (buffer-substring-no-properties (point) (point-at-eol)))
+              (buffer-substring-no-properties (point) (line-end-position)))
             fname))))
 
 (add-hook 'helm-after-update-hook 'helm-ff-update-when-only-one-matched)
@@ -2173,8 +2173,8 @@ Use it for non--interactive calls of `helm-find-files'."
   "Try to find library path at point.
 Find inside `require' and `declare-function' sexp."
   (require 'find-func)
-  (let* ((beg-sexp (save-excursion (search-backward "(" (point-at-bol) t)))
-         (end-sexp (save-excursion (search-forward ")" (point-at-eol) t)))
+  (let* ((beg-sexp (save-excursion (search-backward "(" (line-beginning-position) t)))
+         (end-sexp (save-excursion (search-forward ")" (line-end-position) t)))
          (sexp     (and beg-sexp end-sexp
                         (buffer-substring-no-properties
                          (1+ beg-sexp) (1- end-sexp)))))

--- a/helm-firefox.el
+++ b/helm-firefox.el
@@ -51,7 +51,7 @@
             (goto-char (point-min))
             (prog1
                 (when (search-forward "Path=" nil t)
-                  (buffer-substring-no-properties (point) (point-at-eol)))
+                  (buffer-substring-no-properties (point) (line-end-position)))
               (kill-buffer)))))
     (file-name-as-directory (concat moz-dir moz-user-dir))))
 

--- a/helm-grep.el
+++ b/helm-grep.el
@@ -451,7 +451,7 @@ WHERE can be one of other-window, elscreen, other-frame."
                                (if (eq major-mode 'helm-grep-mode)
                                    (current-buffer)
                                  helm-buffer)
-                             (get-text-property (point-at-bol) 'help-echo))
+                             (get-text-property (line-beginning-position) 'help-echo))
                            (car split)))
          (tramp-method (file-remote-p (or helm-ff-default-directory
                                           default-directory) 'method))
@@ -513,7 +513,7 @@ If N is positive go forward otherwise go backward."
   (let* ((allow-mode (or (eq major-mode 'helm-grep-mode)
                          (eq major-mode 'helm-moccur-mode)))
          (sel (if allow-mode
-                  (buffer-substring (point-at-bol) (point-at-eol))
+                  (buffer-substring (line-beginning-position) (line-end-position))
                 (helm-get-selection nil t)))
          (current-line-list  (if (eq type 'etags)
                                  (split-string sel ": +" t)
@@ -529,13 +529,13 @@ If N is positive go forward otherwise go backward."
         (forward-line n) ; Go forward or backward depending of n value.
         ;; Exit when current-fname is not matched or in `helm-grep-mode'
         ;; the line is not a grep line i.e 'fname:num:tag'.
-        (setq sel (buffer-substring (point-at-bol) (point-at-eol)))
+        (setq sel (buffer-substring (line-beginning-position) (line-end-position)))
         (unless (or (string= current-fname
                              (car (if (eq type 'etags)
                                       (split-string sel ": +" t)
                                     (helm-grep-split-line sel))))
                     (and (eq major-mode 'helm-grep-mode)
-                         (not (get-text-property (point-at-bol) 'help-echo))))
+                         (not (get-text-property (line-beginning-position) 'help-echo))))
           (funcall mark-maybe)
           (throw 'break nil))))
     (cond ((and (> n 0) (eobp))
@@ -543,7 +543,7 @@ If N is positive go forward otherwise go backward."
            (forward-line 0)
            (funcall mark-maybe))
           ((and (< n 0) (bobp))
-           (helm-aif (next-single-property-change (point-at-bol) 'help-echo)
+           (helm-aif (next-single-property-change (line-beginning-position) 'help-echo)
                (goto-char it)
              (forward-line 1))
            (funcall mark-maybe)))))
@@ -679,13 +679,13 @@ Special commands:
 ;;;###autoload
 (defun helm-grep-mode-jump ()
   (interactive)
-  (let ((candidate (buffer-substring (point-at-bol) (point-at-eol))))
+  (let ((candidate (buffer-substring (line-beginning-position) (line-end-position))))
     (condition-case nil
         (progn (helm-grep-action candidate) (delete-other-windows))
       (error nil))))
 
 (defun helm-grep-mode-jump-other-window-1 (arg)
-  (let ((candidate (buffer-substring (point-at-bol) (point-at-eol))))
+  (let ((candidate (buffer-substring (line-beginning-position) (line-end-position))))
     (condition-case nil
         (progn
           (save-selected-window
@@ -707,7 +707,7 @@ Special commands:
 ;;;###autoload
 (defun helm-grep-mode-jump-other-window ()
   (interactive)
-  (let ((candidate (buffer-substring (point-at-bol) (point-at-eol))))
+  (let ((candidate (buffer-substring (line-beginning-position) (line-end-position))))
     (condition-case nil
         (helm-grep-action candidate 'other-window)
       (error nil))))

--- a/helm-match-plugin.el
+++ b/helm-match-plugin.el
@@ -294,13 +294,13 @@ i.e (identity (string-match \"foo\" \"foo bar\")) => t."
 This is the search function for `candidates-in-buffer' enabled sources.
 Use the same method as `helm-mp-3-match' except it search in buffer
 instead of matching on a string.
-i.e (identity (re-search-forward \"foo\" (point-at-eol) t)) => t."
+i.e (identity (re-search-forward \"foo\" (line-end-position) t)) => t."
   (cl-loop with pat = (if (stringp pattern)
                           (helm-mp-3-get-patterns pattern)
                         pattern)
         while (funcall searchfn1 (or (cdar pat) "") nil t)
-        for bol = (point-at-bol)
-        for eol = (point-at-eol)
+        for bol = (line-beginning-position)
+        for eol = (line-end-position)
         if (cl-loop for (pred . str) in (cdr pat) always
                  (progn (goto-char bol)
                         (funcall pred (funcall searchfn2 str eol t))))

--- a/helm-misc.el
+++ b/helm-misc.el
@@ -387,7 +387,7 @@ It is added to `extended-command-history'.
   (when (derived-mode-p 'comint-mode)
     (helm :sources 'helm-source-comint-input-ring
           :input (buffer-substring-no-properties (comint-line-beginning-position)
-                                                 (point-at-eol))
+                                                 (line-end-position))
           :buffer "*helm comint history*")))
 
 

--- a/helm-plugin.el
+++ b/helm-plugin.el
@@ -47,11 +47,11 @@
           (Info-goto-node node)
           (goto-char (point-min))
           (while (search-forward "\n* " nil t)
-            (unless (search-forward "Menu:\n" (1+ (point-at-eol)) t)
+            (unless (search-forward "Menu:\n" (1+ (line-end-position)) t)
               (save-current-buffer (buffer-substring-no-properties
-                                    (point-at-bol) (point-at-eol)))
-              (setq s (point-at-bol)
-                    e (point-at-eol))
+                                    (line-beginning-position) (line-end-position)))
+              (setq s (line-beginning-position)
+                    e (line-end-position))
               (with-current-buffer tobuf
                 (insert-buffer-substring infobuf s e)
                 (insert "\n")))))))))
@@ -181,8 +181,8 @@
                  (if (numberp subexp)
                      (cons (match-string-no-properties subexp)
                            (match-beginning subexp))
-                   (cons (buffer-substring (point-at-bol) (point-at-eol))
-                         (point-at-bol)))))
+                   (cons (buffer-substring (line-beginning-position) (line-end-position))
+                         (line-beginning-position)))))
             (arrange
              #'(lambda (headlines)
                  (unless (null headlines) ; FIX headlines empty bug!

--- a/helm-regexp.el
+++ b/helm-regexp.el
@@ -220,7 +220,7 @@ arg METHOD can be one of buffer, buffer-other-window, buffer-other-frame."
     ;; Move point to the nearest matching regexp from bol.
     (cl-loop for reg in split-pat
           when (save-excursion
-                 (re-search-forward reg (point-at-eol) t))
+                 (re-search-forward reg (line-end-position) t))
           collect (match-beginning 0) into pos-ls
           finally (when pos-ls (goto-char (apply #'min pos-ls))))
     (when mark
@@ -418,12 +418,12 @@ Same as `helm-moccur-goto-line' but go in new frame."
 (defun helm-moccur-mode-goto-line ()
   (interactive)
   (helm-moccur-goto-line
-   (buffer-substring (point-at-bol) (point-at-eol))))
+   (buffer-substring (line-beginning-position) (line-end-position))))
 
 (defun helm-moccur-mode-goto-line-ow ()
   (interactive)
   (helm-moccur-goto-line-ow
-   (buffer-substring (point-at-bol) (point-at-eol))))
+   (buffer-substring (line-beginning-position) (line-end-position))))
 
 (defun helm-moccur-save-results (_candidate)
   "Save helm moccur results in a `helm-moccur-mode' buffer."
@@ -494,7 +494,7 @@ Special commands:
              "\n")
             (goto-char (point-min))
             (cl-loop while (re-search-forward pattern nil t)
-                     for line = (helm-moccur-get-line (point-at-bol) (point-at-eol))
+                     for line = (helm-moccur-get-line (line-beginning-position) (line-end-position))
                      when line
                      do (with-current-buffer buffer
                           (insert

--- a/helm-semantic.el
+++ b/helm-semantic.el
@@ -80,7 +80,7 @@
   (with-current-buffer helm-buffer
     (when (looking-at " ")
       (goto-char (next-single-property-change
-                  (point-at-bol) 'semantic-tag nil (point-at-eol)))) 
+                  (line-beginning-position) 'semantic-tag nil (line-end-position)))) 
     (let ((tag (get-text-property (point) 'semantic-tag)))
       (semantic-go-to-tag tag)
       (unless persistent

--- a/helm-tags.el
+++ b/helm-tags.el
@@ -100,16 +100,16 @@ one match."
       (goto-char (point-min))
       (forward-line 2)
       (delete-region (point-min) (point))
-      (cl-loop while (and (not (eobp)) (search-forward "\001" (point-at-eol) t))
+      (cl-loop while (and (not (eobp)) (search-forward "\001" (line-end-position) t))
             for lineno-start = (point)
             for lineno = (buffer-substring
                           lineno-start
-                          (1- (search-forward "," (point-at-eol) t)))
+                          (1- (search-forward "," (line-end-position) t)))
             do
             (forward-line 0)
             (insert (format "%5s:" lineno))
-            (search-forward "\177" (point-at-eol) t)
-            (delete-region (1- (point)) (point-at-eol))
+            (search-forward "\177" (line-end-position) t)
+            (delete-region (1- (point)) (line-end-position))
             (forward-line 1)))))
 
 (defvar helm-source-ctags

--- a/helm-utils.el
+++ b/helm-utils.el
@@ -217,7 +217,7 @@ Handle multibyte characters by moving by columns."
     (save-excursion
       (insert str))
     (move-to-column width)
-    (buffer-substring (point-at-bol) (point))))
+    (buffer-substring (line-beginning-position) (point))))
 
 (cl-defun helm-substring-by-width (str width &optional (endstr "..."))
   "Truncate string STR to end at column WIDTH.
@@ -313,7 +313,7 @@ With a numeric prefix arg show only the ARG number of candidates."
     (cl-loop with pos
           while (setq pos (next-single-property-change (point) 'helm-header))
           do (goto-char pos)
-          collect (buffer-substring-no-properties (point-at-bol)(point-at-eol))
+          collect (buffer-substring-no-properties (line-beginning-position)(line-end-position))
           do (forward-line 1))))
 
 (defun helm-files-match-only-basename (candidate)


### PR DESCRIPTION
I suppose using original symbol is better than using alias because
`alias` might be deprecated in the future.

NOTE `point-at-bol` and `point-at-eol` are aliases for XEmacs.
