### PR TITLE
Fix inheritance of input method for prompt

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -2298,6 +2298,7 @@ For ANY-PRESELECT ANY-RESUME ANY-KEYMAP ANY-DEFAULT ANY-HISTORY, See `helm'."
                (unwind-protect
                     (minibuffer-with-setup-hook
                         #'(lambda ()
+                            (set-input-method (with-current-buffer helm-current-buffer current-input-method))
                             (setq timer (run-with-idle-timer
                                          (max helm-input-idle-delay 0.001) 'repeat
                                          #'(lambda ()


### PR DESCRIPTION
Minibuffer inherits the input method from the current-buffer.  At the time `read-from-minibuffer` is called, the active buffer is the helm buffer displaynig candidates---this has always the default active method, thus the inheritance doesn't work.

We need to inherit the method from the `helm-current-buffer`, which is where the helm was called from.  We can set the method manually in the `minibuffer-setup-hook`
