### PR TITLE
[Fix #1053] Use proper way to detect when to update

### DIFF
--- a/helm-semantic.el
+++ b/helm-semantic.el
@@ -124,10 +124,8 @@ you have completion on these functions with `C-M i' in the customize interface."
 
 (defun helm-semantic--maybe-set-needs-update ()
   (with-helm-current-buffer
-    (let ((tick (buffer-modified-tick)))
-      (unless (eq helm-cached-imenu-tick tick)
-        (setq helm-cached-imenu-tick tick)
-        (semantic-parse-tree-set-needs-update)))))
+    (when (semantic-parse-tree-needs-update-p)
+      (semantic-parse-tree-set-needs-update))))
 
 (defvar helm-source-semantic nil)
 


### PR DESCRIPTION
Instead of using buffer-modified-tick, better let Semantic decides when
it needs to update the parse tree using `semantic-parse-tree-needs-update-p`.
It is better at detecting an outdated parse tree. When a user adds new text to
a semantic tag i.e. add more code to a function, but does not delete/alter
the function itself, Semantic won't reparse. But when the function name,
or its arguments or its return type... anything attached to it being
modified, then Semantic will update the parse tree.