### PR TITLE
update the require emacs version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ the trap of backward compatibility.
 
 ## Requirements
 
-You need a recent Emacs to use latest helm, at least Emacs-24.3.
+You need a recent Emacs to use latest helm, at least Emacs-24.4.
 
 [async](https://github.com/jwiegley/emacs-async) will be installed as dependency
 when installing from melpa but is facultative when installing from git (recommended though


### PR DESCRIPTION
With commit 7cbbfc0d41204690c670f36ff4a00e67aa7e8e4b, not helm requires emacs 24.4. It doesn't work with 24.3 anymore.

```
helm :config: Symbol's function definition is void: add-function
```

I suggests drop support for emacs 24.3 (which is version in Ubuntu 14.04 LTS) or revert above commit.