### PR TITLE
Show context instead of only entry when visiting org header

### DIFF
--- a/helm-org.el
+++ b/helm-org.el
@@ -27,7 +27,7 @@
 (defun helm-org-goto-marker (marker)
   (switch-to-buffer (marker-buffer marker))
   (goto-char (marker-position marker))
-  (org-show-entry))
+  (org-show-context))
 
 (cl-defun helm-source-org-headings-for-files (filenames
                                               &optional (min-depth 1) (max-depth 8))


### PR DESCRIPTION
Instead of calling `org-show-entry`, call `org-show-context` which also expands (=shows) the parent headers.  This is quite useful if there are multiple sub-headers with the same name (so we see the context right away), or when we want to navigate to parent headers quickly.

The behaviour shouldn't disturb anyone used to the old behaviour as it only expands couple extra lines (depending on the depth of the header)
