### PR TITLE
allow debugging candidate functions

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -2602,7 +2602,7 @@ Helm plug-ins are realized by this function."
                        (error
                         "`%s' must either be a function, a variable or a list"
                         (or candidate-fn candidate-proc))))
-         (candidates (condition-case err
+         (candidates (condition-case-no-debug err
                          ;; Process candidates-(process) function
                          ;; It may return a process or a list of candidates.
                          (if candidate-proc

--- a/helm.el
+++ b/helm.el
@@ -2602,7 +2602,7 @@ Helm plug-ins are realized by this function."
                        (error
                         "`%s' must either be a function, a variable or a list"
                         (or candidate-fn candidate-proc))))
-         (candidates (condition-case-no-debug err
+         (candidates (condition-case-unless-debug err
                          ;; Process candidates-(process) function
                          ;; It may return a process or a list of candidates.
                          (if candidate-proc


### PR DESCRIPTION
Currently, calling candidate functions is wrapped inside condition-case.  This makes it very difficult to debug.

If we would use c-c-unless-debug instead, like we already do in other places, this would make our life with helm much nicer.