### PR TITLE
[Fix #935] Improve Helm compatibility with themes

### DIFF
--- a/helm-bookmark.el
+++ b/helm-bookmark.el
@@ -61,12 +61,12 @@
   :group 'helm-bookmark)
 
 (defface helm-bookmark-file
-    '((t (:foreground "Deepskyblue2")))
+    '((t (:inherit font-lock-builtin-face)))
   "Face used for file bookmarks."
   :group 'helm-bookmark)
 
 (defface helm-bookmark-directory
-    '((t (:inherit helm-ff-directory)))
+    '((t (:inherit dired-directory)))
   "Face used for file bookmarks."
   :group 'helm-bookmark)
 

--- a/helm-buffers.el
+++ b/helm-buffers.el
@@ -91,7 +91,7 @@ Only buffer names are fuzzy matched when this is enabled,
   :group 'helm-buffers-faces)
 
 (defface helm-buffer-not-saved
-    '((t (:foreground "Indianred2")))
+    '((t (:inherit error)))
   "Face used for buffer files not already saved on disk."
   :group 'helm-buffers-faces)
 
@@ -107,12 +107,12 @@ Only buffer names are fuzzy matched when this is enabled,
   :group 'helm-buffers-faces)
 
 (defface helm-buffer-directory
-    '((t (:foreground "DarkRed" :background "LightGray")))
+    '((t (:inherit dired-directory)))
   "Face used for directories in `helm-buffers-list'."
   :group 'helm-buffers-faces)
 
 (defface helm-buffer-file
-    '((t :inherit font-lock-builtin-face))
+    '((t (:inherit font-lock-builtin-face)))
   "Face for buffer file names in `helm-buffers-list'."
   :group 'helm-buffers-faces)
 

--- a/helm-files.el
+++ b/helm-files.el
@@ -247,22 +247,22 @@ I.e use the -path/ipath arguments of find instead of -name/iname."
   :group 'helm-files-faces)
 
 (defface helm-ff-executable
-    '((t (:foreground "green")))
+    '((t (:foreground "#6e8b3d")))
   "Face used for executable files in `helm-find-files'."
   :group 'helm-files-faces)
 
 (defface helm-ff-directory
-    '((t (:foreground "DarkRed" :background "LightGray")))
+    '((t (:inherit dired-directory)))
   "Face used for directories in `helm-find-files'."
   :group 'helm-files-faces)
 
 (defface helm-ff-dotted-directory
-    '((t (:foreground "black" :background "DimGray")))
+  '((t (:inherit font-lock-keyword-face)))
   "Face used for directories in `helm-find-files'."
   :group 'helm-files-faces)
 
 (defface helm-ff-symlink
-    '((t (:foreground "DarkOrange")))
+    '((t (:inherit font-lock-variable-name-face)))
   "Face used for symlinks in `helm-find-files'."
   :group 'helm-files-faces)
 

--- a/helm.el
+++ b/helm.el
@@ -583,9 +583,11 @@ Directories expansion is not supported yet."
     '((((background dark))
        :background "#22083397778B"
        :foreground "white"
+       :box t
        :weight bold :height 1.3 :family "Sans Serif")
       (((background light))
        :background "#abd7f0"
+       :box t
        :foreground "black"
        :weight bold :height 1.3 :family "Sans Serif"))
   "Face for source header in the helm buffer."
@@ -614,8 +616,7 @@ Directories expansion is not supported yet."
   "Face for candidate number in mode-line." :group 'helm-faces)
 
 (defface helm-selection
-    '((((background dark)) :background "ForestGreen")
-      (((background light)) :background "#b5ffd1"))
+  '((t (:inherit highlight)))
   "Face for currently selected item in the helm buffer."
   :group 'helm-faces)
 


### PR DESCRIPTION
Some Helm faces are universal, so we should make it inherit from
built-in faces as much as possible unless directly supported by the
themes:

- helm-selection: inherit from highlight since helm-selection is
  everywhere in Helm and highlight face is defined in every theme.

- helm-header: use a box.

- helm-ff-executable: select a green foreground color that is not too
  bright and is compatible with both light and dark themes.

- helm-ff-directory: inherit from dired-directory for consistency. Also,
  this is where most themes define directory face.

- helm-ff-dotted-directory: use font-lock-keyword-face.

- helm-ff-symlink: uses font-lock-variable-name-face because it has
  similar color in default theme and obviously, reuse the color defined
  by a theme.

- helm-buffer-not-saved: use error for compatibility and draw user
  attention.

- helm-buffer-directory: reuse same built-in face as helm-ff-directory
  for consistency.

- helm-bookmark-file: reuse same built-in face as helm-ff-file for
  consistency.

Please tell me if you want screenshots of some themes for demos. But you should try it and see.