### PR TITLE
* helm-locate.el: require helm-types

### DIFF
--- a/helm-locate.el
+++ b/helm-locate.el
@@ -23,6 +23,7 @@
 
 (require 'cl-lib)
 (require 'helm)
+(require 'helm-types)
 
 
 (defgroup helm-locate nil


### PR DESCRIPTION
`helm-locate-source` parent class is `helm-type-file` defined in `helm-types`