### PR TITLE
Full outline path to a heading included in org helm candidates

### DIFF
--- a/helm-org.el
+++ b/helm-org.el
@@ -101,9 +101,10 @@ NOTE: This will be slow on large org buffers."
         (cl-loop while (re-search-forward org-complex-heading-regexp nil t)
               if (let ((num-stars (length (match-string-no-properties 1))))
                    (and (>= num-stars min-depth) (<= num-stars max-depth)))
-              collect `(,(if nofname (funcall match-fn 0)
-                             (concat (helm-basename filename)
-                                 ": " (funcall match-fn 0)))
+              collect `(,(let ((heading (funcall match-fn 4))
+                               (file (if nofname 'nil (concat (helm-basename filename) ":"))))
+                           (org-format-outline-path
+                            (append (org-get-outline-path) (list heading)) nil file))
                          . ,(point-marker)))))))
 
 ;;;###autoload

--- a/helm-org.el
+++ b/helm-org.el
@@ -102,7 +102,7 @@ NOTE: This will be slow on large org buffers."
               if (let ((num-stars (length (match-string-no-properties 1))))
                    (and (>= num-stars min-depth) (<= num-stars max-depth)))
               collect `(,(let ((heading (funcall match-fn 4))
-                               (file (if nofname 'nil (concat (helm-basename filename) ":"))))
+                               (file (unless nofname (concat (helm-basename filename) ":"))))
                            (org-format-outline-path
                             (append (org-get-outline-path) (list heading)) nil file))
                          . ,(point-marker)))))))


### PR DESCRIPTION
Hello,
Currently, the only information about org heading's context within the helm candidates list
(after invoking helm-org-in-buffer-headings/helm-org-agenda-files-headings) is the number of asterisks preceding the title that reflect the heading's level and its position within the list with respect to its parent and peers.  Unfortunately, after narrowing down the list via helm facilities, the latter information is lost (as the peers and parent are likely filtered out) and identifying the precise heading we are looking for gets tricky if there are multiple headings with similar names but different position within the org hierarchy.

To remedy that, this change introduces the full outline paths to org headings in the candidates list. The paths are formatted via Org's facilities that make sure that important information (such as the title itself) is not obscured if parts of the path need to be truncated.

In addition to removing any ambiguity in terms of the location of particular heading within Org's hierarchy, it allows to filter out the headings not only by headings' titles but also by their outline path (much in the vein of narrowing down the list of files based on their file-system paths).

Cheers,
Adam 
