### PR TITLE
Fix issue opening file name ending with "~"

### DIFF
--- a/helm-files.el
+++ b/helm-files.el
@@ -1362,7 +1362,7 @@ On windows system substitute from start up to \"/[[:lower:]]:/\"."
         (insert fname)
         (goto-char (point-min))
         (skip-chars-forward "/") ;; Avoid infloop in UNC paths Issue #424
-        (if (re-search-forward "~.*/?\\|//\\|/[[:alpha:]]:/" nil t)
+        (if (re-search-forward "~/\\|~.+/?\\|//\\|/[[:alpha:]]:/" nil t)
             (let ((match (match-string 0)))
               (goto-char (if (or (string= match "//")
                                  (string-match-p "/[[:alpha:]]:/" match))


### PR DESCRIPTION
The 'helm-substitute-in-filename' function strips part of the open file
path before "~", so that paths such as "/abc~user/d" will be come
"~user/d". Unfortunately, the function also changes file name such as
"temp_file~" to just "~", making it impossible to open files ending in
"~".

This is to try to fix Issue #679.
