### PR TITLE
helm-source-file-cache doesn't read all files in file-cache-alist

### DIFF
--- a/helm-files.el
+++ b/helm-files.el
@@ -2485,8 +2485,10 @@ Else return ACTIONS unmodified."
   (helm-make-source
    "File Cache" 'helm-file-cache
    :data (lambda ()
-           (cl-loop for (bn dir) in file-cache-alist
-                    collect (expand-file-name bn dir)))))
+           (cl-loop for item in file-cache-alist append
+                    (cl-destructuring-bind (base &rest dirs) item
+                      (cl-loop for dir in dirs collect
+                               (concat dir base)))))))
 
 (cl-defun helm-file-cache-add-directory-recursively
     (dir &optional match (ignore-dirs t))


### PR DESCRIPTION
The variable file-cache-alist is a list of (FILENAME DIRNAME1 DIRNAME2 ...),
but helm-source-file-cache reads only DIRNAME1/FILENAME.
The commit 482b55f18cc00e2fe210fb54754f11fdf3fdcba4 changes the behavior
of helm-source-file-cache.
