### PR TITLE
Make helm mode-line ending match regular emacs mode line

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -3550,7 +3550,7 @@ Possible value of DIRECTION are 'next or 'previous."
                                              'face 'helm-prefarg)))))
                     (:eval (helm-show-candidate-number
                             (car-safe helm-mode-line-string)))
-                    " " helm--mode-line-string-real " -%-")
+                    " " helm--mode-line-string-real " " mode-line-end-spaces)
               helm--mode-line-string-real
               (substitute-command-keys (if (listp helm-mode-line-string)
                                            (cadr helm-mode-line-string)


### PR DESCRIPTION
Sorry for the trivial patch.

This makes the helm mode-line behave more like the regular emacs one. By default, the dashes at the end are shown only in a TTY. If the user customizes `mode-line-end-spaces`, the changes are reflected in both mode lines.

This came about as part of my war on visual clutter. I have `mode-line-end-spaces` set to `nil` at all times.
