### PR TITLE
* helm-tags.el: don't set the keymap twice

### DIFF
--- a/helm-tags.el
+++ b/helm-tags.el
@@ -246,7 +246,6 @@ If no entry in cache, create one."
                         (cadr (helm-etags-split-line candidate))
                       candidate)))
     (mode-line . helm-etags-mode-line-string)
-    (keymap . ,helm-etags-map)
     (action . (("Go to tag" . (lambda (c)
                                 (helm-etags-action-goto 'find-file c)))
                ("Go to tag in other window" . (lambda (c)


### PR DESCRIPTION
The keymap is currently set by the `:keymap` keyword argument
to the `(helm)` function as well as the `helm-source-etags-select`
alist.

Setting it twice seems to thoroughly confuse things.  Fix this by
setting it once.

Fixes #664
