### PR TITLE
Highlight migemo matches (#1175).

### DIFF
--- a/helm-grep.el
+++ b/helm-grep.el
@@ -1014,14 +1014,18 @@ in recurse, and ignoring EXTS, search being made on
         (with-temp-buffer
           (insert (propertize str 'read-only nil))
           (goto-char (point-min))
-          (cl-loop for reg in (if multi-match
-                                  ;; (m)occur.
-                                  (cl-loop for r in (helm-mm-split-pattern
-                                                     helm-pattern)
-                                           unless (string-match "\\`!" r)
-                                           collect r)
-                                  ;; async sources (grep, gid etc...)
-                                  (list helm-input))
+          (cl-loop for reg in
+                   (if multi-match
+                       ;; (m)occur.
+                       (cl-loop for r in (helm-mm-split-pattern
+                                          helm-pattern)
+                                unless (string-match "\\`!" r)
+                                collect
+                                (helm-aif (and helm-migemo-mode
+                                               (assoc r helm-mm--previous-migemo-info))
+                                    (cdr it) r))
+                       ;; async sources (grep, gid etc...)
+                       (list helm-input))
                    do
                    (while (and (re-search-forward reg nil t)
                                (> (- (setq end (match-end 0))

--- a/helm-multi-match.el
+++ b/helm-multi-match.el
@@ -275,10 +275,10 @@ i.e the sources which have the slot :migemo with non--nil value."
 (defun helm-mm-migemo-string-match (pattern str)
   "Migemo version of `string-match'."
   (unless (assoc pattern helm-mm--previous-migemo-info)
-    (push (cons pattern (migemo-get-pattern pattern))
+    (push (cons pattern (concat (migemo-get-pattern pattern)
+                                "\\|" pattern))
           helm-mm--previous-migemo-info))
-  (string-match (concat (assoc-default pattern helm-mm--previous-migemo-info)
-                        "\\|" pattern) str))
+  (string-match (assoc-default pattern helm-mm--previous-migemo-info) str))
 
 (cl-defun helm-mm-3-migemo-match (str &optional (pattern helm-pattern))
   (and helm-migemo-mode

--- a/helm-multi-match.el
+++ b/helm-multi-match.el
@@ -275,9 +275,11 @@ i.e the sources which have the slot :migemo with non--nil value."
 (defun helm-mm-migemo-string-match (pattern str)
   "Migemo version of `string-match'."
   (unless (assoc pattern helm-mm--previous-migemo-info)
-    (push (cons pattern (concat (migemo-get-pattern pattern)
-                                "\\|" pattern))
-          helm-mm--previous-migemo-info))
+    (with-helm-buffer
+      (setq helm-mm--previous-migemo-info
+            (push (cons pattern (concat (migemo-get-pattern pattern)
+                                        "\\|" pattern))
+                  helm-mm--previous-migemo-info))))
   (string-match (assoc-default pattern helm-mm--previous-migemo-info) str))
 
 (cl-defun helm-mm-3-migemo-match (str &optional (pattern helm-pattern))
@@ -286,10 +288,13 @@ i.e the sources which have the slot :migemo with non--nil value."
                 always (funcall pred (helm-mm-migemo-string-match re str)))))
 
 (defun helm-mm-migemo-forward (word &optional bound noerror count)
-  (re-search-forward
-   (if (delq 'ascii (find-charset-string word)) word
-     (concat (migemo-search-pattern-get word) "\\|" word))
-   bound noerror count))
+  (let ((regex (if (delq 'ascii (find-charset-string word))
+                   word
+                   (concat (migemo-search-pattern-get word) "\\|" word))))
+    (with-helm-buffer
+      (setq helm-mm--previous-migemo-info
+            (push (cons word regex) helm-mm--previous-migemo-info)))
+    (re-search-forward regex bound noerror count)))
 
 (defun helm-mm-3-migemo-search (pattern &rest _ignore)
   (and helm-migemo-mode

--- a/helm-multi-match.el
+++ b/helm-multi-match.el
@@ -274,10 +274,10 @@ i.e the sources which have the slot :migemo with non--nil value."
 
 (defun helm-mm-migemo-string-match (pattern str)
   "Migemo version of `string-match'."
-  (unless (string= pattern (car-safe helm-mm--previous-migemo-info))
-    (setq helm-mm--previous-migemo-info
-          (cons pattern (migemo-get-pattern pattern))))
-  (string-match (concat (cdr helm-mm--previous-migemo-info)
+  (unless (assoc pattern helm-mm--previous-migemo-info)
+    (push (cons pattern (migemo-get-pattern pattern))
+          helm-mm--previous-migemo-info))
+  (string-match (concat (assoc-default pattern helm-mm--previous-migemo-info)
                         "\\|" pattern) str))
 
 (cl-defun helm-mm-3-migemo-match (str &optional (pattern helm-pattern))

--- a/helm.el
+++ b/helm.el
@@ -3047,21 +3047,31 @@ sort on the real part."
 It is meant to use with `filter-one-by-one' slot."
   (let* ((pair (and (consp candidate) candidate))
          (display (helm-stringify (if pair (car pair) candidate)))
-         (real (cdr pair)))
+         (real (cdr pair))
+         (regex (helm-aif (and helm-migemo-mode
+                               (assoc helm-pattern
+                                      helm-mm--previous-migemo-info))
+                    (cdr it)
+                  helm-pattern)))
     (with-temp-buffer
-      (insert (propertize display 'read-only nil))
+      (insert display)
       (goto-char (point-min))
-      (if (search-forward helm-pattern nil t)
+      (if (re-search-forward regex nil t)
           (add-text-properties
            (match-beginning 0) (match-end 0) '(face helm-match))
-          (cl-loop with pattern = (if (string-match-p " " helm-pattern)
-                                      (split-string helm-pattern)
-                                      (split-string helm-pattern "" t))
-                   for p in pattern
+          (cl-loop with patterns = (if (string-match-p " " helm-pattern)
+                                       (split-string helm-pattern)
+                                       (split-string helm-pattern "" t))
+                   for p in patterns
+                   for re = (or (and helm-migemo-mode
+                                     (assoc-default
+                                      p helm-mm--previous-migemo-info))
+                                p)
                    do
-                   (when (search-forward p nil t)
+                   (when (search-forward re nil t)
                      (add-text-properties
-                      (match-beginning 0) (match-end 0) '(face helm-match)))))
+                      (match-beginning 0) (match-end 0)
+                      '(face helm-match)))))
       (setq display (buffer-string)))
     (if real (cons display real) display)))
 

--- a/helm.el
+++ b/helm.el
@@ -3068,7 +3068,7 @@ It is meant to use with `filter-one-by-one' slot."
                                       p helm-mm--previous-migemo-info))
                                 p)
                    do
-                   (when (search-forward re nil t)
+                   (when (re-search-forward re nil t)
                      (add-text-properties
                       (match-beginning 0) (match-end 0)
                       '(face helm-match)))))


### PR DESCRIPTION
* helm-grep.el (helm-grep-highlight-match): Do it.
* helm-multi-match.el (helm-mm-migemo-string-match):
The cache is now a full alist containing all patterns.
Allow references for highlighting and also don't compute twice
pattern with migemo.
* helm.el (helm-fuzzy-default-highlight-match): Use it.