### PR TITLE
new macro `helm-with-gensyms'; fix local macro variables

### DIFF
--- a/helm-utils.el
+++ b/helm-utils.el
@@ -672,8 +672,7 @@ Useful in dired buffers when there is inserted subdirs."
 
 (defmacro with-helm-display-marked-candidates (buffer-or-name candidates &rest body)
   (declare (indent 0) (debug t))
-  (let ((buffer (make-symbol "buffer"))
-        (window (make-symbol "window")))
+  (helm-with-gensyms (buffer window)
     `(let* ((,buffer (temp-buffer-window-setup ,buffer-or-name))
             ,window)
        (unwind-protect


### PR DESCRIPTION
Please review. I treated only those macros that can "paste" in arbitrary code (à la &rest body), the other macro definitions are not susceptible for variable capturing AFAIK.

And I excluded helm-aif of course, because there we want a user visible local variable.