### PR TITLE
First step of fuzzy re-order

### DIFF
--- a/helm-bbdb.el
+++ b/helm-bbdb.el
@@ -133,7 +133,7 @@ All other actions are removed."
     (filtered-candidate-transformer . (lambda (candidates _source)
                                         (setq helm-bbdb-name helm-pattern)
                                         (if (not candidates)
-                                            (list "*Add to contacts*")
+                                            (list (helm-normalize-candidate "*Add to contacts*"))
                                           candidates)))
     (action-transformer . (lambda (actions candidate)
                             (helm-bbdb-create-contact actions candidate))))

--- a/helm-bookmark.el
+++ b/helm-bookmark.el
@@ -100,18 +100,19 @@
   "See (info \"(emacs)Bookmarks\").")
 
 (defun helm-bookmark-transformer (candidates _source)
-  (cl-loop for i in candidates
-        for loc = (bookmark-location i)
-        for len =  (string-width i)
+  (cl-loop for cand in candidates
+           for real = (cdr cand)
+        for loc = (bookmark-location real)
+        for len =  (string-width real)
         for trunc = (if (> len bookmark-bmenu-file-column)
-                        (helm-substring i bookmark-bmenu-file-column)
-                      i)
+                        (helm-substring real bookmark-bmenu-file-column)
+                      real)
         for sep = (make-string (- (+ bookmark-bmenu-file-column 2)
                                   (length trunc))
                                ? )
         if helm-bookmark-show-location
-        collect (cons (concat trunc sep (if (listp loc) (car loc) loc)) i)
-        else collect i))
+        collect (helm-normalize-candidate (cons (concat trunc sep (if (listp loc) (car loc) loc)) real))
+        else collect cand))
 
 (defun helm-bookmark-match-fn (candidate)
   "Match function for bookmark sources using `candidates'."

--- a/helm-buffers.el
+++ b/helm-buffers.el
@@ -380,8 +380,8 @@ Should be called after others transformers i.e (boring buffers)."
       candidates
     (sort candidates
           #'(lambda (c1 c2)
-              (< (string-width (helm-candidate-get-real c1))
-                 (string-width (helm-candidate-get-real c2)))))))
+              (< (string-width (cdr c1))
+                 (string-width (cdr c2)))))))
 
 (defun helm-buffers-mark-similar-buffers-1 ()
   (with-helm-window

--- a/helm-buffers.el
+++ b/helm-buffers.el
@@ -325,10 +325,11 @@ See `ido-make-buffer-list' for more infos."
           name (and proc name-prefix) dir size mode dir
           'italic 'helm-buffer-process proc details 'nofile))))))
 
-(defun helm-highlight-buffers (buffers _source)
+(defun helm-highlight-buffers (candidates _source)
   "Transformer function to highlight BUFFERS list.
 Should be called after others transformers i.e (boring buffers)."
-  (cl-loop for i in buffers
+  (cl-loop for candidate in candidates
+           for i = (car candidate)
         for (name size mode meta) = (if helm-buffer-details-flag
                                         (helm-buffer--details i 'details)
                                       (helm-buffer--details i))
@@ -351,7 +352,7 @@ Should be called after others transformers i.e (boring buffers)."
                           (concat truncbuf "\t" formatted-size
                                   "  " fmode "  " meta)
                         name)
-                      i)))
+                      (cdr candidate))))
 
 (defun helm-buffer--get-preselection (buffer-name)
   (concat "^"
@@ -378,8 +379,9 @@ Should be called after others transformers i.e (boring buffers)."
   (if (string= helm-pattern "")
       candidates
     (sort candidates
-          #'(lambda (s1 s2)
-              (< (string-width s1) (string-width s2))))))
+          #'(lambda (c1 c2)
+              (< (string-width (helm-candidate-get-real c1))
+                 (string-width (helm-candidate-get-real c2)))))))
 
 (defun helm-buffers-mark-similar-buffers-1 ()
   (with-helm-window

--- a/helm-command.el
+++ b/helm-command.el
@@ -111,8 +111,8 @@ fuzzy matching is running its own sort function with a different algorithm."
   (with-helm-current-buffer
     (cl-loop with local-map = (helm-M-x-current-mode-map-alist)
           for cand in candidates
-          for real = (helm-candidate-get-real cand)
-          for display = (helm-candidate-get-display cand)
+          for real = (cdr cand)
+          for display = (car cand)
           for local-key  = (car (rassq real local-map))
           for key        = (substitute-command-keys (format "\\[%s]" real))
           collect

--- a/helm-command.el
+++ b/helm-command.el
@@ -111,20 +111,23 @@ fuzzy matching is running its own sort function with a different algorithm."
   (with-helm-current-buffer
     (cl-loop with local-map = (helm-M-x-current-mode-map-alist)
           for cand in candidates
-          for local-key  = (car (rassq cand local-map))
-          for key        = (substitute-command-keys (format "\\[%s]" cand))
+          for real = (helm-candidate-get-real cand)
+          for display = (helm-candidate-get-display cand)
+          for local-key  = (car (rassq real local-map))
+          for key        = (substitute-command-keys (format "\\[%s]" real))
           collect
           (cons (cond ((and (string-match "^M-x" key) local-key)
                        (format "%s (%s)"
-                               cand (propertize
-                                     local-key
-                                     'face 'helm-M-x-key)))
-                      ((string-match "^M-x" key) cand)
+                               display (propertize
+                                        local-key
+                                        'face 'helm-M-x-key)))
+                      ((string-match "^M-x" key)
+                       display)
                       (t (format "%s (%s)"
-                                 cand (propertize
+                                 display (propertize
                                        key
                                        'face 'helm-M-x-key))))
-                cand)
+                real)
           into ls
           finally return
           (if sort (sort ls #'helm-generic-sort-fn) ls))))

--- a/helm-command.el
+++ b/helm-command.el
@@ -156,9 +156,6 @@ You can get help on each command by persistent action."
   (let* ((history (cl-loop for i in extended-command-history
                         when (commandp (intern i)) collect i))
          command sym-com in-help help-cand
-         (orig-fuzzy-sort-fn helm-fuzzy-sort-fn)
-         (helm-fuzzy-sort-fn (lambda (candidates source)
-                               (funcall orig-fuzzy-sort-fn candidates source 'real)))
          (helm--mode-line-display-prefarg t)
          (pers-help #'(lambda (candidate)
                         (let ((hbuf (get-buffer (help-buffer))))

--- a/helm-elisp-package.el
+++ b/helm-elisp-package.el
@@ -183,8 +183,10 @@
   (helm-el-package-upgrade-all))
 
 (defun helm-el-package--transformer (candidates _source)
-  (cl-loop for c in candidates
-           for id = (get-text-property 0 'tabulated-list-id c)
+  (cl-loop for cand in candidates
+           for real = (cdr cand)
+
+           for id = (get-text-property 0 'tabulated-list-id real)
            for name = (if (fboundp 'package-desc-name)
                           (package-desc-name id)
                           (car id))
@@ -192,13 +194,13 @@
            for upgrade-p = (assq name helm-el-package--upgrades)
            for user-installed-p = (and (boundp 'package-selected-packages)
                                        (memq name package-selected-packages))
-           do (when user-installed-p (put-text-property 0 2 'display "S " c))
+           do (when user-installed-p (put-text-property 0 2 'display "S " real))
            do (when (memq name helm-el-package--removable-packages)
-                (put-text-property 0 2 'display "U " c)
+                (put-text-property 0 2 'display "U " real)
                 (put-text-property
                  2 (+ (length (symbol-name name)) 2)
-                 'face 'font-lock-variable-name-face c))
-           for cand = (cons c (car (split-string c)))
+                 'face 'font-lock-variable-name-face real))
+           for cand = (cons real (car (split-string real)))
            when (or (and upgrade-p
                          (eq helm-el-package--show-only 'upgrade))
                     (and installed-p
@@ -206,7 +208,7 @@
                     (and (not installed-p)
                          (eq helm-el-package--show-only 'uninstalled)) 
                     (eq helm-el-package--show-only 'all))
-           collect cand))
+           collect (helm-normalize-candidate cand)))
 
 (defun helm-el-package-show-upgrade ()
   (interactive)

--- a/helm-elisp-package.el
+++ b/helm-elisp-package.el
@@ -184,6 +184,7 @@
 
 (defun helm-el-package--transformer (candidates _source)
   (cl-loop for cand in candidates
+           for display = (car cand)
            for real = (cdr cand)
 
            for id = (get-text-property 0 'tabulated-list-id real)
@@ -196,11 +197,10 @@
                                        (memq name package-selected-packages))
            do (when user-installed-p (put-text-property 0 2 'display "S " real))
            do (when (memq name helm-el-package--removable-packages)
-                (put-text-property 0 2 'display "U " real)
+                (put-text-property 0 2 'display "U " display)
                 (put-text-property
                  2 (+ (length (symbol-name name)) 2)
-                 'face 'font-lock-variable-name-face real))
-           for cand = (cons real (car (split-string real)))
+                 'face 'font-lock-variable-name-face display))
            when (or (and upgrade-p
                          (eq helm-el-package--show-only 'upgrade))
                     (and installed-p
@@ -208,7 +208,7 @@
                     (and (not installed-p)
                          (eq helm-el-package--show-only 'uninstalled)) 
                     (eq helm-el-package--show-only 'all))
-           collect (helm-normalize-candidate cand)))
+           collect (helm-normalize-candidate (cons display (car (split-string real))))))
 
 (defun helm-el-package-show-upgrade ()
   (interactive)

--- a/helm-elisp.el
+++ b/helm-elisp.el
@@ -321,7 +321,7 @@ Return a cons \(beg . end\)."
                       (bound   " (Var)")
                       (face    " (Face)"))
         for spaces = (make-string (- helm-lgst-len (length real)) ? )
-        collect (cons (concat real spaces annot) real) into lst
+        collect (cons (concat display spaces annot) real) into lst
         finally return (sort lst #'helm-generic-sort-fn)))
 
 (defun helm-get-first-line-documentation (sym)

--- a/helm-elisp.el
+++ b/helm-elisp.el
@@ -309,8 +309,10 @@ Return a cons \(beg . end\)."
 
 (defun helm-lisp-completion-transformer (candidates _source)
   "Helm candidates transformer for lisp completion."
-  (cl-loop for c in candidates
-        for sym = (intern c)
+  (cl-loop for cand in candidates
+           for display = (car cand)
+           for real = (cdr cand)
+        for sym = (intern real)
         for annot = (cl-typecase sym
                       (command " (Com)")
                       (class   " (Class)")
@@ -318,8 +320,8 @@ Return a cons \(beg . end\)."
                       (fbound  " (Fun)")
                       (bound   " (Var)")
                       (face    " (Face)"))
-        for spaces = (make-string (- helm-lgst-len (length c)) ? )
-        collect (cons (concat c spaces annot) c) into lst
+        for spaces = (make-string (- helm-lgst-len (length real)) ? )
+        collect (cons (concat real spaces annot) real) into lst
         finally return (sort lst #'helm-generic-sort-fn)))
 
 (defun helm-get-first-line-documentation (sym)
@@ -761,8 +763,9 @@ Filename completion happen if string start after or between a double quote."
     (candidates . timer-list)
     (filtered-candidate-transformer
      . (lambda (candidates _source)
-         (cl-loop for timer in candidates
-               collect (cons (helm-elisp--format-timer timer) timer))))
+         (cl-loop for candidate in candidates
+                  for real = (cdr candidate)
+                  collect (helm-normalize-candidate (cons (helm-elisp--format-timer real) real)))))
     (allow-dups)
     (volatile)
     (type . timer)))
@@ -774,8 +777,9 @@ Filename completion happen if string start after or between a double quote."
     (volatile)
     (filtered-candidate-transformer
      . (lambda (candidates _source)
-         (cl-loop for timer in candidates
-               collect (cons (helm-elisp--format-timer timer) timer))))
+         (cl-loop for candidate in candidates
+                  for real = (cdr candidate)
+                  collect (cons (helm-elisp--format-timer real) real))))
     (type . timer)))
 
 (defun helm-elisp--format-timer (timer)

--- a/helm-eshell.el
+++ b/helm-eshell.el
@@ -61,13 +61,16 @@
     :initform
     (lambda (candidates _sources)
       (cl-loop 
-       for i in candidates
+       for cand in candidates
+       for real = (cdr cand)
        collect
-       (cond ((string-match "\\`~/?" helm-ec-target)
-              (abbreviate-file-name i))
-             ((string-match "\\`/" helm-ec-target) i)
-             (t
-              (file-relative-name i)))
+       (helm-normalize-candidate
+        (cons (cond ((string-match "\\`~/?" helm-ec-target)
+                     (abbreviate-file-name real))
+                    ((string-match "\\`/" helm-ec-target) real)
+                    (t
+                     (file-relative-name real)))
+              real))
        into lst
        finally return (sort lst 'helm-generic-sort-fn))))
    (action :initform 'helm-ec-insert))

--- a/helm-files.el
+++ b/helm-files.el
@@ -2619,13 +2619,16 @@ Else return ACTIONS unmodified."
 Don't use it in your own code unless you know what you are doing.")
 
 (defun helm-file-name-history-transformer (candidates _source)
-  (cl-loop for candidate in candidates collect
-           for real (helm-candidate-get-real candidate)
-        (cond ((file-remote-p real)
-               (cons (propertize real 'face 'helm-history-remote) c))
-              ((file-exists-p real)
-               (cons (propertize real 'face 'helm-ff-file) c))
-              (t (cons (propertize real 'face 'helm-history-deleted) c)))))
+  (cl-loop for candidate in candidates
+           for display = (car candidate)
+           for real = (cdr candidate)
+           collect
+           (helm-normalize-candidate
+            (cond ((file-remote-p real)
+                   (cons (propertize display 'face 'helm-history-remote) real))
+                  ((file-exists-p real)
+                   (cons (propertize display 'face 'helm-ff-file) real))
+                  (t (cons (propertize display 'face 'helm-history-deleted) real))))))
 
 (defun helm-ff-file-name-history ()
   "Switch to `file-name-history' without quitting `helm-find-files'."

--- a/helm-firefox.el
+++ b/helm-firefox.el
@@ -93,7 +93,7 @@
            for real = (cdr cand)
            collect (cons
                     (propertize
-                     i 'face '((:foreground "YellowGreen"))
+                     display 'face '((:foreground "YellowGreen"))
                      'help-echo (helm-firefox-bookmarks-get-value display))
                     real)))
 

--- a/helm-firefox.el
+++ b/helm-firefox.el
@@ -87,11 +87,15 @@
 (defun helm-firefox-bookmarks-get-value (elm)
   (assoc-default elm helm-firefox-bookmarks-alist))
 
-(defun helm-highlight-firefox-bookmarks (bookmarks _source)
-  (cl-loop for i in bookmarks
-        collect (propertize
-                 i 'face '((:foreground "YellowGreen"))
-                 'help-echo (helm-firefox-bookmarks-get-value i))))
+(defun helm-highlight-firefox-bookmarks (candidates _source)
+  (cl-loop for cand in candidates
+           for display = (car cand)
+           for real = (cdr cand)
+           collect (cons
+                    (propertize
+                     i 'face '((:foreground "YellowGreen"))
+                     'help-echo (helm-firefox-bookmarks-get-value display))
+                    real)))
 
 ;;;###autoload
 (defun helm-firefox-bookmarks ()

--- a/helm-misc.el
+++ b/helm-misc.el
@@ -93,7 +93,7 @@
 (defun helm-time-zone-transformer (candidates _source)
   (cl-loop for cand in candidates
            for display = (car cand)
-           for real = (cde cand)
+           for real = (cdr cand)
            collect
            (cons (cond ((string-match (format-time-string "%H:%M" (current-time)) display)
                         (propertize display 'face 'helm-time-zone-current))

--- a/helm-misc.el
+++ b/helm-misc.el
@@ -91,13 +91,16 @@
 ;;; World time
 ;;
 (defun helm-time-zone-transformer (candidates _source)
-  (cl-loop for i in candidates
-        collect
-        (cond ((string-match (format-time-string "%H:%M" (current-time)) i)
-               (propertize i 'face 'helm-time-zone-current))
-              ((string-match helm-time-zone-home-location i)
-               (propertize i 'face 'helm-time-zone-home))
-              (t i))))
+  (cl-loop for cand in candidates
+           for display = (car cand)
+           for real = (cde cand)
+           collect
+           (cons (cond ((string-match (format-time-string "%H:%M" (current-time)) display)
+                        (propertize display 'face 'helm-time-zone-current))
+                       ((string-match helm-time-zone-home-location display)
+                        (propertize display 'face 'helm-time-zone-home))
+                       (t display))
+                 real)))
 
 (defvar helm-source-time-world
   '((name . "Time World List")

--- a/helm-mode.el
+++ b/helm-mode.el
@@ -395,12 +395,13 @@ that use `helm-comp-read' See `helm-M-x' for example."
                          :fuzzy-match fuzzy
                          :filtered-candidate-transformer
                          (append '((lambda (candidates sources)
-                                     (cl-loop for i in candidates
+                                     (cl-loop for cand in candidates
+                                              for display = (helm-candidate-get-display cand)
+                                              for real = (helm-candidate-get-real cand)
                                               ;; Input is added to history in completing-read's
                                               ;; and may be regexp-quoted, so unquote it.
-                                              for cand = (replace-regexp-in-string "\\s\\" "" i)
-                                              do (set-text-properties 0 (length cand) nil cand)
-                                              collect cand)))
+                                              for display = (replace-regexp-in-string "\\s\\" "" display)
+                                              collect (cons display real))))
                                  (and hist-fc-transformer (helm-mklist hist-fc-transformer)))
                          :persistent-action persistent-action
                          :persistent-help persistent-help

--- a/helm-mode.el
+++ b/helm-mode.el
@@ -396,8 +396,8 @@ that use `helm-comp-read' See `helm-M-x' for example."
                          :filtered-candidate-transformer
                          (append '((lambda (candidates sources)
                                      (cl-loop for cand in candidates
-                                              for display = (helm-candidate-get-display cand)
-                                              for real = (helm-candidate-get-real cand)
+                                              for display = (car cand)
+                                              for real = (cdr cand)
                                               ;; Input is added to history in completing-read's
                                               ;; and may be regexp-quoted, so unquote it.
                                               for display = (replace-regexp-in-string "\\s\\" "" display)

--- a/helm-ring.el
+++ b/helm-ring.el
@@ -85,7 +85,6 @@ If nil or zero (disabled), don't truncate candidate, show all."
 (defun helm-kill-ring-transformer (candidates _source)
   "Display only the `helm-kill-ring-max-lines-number' lines of candidate."
   (cl-loop for cand in candidates
-           for display = (car cand)
            for real = (cdr cand)
 
            when (get-text-property 0 'read-only real)

--- a/helm-ring.el
+++ b/helm-ring.el
@@ -84,24 +84,28 @@ If nil or zero (disabled), don't truncate candidate, show all."
 
 (defun helm-kill-ring-transformer (candidates _source)
   "Display only the `helm-kill-ring-max-lines-number' lines of candidate."
-  (cl-loop for i in candidates
-           when (get-text-property 0 'read-only i)
-           do (set-text-properties 0 (length i) '(read-only nil) i)
-           for nlines = (with-temp-buffer (insert i) (count-lines (point-min) (point-max)))
+  (cl-loop for cand in candidates
+           for display = (car cand)
+           for real = (cdr cand)
+
+           when (get-text-property 0 'read-only real)
+           do (set-text-properties 0 (length real) '(read-only nil) real)
+           for nlines = (with-temp-buffer (insert real) (count-lines (point-min) (point-max)))
            if (and helm-kill-ring-max-lines-number
                    (> nlines helm-kill-ring-max-lines-number))
-           collect (cons
-                    (with-temp-buffer
-                      (insert i)
-                      (goto-char (point-min))
-                      (concat
-                       (buffer-substring
-                        (point-min)
-                        (save-excursion
-                          (forward-line helm-kill-ring-max-lines-number)
-                          (point)))
-                       "[...]")) i)
-           else collect i))
+           collect (helm-normalize-candidate
+                    (cons
+                     (with-temp-buffer
+                       (insert real)
+                       (goto-char (point-min))
+                       (concat
+                        (buffer-substring
+                         (point-min)
+                         (save-excursion
+                           (forward-line helm-kill-ring-max-lines-number)
+                           (point)))
+                        "[...]")) real))
+           else collect cand))
 
 (defun helm-kill-ring-action (str)
   "Insert STR in `kill-ring' and set STR to the head.

--- a/helm-source.el
+++ b/helm-source.el
@@ -960,11 +960,10 @@ an eieio class."
     (oset source :nohighlight t)
     (when helm-fuzzy-sort-fn
       (oset source :filtered-candidate-transformer
-            (append (list 'helm-propertize-original-display)
-                    (helm-aif (oref source :filtered-candidate-transformer)
-                        (append (helm-mklist it)
-                                (list helm-fuzzy-sort-fn))
-                      (list helm-fuzzy-sort-fn)))))))
+            (helm-aif (oref source :filtered-candidate-transformer)
+                (append (helm-mklist it)
+                        (list helm-fuzzy-sort-fn))
+              (list helm-fuzzy-sort-fn))))))
 
 (defmethod helm-setup-user-source ((_source helm-source)))
 

--- a/helm-source.el
+++ b/helm-source.el
@@ -958,18 +958,13 @@ an eieio class."
       (oset source :header-line (helm-source--persistent-help-string it source)))
   (when (slot-value source :fuzzy-match)
     (oset source :nohighlight t)
-    (when helm-fuzzy-matching-highlight-fn
-      (oset source :filter-one-by-one
-            (helm-aif (oref source :filter-one-by-one)
-                (append (helm-mklist it)
-                        (list helm-fuzzy-matching-highlight-fn))
-              (list helm-fuzzy-matching-highlight-fn))))
     (when helm-fuzzy-sort-fn
       (oset source :filtered-candidate-transformer
-            (helm-aif (oref source :filtered-candidate-transformer)
-                (append (helm-mklist it)
-                        (list helm-fuzzy-sort-fn))
-              (list helm-fuzzy-sort-fn))))))
+            (append (list 'helm-propertize-original-display)
+                    (helm-aif (oref source :filtered-candidate-transformer)
+                        (append (helm-mklist it)
+                                (list helm-fuzzy-sort-fn))
+                      (list helm-fuzzy-sort-fn)))))))
 
 (defmethod helm-setup-user-source ((_source helm-source)))
 

--- a/helm-sys.el
+++ b/helm-sys.el
@@ -145,10 +145,11 @@ Show actions only on line starting by a PID."
 (defun helm-top-sort-transformer (candidates source)
   (helm-top-transformer
    (if helm-top-sort-fn
-       (cl-loop for c in candidates
-                if (string-match "^ *[0-9]+" c)
-                collect c into pid-cands
-                else collect c into header-cands
+       (cl-loop for cand in candidates
+                for real = (cdr cand)
+                if (string-match "^ *[0-9]+" real)
+                collect cand into pid-cands
+                else collect cand into header-cands
                 finally return (append
                                 header-cands
                                 (sort pid-cands helm-top-sort-fn)))

--- a/helm-utils.el
+++ b/helm-utils.el
@@ -785,21 +785,22 @@ directory, open this directory."
                     candidates)))
 
 (defun helm-filtered-candidate-transformer-file-line-1 (candidate)
-  (when (string-match "^\\(.+?\\):\\([0-9]+\\):\\(.*\\)$" candidate)
-    (let ((filename (match-string 1 candidate))
-          (lineno (match-string 2 candidate))
-          (content (match-string 3 candidate)))
-      (cons (format "%s:%s\n %s"
-                    (propertize filename 'face compilation-info-face)
-                    (propertize lineno 'face compilation-line-face)
-                    content)
-            (list (string-to-number lineno) content
-                  (expand-file-name
-                   filename
-                   (or (helm-interpret-value (helm-attr 'default-directory))
+  (let ((display (car candidate)))
+   (when (string-match "^\\(.+?\\):\\([0-9]+\\):\\(.*\\)$" display)
+     (let ((filename (match-string 1 display))
+           (lineno (match-string 2 display))
+           (content (match-string 3 display)))
+       (cons (format "%s:%s\n %s"
+                     (propertize filename 'face compilation-info-face)
+                     (propertize lineno 'face compilation-line-face)
+                     content)
+             (list (string-to-number lineno) content
+                   (expand-file-name
+                    filename
+                    (or (helm-interpret-value (helm-attr 'default-directory))
                        (and (helm-candidate-buffer)
-                            (buffer-local-value
-                             'default-directory (helm-candidate-buffer))))))))))
+                          (buffer-local-value
+                           'default-directory (helm-candidate-buffer)))))))))))
 
 (cl-defun helm-goto-file-line (lineno &optional content file (find-file-function #'find-file))
   (helm-aif (helm-attr 'before-jump-hook)

--- a/helm-w3m.el
+++ b/helm-w3m.el
@@ -91,11 +91,15 @@ http://emacs-w3m.namazu.org/")
          (arg (and (eq fn 'w3m-browse-url) new-tab)))
     (funcall fn (helm-w3m-bookmarks-get-value elm) arg)))
 
-(defun helm-highlight-w3m-bookmarks (bookmarks _source)
-  (cl-loop for i in bookmarks
-        collect (propertize
-                 i 'face 'helm-w3m-bookmarks
-                 'help-echo (helm-w3m-bookmarks-get-value i))))
+(defun helm-highlight-w3m-bookmarks (candidates _source)
+  (cl-loop for cand in candidates
+           for display = (car cand)
+           for real = (cdr cand)
+           collect (cons
+                    (propertize
+                     display 'face 'helm-w3m-bookmarks
+                     'help-echo (helm-w3m-bookmarks-get-value display))
+                    real)))
 
 
 (defun helm-w3m-delete-bookmark (elm)

--- a/helm.el
+++ b/helm.el
@@ -2914,6 +2914,15 @@ sort on the real part."
                        (< len1 len2))
                       ((> scr1 scr2)))))))))
 
+(defun helm-propertize-original-display (candidates)
+  (cl-loop for c in candidates
+           collect (let* ((pair (if (consp c)
+                                   c
+                                 (cons (helm-candidate-get-display c) c)))
+                          (text (car c)))
+                     (put-text-property 0 (length text) 'helm-original-display t text)
+                     c)))
+
 (defun helm-fuzzy-default-highlight-match (candidate)
   "The default function to highlight matches in fuzzy matching."
   (let* ((pair candidate)

--- a/helm.el
+++ b/helm.el
@@ -2749,12 +2749,6 @@ CANDIDATE is a string, a symbol, or \(DISPLAY . REAL\) cons cell."
          (number-to-string candidate))
         (t candidate)))
 
-(defun helm-candidate-get-real (candidate)
-  "Get real part from CANDIDATE.
-CANDIDATE is a string, a symbol, or \(DISPLAY . REAL\) cons cell."
-  (cond ((cdr-safe candidate))
-        (t candidate)))
-
 (defun helm-candidate-get-display-start-end (candidate)
   "Return (START . END) of candidate based on 'helm-original-display text property."
   (let* ((display (car candidate))

--- a/helm.el
+++ b/helm.el
@@ -2666,9 +2666,10 @@ ARGS is (cand1 cand2 ...) or ((disp1 . real1) (disp2 . real2) ...)
 
 (defun helm-process-filtered-candidate-transformer (candidates source)
   "Execute `filtered-candidate-transformer' function(s) on CANDIDATES in SOURCE."
-  (helm-aif (assoc-default 'filtered-candidate-transformer source)
-      (helm-composed-funcall-with-source source it candidates source)
-    candidates))
+  (let ((transformers (assoc-default 'filtered-candidate-transformer source)))
+    (helm-composed-funcall-with-source source (append (list 'helm-normalize-candidate-to-cons)
+                                                      (helm-mklist transformers))
+                                       candidates source)))
 
 (defmacro helm--maybe-process-filter-one-by-one-candidate (candidate source)
   "Execute `filter-one-by-one' function(s) on CANDIDATE in SOURCE."
@@ -2919,14 +2920,20 @@ same score sort is made by length."
                                              ((> scr1 scr2))))))
                collect (helm-fuzzy-default-highlight-match c-datum)))))
 
-(defun helm-propertize-original-display (candidates _source)
+(defun helm-normalize-candidate-to-cons (candidates _source)
+  "Normalize candidate to be cons cell of (display . real).
+Used in the filtered-candidate-transformer slot."
   (cl-loop for c in candidates
            collect (let* ((pair (if (consp c)
                                    c
                                  (cons (helm-candidate-get-display c) c)))
-                          (text (car pair)))
-                     (put-text-property 0 (length text) 'helm-original-display t text)
-                     pair)))
+                          (display (car pair))
+                          (properties (if helm-fuzzy-sort-fn
+                                          '(helm-original-display t)
+                                        nil)))
+                     ;; clear out other text propertiex as well
+                     (set-text-properties 0 (length display) properties display)
+                     (cons display (cdr pair)))))
 
 (defun helm-fuzzy-default-highlight-match (candidate-data)
   "The default function to highlight matches in fuzzy matching.

--- a/helm.el
+++ b/helm.el
@@ -2667,7 +2667,7 @@ ARGS is (cand1 cand2 ...) or ((disp1 . real1) (disp2 . real2) ...)
 (defun helm-process-filtered-candidate-transformer (candidates source)
   "Execute `filtered-candidate-transformer' function(s) on CANDIDATES in SOURCE."
   (let ((transformers (assoc-default 'filtered-candidate-transformer source)))
-    (helm-composed-funcall-with-source source (append (list 'helm-normalize-candidate-to-cons)
+    (helm-composed-funcall-with-source source (append (list 'helm-normalize-candidates)
                                                       (helm-mklist transformers))
                                        candidates source)))
 
@@ -2920,20 +2920,24 @@ same score sort is made by length."
                                              ((> scr1 scr2))))))
                collect (helm-fuzzy-default-highlight-match c-datum)))))
 
-(defun helm-normalize-candidate-to-cons (candidates _source)
+(defun helm-normalize-candidates (candidates _source)
   "Normalize candidate to be cons cell of (display . real).
 Used in the filtered-candidate-transformer slot."
-  (cl-loop for c in candidates
-           collect (let* ((pair (if (consp c)
-                                   c
-                                 (cons (helm-candidate-get-display c) c)))
-                          (display (car pair))
-                          (properties (if helm-fuzzy-sort-fn
-                                          '(helm-original-display t)
-                                        nil)))
-                     ;; clear out other text propertiex as well
-                     (set-text-properties 0 (length display) properties display)
-                     (cons display (cdr pair)))))
+  (cl-loop for candidate in candidates
+           collect (helm-normalize-candidate candidate)))
+
+(defun helm-normalize-candidate (candidate)
+  "Normalize single candidate."
+  (let* ((pair (if (consp candidate)
+                   candidate
+                 (cons (helm-candidate-get-display candidate) candidate)))
+         (display (car pair))
+         (properties (if helm-fuzzy-sort-fn
+                         '(helm-original-display t)
+                       nil)))
+    ;; clear out other text propertiex as well
+    (set-text-properties 0 (length display) properties display)
+    (cons display (cdr pair))))
 
 (defun helm-fuzzy-default-highlight-match (candidate-data)
   "The default function to highlight matches in fuzzy matching.

--- a/helm.el
+++ b/helm.el
@@ -2909,7 +2909,7 @@ same score sort is made by length."
       (cl-loop for x below helm-candidate-number-limit
                for c-datum in (sort candidate-data
                                     (lambda (s1 s2)
-                                     (let* ((data1 (cdddr s1))
+                                      (let* ((data1 (cdr (cddr s1)))
                                             (data2 (cddr s2))
                                             (len1 (cadr data1))
                                             (len2 (cadr data2))
@@ -2945,7 +2945,7 @@ Returns a candidate intended for helm use."
          (display (car pair))
          (real (cdr pair))
          (start (cadr candidate-data))
-         (end (caddr candidate-data)))
+         (end (car (cddr candidate-data))))
     (with-temp-buffer
       (insert display)
       (goto-char start)

--- a/helm.el
+++ b/helm.el
@@ -2931,12 +2931,9 @@ Used in the filtered-candidate-transformer slot."
   (let* ((pair (if (consp candidate)
                    candidate
                  (cons (helm-candidate-get-display candidate) candidate)))
-         (display (car pair))
-         (properties (if helm-fuzzy-sort-fn
-                         '(helm-original-display t)
-                       nil)))
-    ;; clear out other text propertiex as well
-    (set-text-properties 0 (length display) properties display)
+         (display (car pair)))
+    (when helm-fuzzy-sort-fn
+      (put-text-property 0 (length display) 'helm-original-display t display))
     (cons display (cdr pair))))
 
 (defun helm-fuzzy-default-highlight-match (candidate-data)

--- a/helm.el
+++ b/helm.el
@@ -2928,13 +2928,14 @@ Used in the filtered-candidate-transformer slot."
 
 (defun helm-normalize-candidate (candidate)
   "Normalize single candidate."
-  (let* ((pair (if (consp candidate)
-                   candidate
-                 (cons (helm-candidate-get-display candidate) candidate)))
-         (display (car pair)))
-    (when helm-fuzzy-sort-fn
-      (put-text-property 0 (length display) 'helm-original-display t display))
-    (cons display (cdr pair))))
+  (when candidate
+    (let* ((pair (if (consp candidate)
+                     candidate
+                   (cons (helm-candidate-get-display candidate) candidate)))
+           (display (car pair)))
+      (when helm-fuzzy-sort-fn
+        (put-text-property 0 (length display) 'helm-original-display t display))
+      (cons display (cdr pair)))))
 
 (defun helm-fuzzy-default-highlight-match (candidate-data)
   "The default function to highlight matches in fuzzy matching.

--- a/helm.el
+++ b/helm.el
@@ -2884,34 +2884,36 @@ same score sort is made by length."
   (if (string= helm-pattern "")
       candidates
     (let ((table-scr (make-hash-table :test 'equal)))
-      (sort candidates
-            (lambda (s1 s2)
-              ;; Score and measure the length on real or display part of candidate
-              ;; according to `use-real'.
-              (let* ((real-or-disp-fn (if use-real #'cdr #'car))
-                     (cand1 (if (consp s1)
-                                (funcall real-or-disp-fn s1)
-                              s1))
-                     (cand2 (if (consp s2)
-                                (funcall real-or-disp-fn s2)
-                              s2))
-                     (data1 (or (gethash cand1 table-scr)
-                                (puthash cand1 (list (helm-score-candidate-for-pattern
-                                                      cand1 helm-pattern)
-                                                     (length cand1))
-                                         table-scr)))
-                     (data2 (or (gethash cand2 table-scr)
-                                (puthash cand2 (list (helm-score-candidate-for-pattern
-                                                      cand2 helm-pattern)
-                                                     (length cand2))
-                                         table-scr)))
-                     (len1 (cadr data1))
-                     (len2 (cadr data2))
-                     (scr1 (car data1))
-                     (scr2 (car data2)))
-                (cond ((= scr1 scr2)
-                       (< len1 len2))
-                      ((> scr1 scr2)))))))))
+      (cl-loop for x below helm-candidate-number-limit
+               for candidate in (sort candidates
+                                      (lambda (s1 s2)
+                                        ;; Score and measure the length on real or display part of candidate
+                                        ;; according to `use-real'.
+                                        (let* ((real-or-disp-fn (if use-real #'cdr #'car))
+                                               (cand1 (if (consp s1)
+                                                          (funcall real-or-disp-fn s1)
+                                                        s1))
+                                               (cand2 (if (consp s2)
+                                                          (funcall real-or-disp-fn s2)
+                                                        s2))
+                                               (data1 (or (gethash cand1 table-scr)
+                                                         (puthash cand1 (list (helm-score-candidate-for-pattern
+                                                                               cand1 helm-pattern)
+                                                                              (length cand1))
+                                                                  table-scr)))
+                                               (data2 (or (gethash cand2 table-scr)
+                                                         (puthash cand2 (list (helm-score-candidate-for-pattern
+                                                                               cand2 helm-pattern)
+                                                                              (length cand2))
+                                                                  table-scr)))
+                                               (len1 (cadr data1))
+                                               (len2 (cadr data2))
+                                               (scr1 (car data1))
+                                               (scr2 (car data2)))
+                                          (cond ((= scr1 scr2)
+                                                 (< len1 len2))
+                                                ((> scr1 scr2))))))
+               collect (helm-fuzzy-default-highlight-match candidate)))))
 
 (defun helm-propertize-original-display (candidates)
   (cl-loop for c in candidates

--- a/helm.el
+++ b/helm.el
@@ -2874,14 +2874,13 @@ A bonus of one point is given when PATTERN prefix match CANDIDATE."
     (+ bonus (or bonus1 (length (cl-nintersection
                                  pat-lookup str-lookup :test 'equal))))))
 
-(defun helm-fuzzy-matching-default-sort-fn (candidates _source &optional use-real)
+(defun helm-fuzzy-matching-default-sort-fn (candidates _source)
   "The transformer for sorting candidates in fuzzy matching.
 It is sorting on the display part of by default.
 
 Sort CANDIDATES according to their score calculated by
 `helm-score-candidate-for-pattern'.  When two candidates have the
-same score sort is made by length.  Set USE-REAL to non-nil to
-sort on the real part."
+same score sort is made by length."
   (if (string= helm-pattern "")
       candidates
     (let ((table-scr (make-hash-table :test 'equal)))


### PR DESCRIPTION
Hi Thierry,

There is a lot to talk about here, so please bear with me:

- Call the highlighter from within the helm-fuzzy-matching-default-sort-fn
- Remove customizability of highlighter.
- Only highlight candidates that will be printed.
- Remove "use-real" hack of sort function.
    - Instead rely on text-properties to figure out portion of display that should be matched.

# BREAKING CHANGE

I propose normalizing the collection of candidates to an alist as a first step to processing filtered-candidate-transformer.

This makes the shape of candidates structure more predictable.  I want to do this as a step towards the end goal of making fuzzy a more integral part of the helm experience.  I believe doing so will solve a lot of problems with the sorting.

This means that any `filtered-candidate-transformer` used needs to be modified to process a-lists.  I've made the corresponding changes to the sources in the main repository (work in progress, as I don't use most of them).


----------

Please let me know what you think of the idea.  I look forward to discussing any concerns you have.
