### PR TITLE
Add more types of tags to be displayed to helm-semantic

### DIFF
--- a/helm-semantic.el
+++ b/helm-semantic.el
@@ -69,7 +69,12 @@
               (semantic-tag-components tag) (1+ depth) class)))
 
           ;; Don't do anything with packages or includes for now
-          ((package include))
+          ((package include)
+           (insert
+            (propertize (semantic-format-tag-summarize tag nil t)
+                        'semantic-tag tag)
+            "\n")
+           )
           ;; Catch-all
           (t))))))
 


### PR DESCRIPTION
It should also display dependenciy tags, such as include headers in C
and C++.

Demo:

![helm-semantic-demo1](https://cloud.githubusercontent.com/assets/4818719/4529117/d7a5ebd0-4d74-11e4-9c17-6ee348af0d5d.gif)
