### PR TITLE
emacs-helm.sh: allow EMACS to be overridden from the environment

### DIFF
--- a/emacs-helm.sh
+++ b/emacs-helm.sh
@@ -23,7 +23,7 @@
 # Run it from this directory.
 
 TMP="/tmp/helm-cfg.el"
-EMACS=emacs
+EMACS=${EMACS:-emacs}
 
 case $1 in
     -P)


### PR DESCRIPTION
Use the classic `${VAR:-default}` pattern to allow the emacs binary to be
specified. Example:

```
EMACS=/opt/my-emacs/bin/emacs ./emacs-helm.sh
```
