### PR TITLE
Keep using a prompt even with truncated line in header-line (#1064).

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -3822,21 +3822,22 @@ Possible value of DIRECTION are 'next or 'previous."
                           (and (listp source)
                                (assoc-default 'header-line source))
                           source))
-                  (hlend (make-string (max 0 (- (window-width) (length hlstr))) ? )))
+                  (hlend (make-string (max 0 (- (window-width)
+                                                (length hlstr))) ? )))
              (setq header-line-format
                    (propertize (concat " " hlstr hlend) 'face 'helm-header))))))
   (when force (force-mode-line-update)))
 
 (defun helm--set-header-line (&optional update)
   (with-selected-window (minibuffer-window)
-    (let* ((beg (save-excursion (vertical-motion 0) (point))) 
-           (end (save-excursion (end-of-visual-line) (point)))
+    (let* ((beg  (save-excursion (vertical-motion 0) (point))) 
+           (end  (save-excursion (end-of-visual-line) (point)))
            (vprt (concat (propertize helm--prompt 'face 'minibuffer-prompt)
                          "[...]"))
            ;; The visual line where the cursor is.
            (cont (buffer-substring beg end))
            (pref (propertize " " 'display '(space :width left-fringe)))
-           (pos (- (point) beg)))
+           (pos  (- (point) beg)))
       (with-helm-buffer
         (unless (string-match helm--prompt cont)
           (setq pref (propertize " " 'display (concat pref vprt))
@@ -3846,7 +3847,7 @@ Possible value of DIRECTION are 'next or 'previous."
                                      (substring cont (length vprt))))))
         (setq header-line-format (concat pref cont " "))
         (put-text-property
-         ; Increment pos to handle the space before prompt (i.e `pref').
+         ;; Increment pos to handle the space before prompt (i.e `pref').
          (1+ pos) (+ 2 pos)
          'face 'cursor header-line-format)
         (when update (force-mode-line-update))))))

--- a/helm.el
+++ b/helm.el
@@ -666,6 +666,11 @@ input method with `toggle-input-method'."
   "Face used to highlight matches."
   :group 'helm)
 
+(defface helm-header-line-left-margin
+  '((t (:foreground "black" :background "yellow")))
+  "Face used to highlight helm-header sign in left-margin."
+  :group 'helm)
+
 
 ;;; Variables.
 ;;
@@ -3832,17 +3837,15 @@ Possible value of DIRECTION are 'next or 'previous."
   (with-selected-window (minibuffer-window)
     (let* ((beg  (save-excursion (vertical-motion 0) (point))) 
            (end  (save-excursion (end-of-visual-line) (point)))
-           (vprt (concat (propertize helm--prompt 'face 'minibuffer-prompt)
-                         "[...]"))
            ;; The visual line where the cursor is.
            (cont (buffer-substring beg end))
            (pref (propertize
                   " "
                   'display (if (string-match helm--prompt cont)
                                '(space :width left-fringe)
-                               (propertize "->"
-                                           'face '((:background "yellow"
-                                                    :foreground "black"))))))
+                               (propertize
+                                "->"
+                                'face 'helm-header-line-left-margin))))
            (pos  (- (point) beg)))
       (with-helm-buffer
         (setq header-line-format (concat pref cont " "))

--- a/helm.el
+++ b/helm.el
@@ -1959,6 +1959,8 @@ ANY-KEYMAP ANY-DEFAULT ANY-HISTORY See `helm'."
   (let ((non-essential t)
         (input-method-verbose-flag helm-input-method-verbose-flag)
         (old--cua cua-mode)
+        (resize-mini-windows (and (null helm-echo-input-in-header-line)
+                                  resize-mini-windows))
         (helm--maybe-use-default-as-input
          (or helm--maybe-use-default-as-input ; it is let-bounded so use it.
              (cl-loop for s in (helm-normalize-sources any-sources)

--- a/helm.el
+++ b/helm.el
@@ -1959,8 +1959,6 @@ ANY-KEYMAP ANY-DEFAULT ANY-HISTORY See `helm'."
   (let ((non-essential t)
         (input-method-verbose-flag helm-input-method-verbose-flag)
         (old--cua cua-mode)
-        (resize-mini-windows (and (null helm-echo-input-in-header-line)
-                                  resize-mini-windows))
         (helm--maybe-use-default-as-input
          (or helm--maybe-use-default-as-input ; it is let-bounded so use it.
              (cl-loop for s in (helm-normalize-sources any-sources)
@@ -2457,6 +2455,8 @@ For ANY-PRESELECT ANY-RESUME ANY-KEYMAP ANY-DEFAULT ANY-HISTORY, See `helm'."
                            (assoc-default 'history src)))
            (timer nil)
            blink-matching-paren
+           (resize-mini-windows (and (null helm-echo-input-in-header-line)
+                                     resize-mini-windows))
            (first-src (car helm-sources))
            (first-src-val (if (symbolp first-src)
                               (symbol-value first-src)

--- a/helm.el
+++ b/helm.el
@@ -3836,15 +3836,15 @@ Possible value of DIRECTION are 'next or 'previous."
                          "[...]"))
            ;; The visual line where the cursor is.
            (cont (buffer-substring beg end))
-           (pref (propertize " " 'display '(space :width left-fringe)))
+           (pref (propertize
+                  " "
+                  'display (if (string-match helm--prompt cont)
+                               '(space :width left-fringe)
+                               (propertize "->"
+                                           'face '((:background "yellow"
+                                                    :foreground "black"))))))
            (pos  (- (point) beg)))
       (with-helm-buffer
-        (unless (string-match helm--prompt cont)
-          (setq pref (propertize " " 'display (concat pref vprt))
-                cont (propertize cont 'display
-                                 (if (> (length vprt) (length cont))
-                                     cont
-                                     (substring cont (length vprt))))))
         (setq header-line-format (concat pref cont " "))
         (put-text-property
          ;; Increment pos to handle the space before prompt (i.e `pref').

--- a/helm.el
+++ b/helm.el
@@ -3829,17 +3829,23 @@ Possible value of DIRECTION are 'next or 'previous."
   (with-selected-window (minibuffer-window)
     (let* ((beg (save-excursion (vertical-motion 0) (point))) 
            (end (save-excursion (end-of-visual-line) (point)))
+           (vprt (concat (propertize helm--prompt 'face 'minibuffer-prompt)
+                         "[...]"))
            ;; The visual line where the cursor is.
            (cont (buffer-substring beg end))
+           (pref (propertize " " 'display '(space :width left-fringe)))
            (pos (- (point) beg)))
-      (with-helm-window
-        (setq header-line-format
-              (concat (propertize " " 'display '(space :width left-fringe)) ; [1]
-                      cont
-                      " " ; Make it possible to show cursor after last character.
-                      ))
+      (with-helm-buffer
+        (unless (string-match helm--prompt cont)
+          (setq pref (propertize " " 'display (concat pref vprt))
+                cont (propertize cont 'display
+                                 (if (> (length vprt) (length cont))
+                                     cont
+                                     (substring cont (length vprt))))))
+        (setq header-line-format (concat pref cont " "))
         (put-text-property
-         (1+ pos) (+ 2 pos) ; Increment pos to handle the space before prompt [1].
+         ; Increment pos to handle the space before prompt (i.e `pref').
+         (1+ pos) (+ 2 pos)
          'face 'cursor header-line-format)
         (when update (force-mode-line-update))))))
 


### PR DESCRIPTION
* helm.el (helm--set-header-line): Do it.