### PR TITLE
require helm-utils for helm-org.el

### DIFF
--- a/helm-org.el
+++ b/helm-org.el
@@ -18,6 +18,7 @@
 ;;; Code:
 (require 'cl-lib)
 (require 'helm)
+(require 'helm-utils)
 (require 'org)
 
 (defgroup helm-org nil


### PR DESCRIPTION
helm-org-agenda-files-headings needs helm-basename defined

Discovered with joy that there exists `helm-org-agenda-files-headings`. Works like a charm, except in my freshly opened session I get

helm-get-org-candidates-in-file: Symbol's function definition is void: helm-basename

Thanks again for helm!
Derek