### PR TITLE
Bug fix: Non-string value for REAL with multi-select action.

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -4528,7 +4528,7 @@ When key WITH-WILDCARD is specified try to expand a wilcard if some."
           (if real
               ;; Check if real value of current candidate is the same
               ;; that the one stored in overlay.
-              (and (string= (overlay-get o 'real) real)
+              (and (equal (overlay-get o 'real) real)
                    (move-overlay o (point-at-bol 0) (1+ (point-at-eol 0))))
             (move-overlay o (point-at-bol 0) (1+ (point-at-eol 0)))))))))
 (add-hook 'helm-update-hook 'helm-revive-visible-mark)


### PR DESCRIPTION
An error was raised when one use non-string value for REAL of
(DISPLAY . REAL) pair and try to execute command with multiple
candidates.  The cause is `string=` was used for equivalence
checking of REAL.

Note that using `equal` is not the best way.  If we use an object
containing circular list for a value of REAL, we fall into infinite
loop.

Note that I am only a user of helm and do not understand helm internal precisely.
