### PR TITLE
Make helm-score-candidate-for-pattern a defun, not a defsubst

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -2816,7 +2816,7 @@ This function is used with sources build with `helm-source-sync'."
            when (cdr str)
            collect (list (car str) (cadr str))))
 
-(defsubst helm-score-candidate-for-pattern (candidate pattern)
+(defun helm-score-candidate-for-pattern (candidate pattern)
   "Give a score to CANDIDATE according to PATTERN.
 Score is calculated against number of contiguous matches found with PATTERN.
 If PATTERN is fully matched in CANDIDATE a maximal score (100) is given.


### PR DESCRIPTION
Advantages:
* `helm-score-candidate-for-pattern` can be customized by the user for great good.
* Smaller byte-compiled result, as `helm-score-candidate-for-pattern` is a decently large function.

Disadvantages:
* `helm-fuzzy-matching-default-sort-fn` pays at best twice `O(n log n)` function calls. However, this is negligible compared to the number of calls already done in the sort function. I have not noticed a performance difference, even on large sets.

Advantage 1 is huge, as it allows the user to tweak and modify helm's scoring function, possibly to substantially improve the intelligence of helm's fuzzy matching.