### PR TITLE
Don't re-define fboundp

### DIFF
--- a/helm-config.el
+++ b/helm-config.el
@@ -201,14 +201,16 @@
 
 ;;; Compatibility emacs-24.4+
 ;; Inlined from Emacs trunk.
-(defalias 'function-put
-  ;; We don't want people to just use `put' because we can't conveniently
-  ;; hook into `put' to remap old properties to new ones.  But for now, there's
-  ;; no such remapping, so we just call `put'.
-  #'(lambda (f prop value) (put f prop value))
-  "Set function F's property PROP to VALUE.
+(eval-and-compile
+  (unless (fboundp 'function-put)
+    (defalias 'function-put
+      ;; We don't want people to just use `put' because we can't conveniently
+      ;; hook into `put' to remap old properties to new ones.  But for now, there's
+      ;; no such remapping, so we just call `put'.
+      #'(lambda (f prop value) (put f prop value))
+      "Set function F's property PROP to VALUE.
 The namespace for PROP is shared with symbols.
-So far, F can only be a symbol, not a lambda expression.")
+So far, F can only be a symbol, not a lambda expression.")))
 
 
 ;;; Load the autoload file


### PR DESCRIPTION
If `fboundp` is already defined, don't re-define it.  Makes `find-function` jump to its real definition instead this one…