### PR TITLE
Fix jumping to candidates in etags (#1164).

### DIFF
--- a/helm-tags.el
+++ b/helm-tags.el
@@ -276,10 +276,10 @@ If FILE is nil return nil."
          (/= last-modif (helm-etags-mtime file)))))
 
 ;;;###autoload
-(defun helm-etags-select (arg)
+(defun helm-etags-select (reinit)
   "Preconfigured helm for etags.
-If called with a prefix argument or if any of the tag files have
-been modified, reinitialize cache.
+If called with a prefix argument REINIT
+or if any of the tag files have been modified, reinitialize cache.
 
 This function aggregates three sources of tag files:
 
@@ -294,7 +294,8 @@ This function aggregates three sources of tag files:
         (str (if (region-active-p)
                  (buffer-substring-no-properties
                   (region-beginning) (region-end))
-                 (thing-at-point 'symbol))))
+                 (with-syntax-table (standard-syntax-table)
+                   (thing-at-point 'symbol)))))
     (if (cl-notany 'file-exists-p tag-files)
         (message "Error: No tag file found.\
 Create with etags shell command, or visit with `find-tag' or `visit-tags-table'.")
@@ -302,7 +303,7 @@ Create with etags shell command, or visit with `find-tag' or `visit-tags-table'.
                  unless (member k tag-files)
                  do (remhash k helm-etags-cache))
         (mapc (lambda (f)
-                (when (or (equal arg '(4))
+                (when (or (equal reinit '(4))
                           (and helm-etags-mtime-alist
                                (helm-etags-file-modified-p f)))
                   (remhash f helm-etags-cache)))

--- a/helm-tags.el
+++ b/helm-tags.el
@@ -294,6 +294,11 @@ This function aggregates three sources of tag files:
         (str (if (region-active-p)
                  (buffer-substring-no-properties
                   (region-beginning) (region-end))
+                 ;; Use a raw syntax-table to determine tap.
+                 ;; This may be wrong when calling etags
+                 ;; with hff from a buffer that use
+                 ;; a different syntax, but most of the time it
+                 ;; should be better.
                  (with-syntax-table (standard-syntax-table)
                    (thing-at-point 'symbol)))))
     (if (cl-notany 'file-exists-p tag-files)


### PR DESCRIPTION
* helm-tags.el (helm-etags-create-buffer): Now calculate line number
and include it.
(helm-etags-split-line): Same as helm-grep-split-line (should use it instead).
(helm-etags-build-source): Fix match-part according to new split.
(helm-etags-action-goto): Jump to candidate according to line number.