### PR TITLE
Update hgrep keymap for more convenient

### DIFF
--- a/helm-grep.el
+++ b/helm-grep.el
@@ -238,6 +238,10 @@ If set to nil `doc-view-mode' will be used instead of an external command."
     (define-key map (kbd "<C-up>")   'helm-grep-mode-jump-other-window-backward)
     (define-key map (kbd "<M-down>") 'helm-gm-next-file)
     (define-key map (kbd "<M-up>")   'helm-gm-precedent-file)
+    (define-key map (kbd "M-n")      'helm-grep-mode-jump-other-window-forward)
+    (define-key map (kbd "M-p")      'helm-grep-mode-jump-other-window-backward)
+    (define-key map (kbd "M-N")      'helm-gm-next-file)
+    (define-key map (kbd "M-P")      'helm-gm-precedent-file)
     map))
 
 


### PR DESCRIPTION
- M-n and M-p can be used to go to next/previous match and open match
  in other window.

- M-N and M-P can be used to go to next/previous file in hgrep
  buffer. Users only need to press Shift to switch to the other feature 
  instead of moving their hands far away to the arrow keys.