### PR TITLE
compute score only once for each candidate

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -2786,7 +2786,7 @@ This function is used with sources build with `helm-source-sync'."
            (mapcar
             (lambda (c)
               (let* ((cand (if (consp c)
-                               (if (eq real-or-display 'display) (car s1) (cdr s1))
+                               (if (eq real-or-display 'display) (car c) (cdr c))
                              c))
                      (scr (helm-score-candidate-for-pattern cand helm-pattern))
                      (len (length cand)))


### PR DESCRIPTION
Thanks for adding fuzzy matching!  This patch keeps the sorting behavior the same, but does it more efficiently by computing the score only once for each candidate.  For me it boosted performance by 10x on a list of 5000 files.  (#145)
