### PR TITLE
Explicitly enable semantic-mode

### DIFF
--- a/helm-semantic.el
+++ b/helm-semantic.el
@@ -109,6 +109,7 @@
 
 (defclass helm-semantic-source (helm-source-in-buffer)
   ((init :initform (lambda ()
+                     (semantic-mode 1)
                      (helm-semantic--maybe-set-needs-update)
                      (setq helm-semantic--tags-cache (semantic-fetch-tags))
                      (with-current-buffer (helm-candidate-buffer 'global)


### PR DESCRIPTION
Currently, when entering a file that is supported by Semantic,
helm-semantic returns an empty candidate buffer because semantic-mode is
disabled in current buffer even if previously semantic-mode was
activated. This happens in emacs-lisp-mode. semantic-mode works properly
for C/C++ only.

To avoid empty buffer when using helm-semantic, explicitly enable
semantic-mode for fetching its tags.