### PR TITLE
Fix helm-fuzzy-matching-highlight-fn not called.

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -2989,7 +2989,7 @@ It is meant to use with `filter-one-by-one' slot."
   "The filtered-candidate-transformer function to highlight matches in fuzzy.
 See helm-fuzzy-default-highlight-match."
   (cl-loop for c in candidates
-           collect (helm-fuzzy-default-highlight-match c)))
+           collect (funcall helm-fuzzy-matching-highlight-fn c)))
 
 (defun helm-match-functions (source)
   (let ((matchfns (or (assoc-default 'match source)


### PR DESCRIPTION
`helm-fuzzy-matching-highlight-fn` is exposed as a customizable variable, but the default value is always called.