### PR TITLE
remove candidate-number-limit from helm-source-ucs

### DIFF
--- a/helm-font.el
+++ b/helm-font.el
@@ -152,7 +152,6 @@ Only math* symbols are collected."
 (defvar helm-source-ucs
   (helm-build-in-buffer-source "Ucs names"
     :init #'helm-ucs-init
-    :candidate-number-limit 9999
     :help-message 'helm-ucs-help-message
     :filtered-candidate-transformer
     (lambda (candidates _source) (sort candidates #'helm-generic-sort-fn))


### PR DESCRIPTION
The load time for helm-source-ucs is unreasonably high, particularly on
OSX. Tested with a global candidate-number-limit of 100, load time is
greatly improved.

See #1137 and shosti/helm-unicode#2