### PR TITLE
Fix helm-locate-set-command for GNU/Linux

### DIFF
--- a/helm-locate.el
+++ b/helm-locate.el
@@ -187,7 +187,7 @@ See `helm-locate-with-db' and `helm-locate'."
   (unless helm-locate-command
     (setq helm-locate-command
           (cl-case system-type
-            (gnu/linux "locate %s -e -r %s")
+            (gnu/linux "locate %s -e -A --regex %s")
             (berkeley-unix "locate %s %s")
             (windows-nt "es %s %s")
             (t "locate %s %s")))))


### PR DESCRIPTION
Use correct option arguments for locate command.