### PR TITLE
 Allow migemo+regex in helm-buffers--match-from-inside (#1175).

### DIFF
--- a/helm-buffers.el
+++ b/helm-buffers.el
@@ -523,7 +523,9 @@ i.e same color."
         (with-current-buffer buf
           (save-excursion
             (goto-char (point-min))
-            (re-search-forward regexp nil t)))
+            (if helm-migemo-mode
+                (helm-mm-migemo-forward regexp nil t)
+             (re-search-forward regexp nil t))))
         t)))
 
 (defun helm-buffers--match-from-directory (candidate)

--- a/helm-multi-match.el
+++ b/helm-multi-match.el
@@ -290,9 +290,10 @@ i.e the sources which have the slot :migemo with non--nil value."
   (let ((regex (if (delq 'ascii (find-charset-string word))
                    word
                    (concat (migemo-search-pattern-get word) "\\|" word))))
-    (with-helm-buffer
-      (setq helm-mm--previous-migemo-info
-            (push (cons word regex) helm-mm--previous-migemo-info)))
+    (unless (assoc word helm-mm--previous-migemo-info)
+     (with-helm-buffer
+       (setq helm-mm--previous-migemo-info
+             (push (cons word regex) helm-mm--previous-migemo-info))))
     (re-search-forward regex bound noerror count)))
 
 (defun helm-mm-3-migemo-search (pattern &rest _ignore)

--- a/helm-regexp.el
+++ b/helm-regexp.el
@@ -24,7 +24,6 @@
 (require 'helm-plugin)
 
 (declare-function helm-mm-split-pattern "helm-multi-match")
-(declare-function migemo-forward "ext:migemo.el")
 
 
 (defgroup helm-regexp nil
@@ -248,7 +247,7 @@ arg METHOD can be one of buffer, buffer-other-window, buffer-other-frame."
           when (save-excursion
                  (condition-case _err
                      (if helm-migemo-mode
-                         (migemo-forward reg (point-at-eol) t)
+                         (helm-mm-migemo-forward reg (point-at-eol) t)
                        (re-search-forward reg (point-at-eol) t))
                    (invalid-regexp nil)))
           collect (match-beginning 0) into pos-ls


### PR DESCRIPTION
Hi,

I'd like to use `@` form in `helm-mini`.
Could `helm-mm-migemo-forward` be used in `helm-buffers--match-from-inside`?

And it seems `helm-mm-migemo-forward` could be better to allow regex in `helm-moccur-action` (#1185).

BTW, should I separate the PR?

Thank you.

P.S. It seems the following declarations could be needed to suppress warnings in helm-regexp and helm-multi-match.

For helm-regexp
```emacs-lisp
(declare-function helm-grep-split-line "helm-grep")
(declare-function helm-grep-highlight-match "helm-grep")
(declare-function helm-buffer-list "helm-buffers")
(declare-function helm-comp-read "helm-mode")
```

For helm-multi-match
```emacs-lisp
(declare-function helm-buffer-get "helm")
```
