### PR TITLE
Move `helm-fuzzy-matching-default-sort-fn-1' logic into `helm-fuzzy-sort...

### DIFF
--- a/helm-command.el
+++ b/helm-command.el
@@ -156,9 +156,9 @@ You can get help on each command by persistent action."
   (let* ((history (cl-loop for i in extended-command-history
                         when (commandp (intern i)) collect i))
          command sym-com in-help help-cand
+         (orig-fuzzy-sort-fn helm-fuzzy-sort-fn)
          (helm-fuzzy-sort-fn (lambda (candidates _source)
-                                       (helm-fuzzy-matching-default-sort-fn-1
-                                        candidates 'real)))
+                               (funcall orig-fuzzy-sort-fn candidates _source 'real)))
          (helm--mode-line-display-prefarg t)
          (pers-help #'(lambda (candidate)
                         (let ((hbuf (get-buffer (help-buffer))))

--- a/helm.el
+++ b/helm.el
@@ -2787,38 +2787,38 @@ A bonus of one point is given when PATTERN prefix match CANDIDATE."
     (+ bonus (or bonus1 (length (cl-nintersection
                                  pat-lookup str-lookup :test 'equal))))))
 
-(defun helm-fuzzy-matching-default-sort-fn-1 (candidates &optional real-or-display)
-  "The sort function used for fuzzy-matching in helm.
+(defun helm-fuzzy-matching-default-sort-fn (candidates _source &optional use-real)
+  "The transformer for sorting candidates in fuzzy matching.
+It is sorting on the display part of by default.
+
 Sort CANDIDATES according to their score calculated by
-`helm-score-candidate-for-pattern'.
-When two candidates have the same score sort is made by length.
-Argument REAL-OR-DISPLAY define if sort is made on the real or the display
-part of candidate, if its value is 'display use the display part, any other value
-will use the real part."
+`helm-score-candidate-for-pattern'.  When two candidates have the
+same score sort is made by length.  Set USE-REAL to non-nil to
+sort on the real part."
   (if (string= helm-pattern "")
       candidates
       (let ((table-scr (make-hash-table :test 'equal)))
         (sort candidates
               (lambda (s1 s2)
                 ;; Score and measure the length on real or display part of candidate
-                ;; according to `real-or-display'.
-                (let* ((real-or-disp-fn (if (eq real-or-display 'display) #'car #'cdr))
+                ;; according to `use-real'.
+                (let* ((real-or-disp-fn (if use-real #'cdr #'car))
                        (cand1 (if (consp s1)
                                   (funcall real-or-disp-fn s1)
-                                  s1))
+                                s1))
                        (cand2 (if (consp s2)
                                   (funcall real-or-disp-fn s2)
-                                  s2))
+                                s2))
                        (data1 (or (gethash cand1 table-scr)
-                                  (puthash cand1 (list (helm-score-candidate-for-pattern
-                                                        cand1 helm-pattern)
-                                                       (length cand1))
-                                           table-scr)))
+                                 (puthash cand1 (list (helm-score-candidate-for-pattern
+                                                       cand1 helm-pattern)
+                                                      (length cand1))
+                                          table-scr)))
                        (data2 (or (gethash cand2 table-scr)
-                                  (puthash cand2 (list (helm-score-candidate-for-pattern
-                                                        cand2 helm-pattern)
-                                                       (length cand2))
-                                           table-scr)))
+                                 (puthash cand2 (list (helm-score-candidate-for-pattern
+                                                       cand2 helm-pattern)
+                                                      (length cand2))
+                                          table-scr)))
                        (len1 (cadr data1))
                        (len2 (cadr data2))
                        (scr1 (car data1))
@@ -2826,12 +2826,6 @@ will use the real part."
                   (cond ((= scr1 scr2)
                          (< len1 len2))
                         ((> scr1 scr2)))))))))
-
-(defun helm-fuzzy-matching-default-sort-fn (candidates _source)
-  "The default transformer for sorting candidates in fuzzy matching.
-It is sorting on the display part of candidate.
-See `helm-fuzzy-matching-default-sort-fn-1'."
-  (helm-fuzzy-matching-default-sort-fn-1 candidates 'display))
 
 (defun helm-fuzzy-default-highlight-match (candidate)
   "The default function to highlight matches in fuzzy matching.


### PR DESCRIPTION
...-fn'.
- `helm-M-x' was referencing the internal implementation, which makes it
  awkward to override with a custom sorter.
