### PR TITLE
Restore headlines plugin

### DIFF
--- a/helm-plugin.el
+++ b/helm-plugin.el
@@ -142,6 +142,93 @@
   Will list all lines in .emacs.el.")
 
 
+;;; Plug-in: `headline'
+;;
+;;
+(defun helm-compile-source--helm-headline (source)
+  (if (assoc-default 'headline source)
+      (append '((init . helm-headline-init)
+                (get-line . buffer-substring)
+                (type . line))
+              source
+              '((candidates-in-buffer)
+                (persistent-help . "Show this line")))
+    source))
+(add-to-list 'helm-compile-source-functions 'helm-compile-source--helm-headline)
+
+(defun helm-headline-init ()
+  (when (and (helm-current-buffer-is-modified)
+             (with-helm-current-buffer
+               (eval (or (helm-attr 'condition) t))))
+    (helm-headline-make-candidate-buffer
+     (helm-interpret-value (helm-attr 'headline))
+     (helm-interpret-value (helm-attr 'subexp)))))
+
+(helm-document-attribute 'headline "Headline plug-in"
+  "  Regexp string for helm-headline to scan.")
+(helm-document-attribute 'condition "Headline plug-in"
+  "  A sexp representing the condition to use helm-headline.")
+(helm-document-attribute 'subexp "Headline plug-in"
+  "  Display (match-string-no-properties subexp).")
+
+(defun helm-headline-get-candidates (regexp subexp)
+  (with-helm-current-buffer
+    (save-excursion
+      (goto-char (point-min))
+      (if (functionp regexp) (setq regexp (funcall regexp)))
+      (let ((matched 
+             #'(lambda ()
+                 (if (numberp subexp)
+                     (cons (match-string-no-properties subexp)
+                           (match-beginning subexp))
+                   (cons (buffer-substring (point-at-bol) (point-at-eol))
+                         (point-at-bol)))))
+            (arrange
+             #'(lambda (headlines)
+                 (unless (null headlines) ; FIX headlines empty bug!
+                   (cl-loop with curhead = (make-vector
+                                            (1+ (cl-loop for (_ . hierarchy) in headlines
+                                                      maximize hierarchy))
+                                            "")
+                         for ((str . pt) . hierarchy) in headlines
+                         do (aset curhead hierarchy str)
+                         collecting
+                         (cons
+                          (format "H%d:%s" (1+ hierarchy)
+                                  (mapconcat 'identity
+                                             (cl-loop for i from 0 to hierarchy
+                                                   collecting (aref curhead i))
+                                             " / "))
+                          pt))))))
+        (if (listp regexp)
+            (funcall arrange
+                     (sort
+                      (cl-loop for re in regexp
+                            for hierarchy from 0
+                            do (goto-char (point-min))
+                            appending
+                            (cl-loop
+                                  while (re-search-forward re nil t)
+                                  collect (cons (funcall matched) hierarchy)))
+                      (lambda (a b) (> (cdar b) (cdar a)))))
+          (cl-loop while (re-search-forward regexp nil t)
+                collect (funcall matched)))))))
+
+(defun helm-headline-make-candidate-buffer (regexp subexp)
+  (with-current-buffer (helm-candidate-buffer 'local)
+    (cl-loop for (content . pos) in (helm-headline-get-candidates regexp subexp)
+          do (insert
+              (format "%5d:%s\n"
+                      (with-helm-current-buffer
+                        (line-number-at-pos pos))
+                      content)))))
+
+(defun helm-headline-goto-position (pos recenter)
+  (goto-char pos)
+  (unless recenter
+    (set-window-start (get-buffer-window helm-current-buffer) (point))))
+
+
 ;;; Plug-in: `persistent-help'
 ;;
 ;; Add help about persistent action in `helm-buffer' header.


### PR DESCRIPTION
This reverts commit 29d80ce2361651b2533da6b69b49b6e000f8f9e0.

Headlines may not be used internally, but they're still a great feature that some people (including myself and some of my co-workers) find indispensable. I'd love to see the functionality restored if that's all right. Thanks!
