### PR TITLE
Make helm-man compatible with man v1.6

### DIFF
--- a/helm-man.el
+++ b/helm-man.el
@@ -57,7 +57,7 @@ source.")
             (let ((file (helm-comp-read
                          "ManFile: " wfiles :must-match t)))
               (if (eq helm-man-or-woman-function 'Man-getpage-in-background)
-                  (manual-entry (format "-l %s" file))
+                  (manual-entry file)
                 (woman-find-file file)))
           (funcall helm-man-or-woman-function candidate))
       ;; If woman is unable to format correctly


### PR DESCRIPTION
man v1.6 does not support `-l` option and it can open man-pages only by passing absolute file paths as arguments.
man v2 (man-db) also works without `-l` option when its arguments are absolute paths.

I tested this with man v1.6c on Mac OS X and man v2.7.1 on Arch Linux, and both seem to work well.