### PR TITLE
Smart "Candidate(s)" string

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -3240,7 +3240,7 @@ it is \"Candidate\(s\)\" by default."
       (let ((nc (helm-get-candidate-number 'in-current-source)))
         (propertize
          (format "[%s %s]" nc
-                 (or name (concat "Candidate" (if (> nc 1) "s"))))
+                 (or name (concat "Candidate" (if (= nc 1) "s"))))
         'face 'helm-candidate-number)))))
 
 (cl-defun helm-move-selection-common (&key where direction)


### PR DESCRIPTION
If there is only one candidate, then display "Candidate". If there are zero or more than one, display "Candidates".

`nc -> number-of-candidates`
