### PR TITLE
Escape regex characters in `helm--prompt`

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -3861,7 +3861,7 @@ Possible value of DIRECTION are 'next or 'previous."
            (cont (buffer-substring beg end))
            (pref (propertize
                   " "
-                  'display (if (string-match helm--prompt cont)
+                  'display (if (string-match-p (regexp-quote helm--prompt) cont)
                                '(space :width left-fringe)
                                (propertize
                                 "->"


### PR DESCRIPTION
I ran into this issue after the "->" was added because helm-projectile uses "[project] pattern:" for its prompt.  When `string-match` does this comparison, the "[project]" part is treated as a set of characters rather than a raw string, thus always failing the condition in the `if`.

I've changed the test to treat `helm--prompt` as a raw string as well as changed it to use `string-match-p` since you aren't using the returned index.