### PR TITLE
A function to build a source from an emacs fileset

### DIFF
--- a/helm-files.el
+++ b/helm-files.el
@@ -2489,6 +2489,23 @@ Else return ACTIONS unmodified."
     (type . file)))
 
 
+;;; Filesets
+;;
+;;
+(defun helm-make-source-filesets (fsname)
+  `((name . ,(format "%s Fileset" fsname))
+    (init
+     . (lambda ()
+         (require 'filesets nil t)))
+    (candidates . (lambda ()
+                    (with-helm-current-buffer
+                      (filesets-get-filelist (filesets-get-fileset-from-name ,fsname))
+                      )))
+    (keymap . ,helm-generic-files-map)
+    (help-message . helm-generic-file-help-message)
+    (mode-line . helm-generic-file-mode-line-string)
+    (type . file)))
+
 ;;; File name history
 ;;
 ;;


### PR DESCRIPTION
Filesets are an emacs feature for defining a grouping of files upon
which operations can be performed in bulk e.g. grep, shell commands,
etc. Filesets are mentioned here in the emacs manual:
http://www.gnu.org/software/emacs/manual/html_node/emacs/Filesets.html

You can use this function to make a helm source from a fileset. For
example, given a fileset called "Public HTML", you can construct a helm
source as follows:

(defvar my/helm-source-public-html (helm-make-source-filesets "Public HTML"))

Then my/helm-source-public-html can be added to helm-for-files-preferred-list.
