### PR TITLE
Added helm faces to the Faces customize group.

### DIFF
--- a/helm-buffers.el
+++ b/helm-buffers.el
@@ -71,36 +71,42 @@ Only buffer names are fuzzy matched when this is enabled,
 ;;; Faces
 ;;
 ;;
+(defgroup helm-buffers-faces nil
+  "Customize the appearance of helm-buffers."
+  :prefix "helm-"
+  :group 'helm-buffers
+  :group 'helm-faces)
+
 (defface helm-buffer-saved-out
     '((t (:foreground "red" :background "black")))
   "Face used for buffer files modified outside of emacs."
-  :group 'helm-buffers)
+  :group 'helm-buffers-faces)
 
 (defface helm-buffer-not-saved
     '((t (:foreground "Indianred2")))
   "Face used for buffer files not already saved on disk."
-  :group 'helm-buffers)
+  :group 'helm-buffers-faces)
 
 (defface helm-buffer-size
     '((((background dark)) :foreground "RosyBrown")
       (((background light)) :foreground "SlateGray"))
   "Face used for buffer size."
-  :group 'helm-buffers)
+  :group 'helm-buffers-faces)
 
 (defface helm-buffer-process
     '((t (:foreground "Sienna3")))
   "Face used for process status in buffer."
-  :group 'helm-buffers)
+  :group 'helm-buffers-faces)
 
 (defface helm-buffer-directory
     '((t (:foreground "DarkRed" :background "LightGray")))
   "Face used for directories in `helm-buffers-list'."
-  :group 'helm-buffers)
+  :group 'helm-buffers-faces)
 
 (defface helm-buffer-file
     '((t :inherit font-lock-type-face))
   "Face for buffer file names in `helm-buffers-list'."
-  :group 'helm-buffers)
+  :group 'helm-buffers-faces)
 
 
 ;;; Buffers keymap

--- a/helm-command.el
+++ b/helm-command.el
@@ -47,9 +47,15 @@ Show all candidates on startup when 0 (default)."
 ;;; Faces
 ;;
 ;;
+(defgroup helm-command-faces nil
+  "Customize the appearance of helm-command."
+  :prefix "helm-"
+  :group 'helm-command
+  :group 'helm-faces)
+
 (defface helm-M-x-key '((t (:foreground "orange" :underline t)))
   "Face used in helm-M-x to show keybinding."
-  :group 'helm-command)
+  :group 'helm-command-faces)
 
 
 (defvar helm-M-x-input-history nil)

--- a/helm-elisp.el
+++ b/helm-elisp.el
@@ -67,15 +67,21 @@ e.g give only function names after \(function ."
 ;;; Faces
 ;;
 ;;
+(defgroup helm-elisp-faces nil
+  "Customize the appearance of helm-elisp."
+  :prefix "helm-"
+  :group 'helm-elisp
+  :group 'helm-faces)
+
 (defface helm-lisp-show-completion
     '((t (:background "DarkSlateGray")))
   "Face used for showing candidates in `helm-lisp-completion'."
-  :group 'helm-elisp)
+  :group 'helm-elisp-faces)
 
 (defface helm-lisp-completion-info
     '((t (:foreground "red")))
   "Face used for showing info in `helm-lisp-completion'."
-  :group 'helm-elisp)
+  :group 'helm-elisp-faces)
 
 
 ;;; Show completion.

--- a/helm-files.el
+++ b/helm-files.el
@@ -229,45 +229,51 @@ I.e use the -path/ipath arguments of find instead of -name/iname."
 ;;; Faces
 ;;
 ;;
+(defgroup helm-files-faces nil
+  "Customize the appearance of helm-files."
+  :prefix "helm-"
+  :group 'helm-files
+  :group 'helm-faces)
+
 (defface helm-ff-prefix
     '((t (:background "yellow" :foreground "black")))
   "Face used to prefix new file or url paths in `helm-find-files'."
-  :group 'helm-files)
+  :group 'helm-files-faces)
 
 (defface helm-ff-executable
     '((t (:foreground "green")))
   "Face used for executable files in `helm-find-files'."
-  :group 'helm-files)
+  :group 'helm-files-faces)
 
 (defface helm-ff-directory
     '((t (:foreground "DarkRed" :background "LightGray")))
   "Face used for directories in `helm-find-files'."
-  :group 'helm-files)
+  :group 'helm-files-faces)
 
 (defface helm-ff-symlink
     '((t (:foreground "DarkOrange")))
   "Face used for symlinks in `helm-find-files'."
-  :group 'helm-files)
+  :group 'helm-files-faces)
 
 (defface helm-ff-invalid-symlink
     '((t (:foreground "black" :background "red")))
   "Face used for invalid symlinks in `helm-find-files'."
-  :group 'helm-files)
+  :group 'helm-files-faces)
 
 (defface helm-ff-file
     '((t (:inherit font-lock-builtin-face)))
   "Face used for file names in `helm-find-files'."
-  :group 'helm-files)
+  :group 'helm-files-faces)
 
 (defface helm-history-deleted
     '((t (:inherit helm-ff-invalid-symlink)))
   "Face used for deleted files in `file-name-history'."
-  :group 'helm-files)
+  :group 'helm-files-faces)
 
 (defface helm-history-remote
     '((t (:foreground "Indianred1")))
   "Face used for remote files in `file-name-history'."
-  :group 'helm-files)
+  :group 'helm-files-faces)
 
 
 ;;; Helm-find-files - The helm file browser.

--- a/helm-grep.el
+++ b/helm-grep.el
@@ -138,37 +138,43 @@ If set to nil `doc-view-mode' will be used instead of an external command."
 ;;; Faces
 ;;
 ;;
+(defgroup helm-grep-faces nil
+  "Customize the appearance of helm-grep."
+  :prefix "helm-"
+  :group 'helm-grep
+  :group 'helm-faces)
+
 (defface helm-grep-match
   '((((background light)) :foreground "#b00000")
     (((background dark))  :foreground "gold1"))
   "Face used to highlight grep matches."
-  :group 'helm-grep)
+  :group 'helm-grep-faces)
 
 (defface helm-grep-file
     '((t (:foreground "BlueViolet"
           :underline t)))
   "Face used to highlight grep results filenames."
-  :group 'helm-grep)
+  :group 'helm-grep-faces)
 
 (defface helm-grep-lineno
     '((t (:foreground "Darkorange1")))
   "Face used to highlight grep number lines."
-  :group 'helm-grep)
+  :group 'helm-grep-faces)
 
 (defface helm-grep-running
     '((t (:foreground "Red")))
   "Face used in mode line when grep is running."
-  :group 'helm-grep)
+  :group 'helm-grep-faces)
 
 (defface helm-grep-finish
     '((t (:foreground "Green")))
   "Face used in mode line when grep is finish."
-  :group 'helm-grep)
+  :group 'helm-grep-faces)
 
 (defface helm-grep-cmd-line
     '((t (:inherit diff-added)))
   "Face used to highlight grep command line when no results."
-  :group 'helm-grep)
+  :group 'helm-grep-faces)
 
 
 ;;; Keymaps

--- a/helm.el
+++ b/helm.el
@@ -505,6 +505,12 @@ This happen when using `helm-next/previous-line'."
 ;;; Faces
 ;;
 ;;
+(defgroup helm-faces nil
+  "Customize the appearance of helm."
+  :prefix "helm-"
+  :group 'faces
+  :group 'helm)
+
 (defface helm-source-header
     '((((background dark))
        :background "#22083397778B"
@@ -515,7 +521,7 @@ This happen when using `helm-next/previous-line'."
        :foreground "black"
        :weight bold :height 1.3 :family "Sans Serif"))
   "Face for source header in the helm buffer."
-  :group 'helm)
+  :group 'helm-faces)
 
 (defface helm-visible-mark
     '((((min-colors 88) (background dark))
@@ -527,40 +533,40 @@ This happen when using `helm-next/previous-line'."
        (:background "green1"))
       (t (:background "green")))
   "Face for visible mark."
-  :group 'helm)
+  :group 'helm-faces)
 
 (defface helm-header
     '((t (:inherit header-line)))
   "Face for header lines in the helm buffer."
-  :group 'helm)
+  :group 'helm-faces)
 
 (defface helm-candidate-number
     '((((background dark)) :background "Yellow" :foreground "black")
       (((background light)) :background "#faffb5" :foreground "black"))
-  "Face for candidate number in mode-line." :group 'helm)
+  "Face for candidate number in mode-line." :group 'helm-faces)
 
 (defface helm-selection
     '((((background dark)) :background "ForestGreen" :underline t)
       (((background light)) :background "#b5ffd1" :underline t))
   "Face for currently selected item in the helm buffer."
-  :group 'helm)
+  :group 'helm-faces)
 
 (defface helm-separator
     '((((background dark)) :foreground "red")
       (((background light)) :foreground "#ffbfb5"))
   "Face for multiline source separator."
-  :group 'helm)
+  :group 'helm-faces)
 
 (defface helm-action
     '((t (:underline t)))
   "Face for action lines in the helm action buffer."
-  :group 'helm)
+  :group 'helm-faces)
 
 (defface helm-prefarg
     '((((background dark)) :foreground "green")
       (((background light)) :foreground "red"))
   "Face for showing prefix arg in mode-line."
-  :group 'helm)
+  :group 'helm-faces)
 
 
 ;;; Variables.


### PR DESCRIPTION
Previously the only way to access the customization options for
the helm faces was through Convenience > Helm and they were there
in the top level view. Now, the customization options are
accessible through the subgroup in Helm > Helm Faces, or through
Faces > Helm Faces. The customizations of the subgroups, such as
helm-buffers, follows the same convention -- accessible both
through Helm > Helm Buffers > Helm Buffers Faces and Faces > Helm
Faces > Helm Buffers Faces.

When trying to customize helm it took me a while to find the location of 
the helm faces customizations. This pull request attempts to make the
discovery of the helm faces customizations a little more intuitive.
