### PR TITLE
Change keyword :default to :input in function helm-do-grep-1

### DIFF
--- a/helm-grep.el
+++ b/helm-grep.el
@@ -918,7 +918,7 @@ in recurse, search being made on `helm-zgrep-file-extension-regexp'."
     (helm
      :sources 'helm-source-grep
      :buffer (format "*helm %s*" (if zgrep "zgrep" (helm-grep-command recurse)))
-     :default default-input
+     :input default-input
      :keymap helm-grep-map
      :history 'helm-grep-history
      :truncate-lines t)))


### PR DESCRIPTION
Hi Thierry,

This PR fixes the keyword `:default` passed to `helm` function in `helm-do-grep-1`, it should be `:input`.

Cheers,
syl20bnr