### PR TITLE
adding option to show full help with helm-lisp-completion-persistent-action

### DIFF
--- a/helm-elisp.el
+++ b/helm-elisp.el
@@ -107,6 +107,13 @@ fuzzy completion is not available in `completion-at-point'."
   "Face used for showing info in `helm-lisp-completion'."
   :group 'helm-elisp-faces)
 
+(defcustom helm-elisp-help-function
+  'helm-elisp-showdoc-modeline
+  "Function for displaying help for lisp symbols."
+  :group 'helm-elisp
+  :type '(choice (function :tag "Open help for the symbol." helm-elisp-showhelp)
+                 (function :tag "Show one liner in modeline." helm-elisp-showdoc-modeline)))
+
 
 ;;; Show completion.
 ;;
@@ -299,6 +306,19 @@ Return a cons \(beg . end\)."
       (message "[No Match]"))))
 
 (defun helm-lisp-completion-persistent-action (candidate)
+  "Show documentation for the function."
+  (apply helm-elisp-help-function (list candidate)))
+
+(defun helm-elisp-showhelp (candidate)
+  "Show full help for the function."
+  (let ((sym (intern-soft candidate)))
+    (cl-typecase sym
+      (fbound   (describe-function sym))
+      (bound    (describe-variable sym))
+      (face     (describe-face sym)))))
+
+(defun helm-elisp-showdoc-modeline (candidate)
+  "Show documentation for the function in modeline."
   (let ((cursor-in-echo-area t)
         mode-line-in-non-selected-windows)
     (helm-show-info-in-mode-line

--- a/helm-elisp.el
+++ b/helm-elisp.el
@@ -345,13 +345,10 @@ Return a cons \(beg . end\)."
 (defun helm-get-first-line-documentation (sym)
   "Return first line documentation of symbol SYM.
 If SYM is not documented, return \"Not documented\"."
-  (let ((doc (cond ((fboundp sym)
-                    (documentation sym t))
-                   ((boundp sym)
-                    (documentation-property sym 'variable-documentation t))
-                   ((facep sym)
-                    (face-documentation sym))
-                   (t nil))))
+  (let ((doc (cl-typecase sym
+                 (fbound  (documentation sym t))
+                 (bound   (documentation-property sym 'variable-documentation t))
+                 (face    (face-documentation sym)))))
     (if (and doc (not (string= doc ""))
              ;; `documentation' return "\n\n(args...)"
              ;; for CL-style functions.


### PR DESCRIPTION
Currently helm-lisp-completion-persistent-action shows one line summary in modeline. This pull request adds an option to show full help.