### PR TITLE
helm-etags-select selected region if possible

### DIFF
--- a/helm-tags.el
+++ b/helm-tags.el
@@ -328,7 +328,8 @@ This function aggregates three sources of tag files:
   (interactive "P")
   (let ((tag-files (helm-etags-all-tag-files))
         (helm-execute-action-at-once-if-one helm-etags-execute-action-at-once-if-one)
-        (str (thing-at-point 'symbol)))
+        (str (if (region-active-p) (buffer-substring-no-properties (region-beginning) (region-end))
+               (thing-at-point 'symbol))))
     (if (cl-notany 'file-exists-p tag-files)
         (message "Error: No tag file found. Create with etags shell command, or visit with `find-tag' or `visit-tags-table'.")
       (cl-loop for k being the hash-keys of helm-etags-cache


### PR DESCRIPTION
In modern html5 projects, the tag/keyword to
look up could be complicated

For example, in AngularJS, a controller is a string
which could contain any characters.