### PR TITLE
org-get-outline-path used in fast mode to accelerate large org file scans

### DIFF
--- a/helm-org.el
+++ b/helm-org.el
@@ -99,13 +99,15 @@ NOTE: This will be slow on large org buffers."
       (save-excursion
         (goto-char (point-min))
         (cl-loop while (re-search-forward org-complex-heading-regexp nil t)
-              if (let ((num-stars (length (match-string-no-properties 1))))
-                   (and (>= num-stars min-depth) (<= num-stars max-depth)))
-              collect `(,(let ((heading (funcall match-fn 4))
-                               (file (unless nofname (concat (helm-basename filename) ":"))))
-                           (org-format-outline-path
-                            (append (org-get-outline-path) (list heading)) nil file))
-                         . ,(point-marker)))))))
+                 if (let ((num-stars (length (match-string-no-properties 1))))
+                      (and (>= num-stars min-depth) (<= num-stars max-depth)))
+                 collect `(,(let ((heading (funcall match-fn 4))
+                                  (file (unless nofname (concat (helm-basename filename) ":")))
+                                  (level (length (match-string-no-properties 1)))
+                                  )
+                              (org-format-outline-path
+                               (append (org-get-outline-path t level heading) (list heading)) nil file))
+                           . ,(point-marker)))))))
 
 ;;;###autoload
 (defun helm-org-agenda-files-headings ()


### PR DESCRIPTION
Listing org headlines with full outline path included is noticibly faster now on my (moderately sized) org files.