### PR TITLE
Fix autoloading helm-buffers-list

### DIFF
--- a/helm-buffers.el
+++ b/helm-buffers.el
@@ -22,6 +22,7 @@
 (require 'helm-utils)
 (require 'helm-elscreen)
 (require 'helm-grep)
+(require 'helm-plugin)
 (require 'helm-regexp)
 
 (declare-function ido-make-buffer-list "ido" (default))


### PR DESCRIPTION
When autoloading `helm-buffers-list`, an error occurs like this:

```
Debugger entered--Lisp error: (error "helm-interpret-value: Symbol must be a function or a variable")
  signal(error ("helm-interpret-value: Symbol must be a function or a variable"))
  error("helm-interpret-value: Symbol must be a function or a variable")
  helm-interpret-value(helm-persistent-help-string ((name . "Buffers") ...
  helm-display-mode-line(((name . "Buffers") ...
  helm-move-selection-common(:where line :direction next)
  helm--next-or-previous-line(next nil)
  helm-next-line()
...
  helm-buffers-list()
  eval((helm-buffers-list) nil)
  eval-last-sexp-1(t)
  eval-last-sexp(t)
  eval-print-last-sexp()
  call-interactively(eval-print-last-sexp nil nil)
```

I think it's because `helm-persistent-help-string` is not defined, so requiring `helm-plugin` in `helm-buffers` may make this error to be fixed.
