### PR TITLE
helm-files pattern auto-expansion for user defined path aliases

### DIFF
--- a/helm-dabbrev.el
+++ b/helm-dabbrev.el
@@ -46,11 +46,13 @@ Have no effect when `helm-dabbrev-always-search-all' is non--nil."
 (defcustom helm-dabbrev-major-mode-assoc
   '((emacs-lisp-mode . lisp-interaction-mode))
   "Major mode association alist.
-This allow helm-dabbrev searching in buffers with the associated `major-mode'.
+If non--nil this allows helm-dabbrev searching in buffers with the associated `major-mode'.
 e.g \(emacs-lisp-mode . lisp-interaction-mode\)
 will allow searching in the lisp-interaction-mode buffer when `current-buffer'
 is an `emacs-lisp-mode' buffer and vice versa i.e
-no need to provide \(lisp-interaction-mode . emacs-lisp-mode\) association."
+no need to provide \(lisp-interaction-mode . emacs-lisp-mode\) association.
+If nil the `major-mode' of buffers is disregarded and the search happens in all buffers
+(similar behaviour to `dabbrev-expand' with `dabbrev-check-all-buffers' set to non--nil)"
   :type '(alist :key-type symbol :value-type symbol)
   :group 'helm-dabbrev)
 
@@ -104,33 +106,35 @@ but the initial search for all candidates in buffer(s)."
   ;; Determine the major-mode of START-BUFFER as `cur-maj-mode'.
   ;; Each time the loop go in another buffer we try to find if its
   ;; `major-mode' is:
+  ;; - any mode if `helm-dabbrev-major-mode-assoc' is nil
   ;; - same as the `cur-maj-mode'
   ;; - derived from `cur-maj-mode'
   ;; - have an assoc entry (major-mode . cur-maj-mode)
   ;; - have an rassoc entry (cur-maj-mode . major-mode)
   ;; - check if one of these entries inherit from another one in
   ;;   `helm-dabbrev-major-mode-assoc'.
-  (let* ((cur-maj-mode  (with-current-buffer start-buffer major-mode))
-         (c-assoc-mode  (assq cur-maj-mode helm-dabbrev-major-mode-assoc))
-         (c-rassoc-mode (rassq cur-maj-mode helm-dabbrev-major-mode-assoc))
-         (o-assoc-mode  (assq major-mode helm-dabbrev-major-mode-assoc))
-         (o-rassoc-mode (rassq major-mode helm-dabbrev-major-mode-assoc))
-         (cdr-c-assoc-mode (cdr c-assoc-mode))
-         (cdr-o-assoc-mode (cdr o-assoc-mode)))
-    (or (eq major-mode cur-maj-mode)
-        (derived-mode-p cur-maj-mode)
-        (or (eq cdr-c-assoc-mode major-mode)
-            (eq (car c-rassoc-mode) major-mode)
-            (eq (cdr (assq cdr-c-assoc-mode helm-dabbrev-major-mode-assoc))
-                major-mode)
-            (eq (car (rassq cdr-c-assoc-mode helm-dabbrev-major-mode-assoc))
-                major-mode))
-        (or (eq cdr-o-assoc-mode cur-maj-mode)
-            (eq (car o-rassoc-mode) cur-maj-mode)
-            (eq (cdr (assq cdr-o-assoc-mode helm-dabbrev-major-mode-assoc))
-                cur-maj-mode)
-            (eq (car (rassq cdr-o-assoc-mode helm-dabbrev-major-mode-assoc))
-                cur-maj-mode)))))
+  (or (not helm-dabbrev-major-mode-assoc)
+      (let* ((cur-maj-mode  (with-current-buffer start-buffer major-mode))
+             (c-assoc-mode  (assq cur-maj-mode helm-dabbrev-major-mode-assoc))
+             (c-rassoc-mode (rassq cur-maj-mode helm-dabbrev-major-mode-assoc))
+             (o-assoc-mode  (assq major-mode helm-dabbrev-major-mode-assoc))
+             (o-rassoc-mode (rassq major-mode helm-dabbrev-major-mode-assoc))
+             (cdr-c-assoc-mode (cdr c-assoc-mode))
+             (cdr-o-assoc-mode (cdr o-assoc-mode)))
+        (or (eq major-mode cur-maj-mode)
+            (derived-mode-p cur-maj-mode)
+            (or (eq cdr-c-assoc-mode major-mode)
+                (eq (car c-rassoc-mode) major-mode)
+                (eq (cdr (assq cdr-c-assoc-mode helm-dabbrev-major-mode-assoc))
+                    major-mode)
+                (eq (car (rassq cdr-c-assoc-mode helm-dabbrev-major-mode-assoc))
+                    major-mode))
+            (or (eq cdr-o-assoc-mode cur-maj-mode)
+                (eq (car o-rassoc-mode) cur-maj-mode)
+                (eq (cdr (assq cdr-o-assoc-mode helm-dabbrev-major-mode-assoc))
+                    cur-maj-mode)
+                (eq (car (rassq cdr-o-assoc-mode helm-dabbrev-major-mode-assoc))
+                    cur-maj-mode))))))
 
 (defun helm-dabbrev--collect (str limit ignore-case all)
   (let* ((case-fold-search ignore-case)

--- a/helm-dabbrev.el
+++ b/helm-dabbrev.el
@@ -46,13 +46,11 @@ Have no effect when `helm-dabbrev-always-search-all' is non--nil."
 (defcustom helm-dabbrev-major-mode-assoc
   '((emacs-lisp-mode . lisp-interaction-mode))
   "Major mode association alist.
-If non--nil this allows helm-dabbrev searching in buffers with the associated `major-mode'.
+This allow helm-dabbrev searching in buffers with the associated `major-mode'.
 e.g \(emacs-lisp-mode . lisp-interaction-mode\)
 will allow searching in the lisp-interaction-mode buffer when `current-buffer'
 is an `emacs-lisp-mode' buffer and vice versa i.e
-no need to provide \(lisp-interaction-mode . emacs-lisp-mode\) association.
-If nil the `major-mode' of buffers is disregarded and the search happens in all buffers
-(similar behaviour to `dabbrev-expand' with `dabbrev-check-all-buffers' set to non--nil)"
+no need to provide \(lisp-interaction-mode . emacs-lisp-mode\) association."
   :type '(alist :key-type symbol :value-type symbol)
   :group 'helm-dabbrev)
 
@@ -106,35 +104,33 @@ but the initial search for all candidates in buffer(s)."
   ;; Determine the major-mode of START-BUFFER as `cur-maj-mode'.
   ;; Each time the loop go in another buffer we try to find if its
   ;; `major-mode' is:
-  ;; - any mode if `helm-dabbrev-major-mode-assoc' is nil
   ;; - same as the `cur-maj-mode'
   ;; - derived from `cur-maj-mode'
   ;; - have an assoc entry (major-mode . cur-maj-mode)
   ;; - have an rassoc entry (cur-maj-mode . major-mode)
   ;; - check if one of these entries inherit from another one in
   ;;   `helm-dabbrev-major-mode-assoc'.
-  (or (not helm-dabbrev-major-mode-assoc)
-      (let* ((cur-maj-mode  (with-current-buffer start-buffer major-mode))
-             (c-assoc-mode  (assq cur-maj-mode helm-dabbrev-major-mode-assoc))
-             (c-rassoc-mode (rassq cur-maj-mode helm-dabbrev-major-mode-assoc))
-             (o-assoc-mode  (assq major-mode helm-dabbrev-major-mode-assoc))
-             (o-rassoc-mode (rassq major-mode helm-dabbrev-major-mode-assoc))
-             (cdr-c-assoc-mode (cdr c-assoc-mode))
-             (cdr-o-assoc-mode (cdr o-assoc-mode)))
-        (or (eq major-mode cur-maj-mode)
-            (derived-mode-p cur-maj-mode)
-            (or (eq cdr-c-assoc-mode major-mode)
-                (eq (car c-rassoc-mode) major-mode)
-                (eq (cdr (assq cdr-c-assoc-mode helm-dabbrev-major-mode-assoc))
-                    major-mode)
-                (eq (car (rassq cdr-c-assoc-mode helm-dabbrev-major-mode-assoc))
-                    major-mode))
-            (or (eq cdr-o-assoc-mode cur-maj-mode)
-                (eq (car o-rassoc-mode) cur-maj-mode)
-                (eq (cdr (assq cdr-o-assoc-mode helm-dabbrev-major-mode-assoc))
-                    cur-maj-mode)
-                (eq (car (rassq cdr-o-assoc-mode helm-dabbrev-major-mode-assoc))
-                    cur-maj-mode))))))
+  (let* ((cur-maj-mode  (with-current-buffer start-buffer major-mode))
+         (c-assoc-mode  (assq cur-maj-mode helm-dabbrev-major-mode-assoc))
+         (c-rassoc-mode (rassq cur-maj-mode helm-dabbrev-major-mode-assoc))
+         (o-assoc-mode  (assq major-mode helm-dabbrev-major-mode-assoc))
+         (o-rassoc-mode (rassq major-mode helm-dabbrev-major-mode-assoc))
+         (cdr-c-assoc-mode (cdr c-assoc-mode))
+         (cdr-o-assoc-mode (cdr o-assoc-mode)))
+    (or (eq major-mode cur-maj-mode)
+        (derived-mode-p cur-maj-mode)
+        (or (eq cdr-c-assoc-mode major-mode)
+            (eq (car c-rassoc-mode) major-mode)
+            (eq (cdr (assq cdr-c-assoc-mode helm-dabbrev-major-mode-assoc))
+                major-mode)
+            (eq (car (rassq cdr-c-assoc-mode helm-dabbrev-major-mode-assoc))
+                major-mode))
+        (or (eq cdr-o-assoc-mode cur-maj-mode)
+            (eq (car o-rassoc-mode) cur-maj-mode)
+            (eq (cdr (assq cdr-o-assoc-mode helm-dabbrev-major-mode-assoc))
+                cur-maj-mode)
+            (eq (car (rassq cdr-o-assoc-mode helm-dabbrev-major-mode-assoc))
+                cur-maj-mode)))))
 
 (defun helm-dabbrev--collect (str limit ignore-case all)
   (let* ((case-fold-search ignore-case)

--- a/helm-files.el
+++ b/helm-files.el
@@ -1434,6 +1434,54 @@ or when `helm-pattern' is equal to \"~/\"."
         (helm-set-pattern input)
         (helm-check-minibuffer-input)))))
 
+(defcustom helm-dabbrev-aliases
+   '(("t" . "/temp"))
+  "Helm path alias definition alist.
+This variable allows to define aliases that will be later
+automatically expanded when inserted into the `helm-files' search
+pattern with a `:' prefix. It enables quick navigation to the
+aliased paths in a manner similar to the root or home directory
+auto-expansion via `~/' and `//'.  
+
+For instance, assuming a \(\"t\" . \"/temp\"\) alias is
+configured in `helm-dabbrev-aliases', entering `:t' followed by
+`/' at the end of the search pattern will take you immediately to
+the `/temp' directory. Obviously the same works for paths of arbitrary
+complexity."
+  :type '(alist :key-type string :value-type string)
+  :group 'helm-dabbrev)
+
+(defun helm-ff-auto-expand-alias ()
+  "Allow expanding any aliases configured in `helm-dabbrev-aliases' to
+  the corresponding path."
+  (when (and (helm-file-completion-source-p)
+             (string-match
+              "/:\\(.*\\)/"
+              helm-pattern)
+             (with-current-buffer (window-buffer (minibuffer-window)) (eolp))
+             (not (string-match helm-ff-url-regexp helm-pattern)))
+    (let* ((alias (match-string 1 helm-pattern))
+           (subst (cdr (assoc alias helm-dabbrev-aliases)))
+           (input (if subst (expand-file-name
+                             subst
+                             (and (memq system-type '(windows-nt ms-dos))
+                                  (getenv "SystemDrive")) ; nil on Unix.
+                             )
+                    ;; remove the alias reference if substitution not found
+                    (replace-regexp-in-string                  
+                     (concat ":" alias "/") "" helm-pattern)))
+           )
+      (if (file-directory-p input)
+          (setq helm-ff-default-directory
+                (setq input (file-name-as-directory input)))
+        (setq helm-ff-default-directory (file-name-as-directory
+                                         (file-name-directory input))))
+      (with-helm-window
+        (helm-set-pattern input)
+        (helm-check-minibuffer-input)))))
+
+                                   
+
 (defun helm-substitute-in-filename (fname)
   "Substitute all parts of FNAME from start up to \"~/\" or \"/\".
 On windows system substitute from start up to \"/[[:lower:]]:/\".
@@ -1458,6 +1506,7 @@ and should be used carefully elsewhere, or not at all, using
 
 (add-hook 'helm-after-update-hook 'helm-ff-update-when-only-one-matched)
 (add-hook 'helm-after-update-hook 'helm-ff-auto-expand-to-home-or-root)
+(add-hook 'helm-after-update-hook 'helm-ff-auto-expand-alias)
 
 (defun helm-point-file-in-dired (file)
   "Put point on filename FILE in dired buffer."


### PR DESCRIPTION
I find the root and home directory auto-expansion in search pattern extremely useful for rapid navigation around the file system. So useful in fact, that I have created a simple extension of the concept that allows for rapid and friction-less navigation to any oft visited directory based on a configured list of aliases. 

It has proven pretty convenient for me so far, so I am sharing it here. Still not sure about possible overlap with the 'bookmark' facility, but as far as I managed to glean from the sources the latter requires some additional interactions and therefore does not provide the same sort of "immediacy" . 

Regards,
Adam