### PR TITLE
[Fix #929] Improve helm-semantic interface

### DIFF
--- a/helm-semantic.el
+++ b/helm-semantic.el
@@ -50,6 +50,13 @@
 ;; Internals vars
 (defvar helm-semantic--tags-cache nil)
 
+(defcustom helm-semantic-display-style 'semantic-format-tag-summarize
+  "Function to present a semantic tag."
+  :group 'helm-semantic
+  :type '(radio
+          (const :tag "Default" semantic-format-tag-summarize)
+          (const :tag "Prototype" semantic-format-tag-prototype)))
+
 (defun helm-semantic--fetch-candidates (tags depth &optional class)
   "Write the contents of TAGS to the current buffer."
   (let ((class class) cur-type)
@@ -63,22 +70,23 @@
                (setq class nil))
              (insert
               (if (and class (not type-p))
-                  (format "%s%sClass(%s) "
+                  (format "%s%s(%s) "
                           spaces (if (< depth 2) "" "├►") class)
                 spaces)
               ;; Save the tag for later
-              (propertize (semantic-format-tag-summarize tag nil t)
+              (propertize (funcall helm-semantic-display-style tag nil t)
                           'semantic-tag tag)
               "\n")
              (and type-p (setq class (car tag)))
              ;; Recurse to children
-             (helm-semantic--fetch-candidates
-              (semantic-tag-components tag) (1+ depth) class)))
+             (unless (eq cur-type 'function)
+               (helm-semantic--fetch-candidates
+                (semantic-tag-components tag) (1+ depth) class))))
 
           ;; Don't do anything with packages or includes for now
           ((package include)
            (insert
-            (propertize (semantic-format-tag-summarize tag nil t)
+            (propertize (funcall helm-semantic-display-style tag nil t)
                         'semantic-tag tag)
             "\n")
            )


### PR DESCRIPTION
- Add a custom variable helm-semantic-display-style that allows user to
  choose between two display style: the default (the current style) and
  a more concise style, semantic-format-tag-prototype that omits all the
  information about a tag (i.e. no "Function: " or "Variable: " is
  appended in each entry).

- Remove "Class" in format string to reduce the verbosity. Instead, only
  show the parent name next to current tag.

- Don't create a candidate for function parameters. User would be faster
  to jump to a function and navigate to the function parameter.