### PR TITLE
Remove helm buffer from buffer-list if buffer gets killed.

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -4040,10 +4040,12 @@ to a list of forms.\n\n")
 
 ;; Core: misc
 (defun helm-kill-buffer-hook ()
-  "Remove tick entry from `helm-tick-hash' when killing a buffer."
+  "Remove tick entry from `helm-tick-hash' and remove buffer from
+`helm-buffers' when killing a buffer."
   (cl-loop for key being the hash-keys in helm-tick-hash
         if (string-match (format "^%s/" (regexp-quote (buffer-name))) key)
-        do (remhash key helm-tick-hash)))
+        do (remhash key helm-tick-hash))
+  (setq helm-buffers (remove (buffer-name) helm-buffers)))
 (add-hook 'kill-buffer-hook 'helm-kill-buffer-hook)
 
 (defun helm-preselect (candidate-or-regexp &optional source)


### PR DESCRIPTION
Hello,
this is my first attempt to contribute to helm, so please be patient.

I'm not sure if there is a reason not to remove  a killed helm-buffer from helm-buffers, but
helm-resume is complaining about a killed buffer. So here is my patch proposal.
