### PR TITLE
Add helm-gid-program customization option

### DIFF
--- a/helm-id-utils.el
+++ b/helm-id-utils.el
@@ -24,6 +24,15 @@
   "ID-Utils related Applications and libraries for Helm."
   :group 'helm)
 
+(defcustom helm-gid-program "gid"
+  "Name of gid command (usually `gid').
+For Mac OS X users, if you install GNU coreutils, the name `gid'
+might be occupied by `id' from GNU coreutils, and you should set
+it to correct name (or absolute path), for example, if using
+MacPorts to install id-utils, it should be `gid32'."
+  :group 'helm-id-utils
+  :type 'file)
+
 (defcustom helm-gid-db-file-name "ID"
   "Name of a database file created by `mkid' command from `ID-utils'."
   :group 'helm-id-utils
@@ -31,10 +40,10 @@
 
 (defun helm-gid-candidates-process ()
   (let ((proc (start-process
-               "gid" nil "gid"
+               "gid" nil helm-gid-program
                "-r" helm-pattern)))
     (set (make-local-variable 'helm-grep-last-cmd-line)
-         (format "gid -r %s" helm-pattern))
+         (format "%s -r %s" helm-gid-program helm-pattern))
     (prog1 proc
       (set-process-sentinel
        proc (lambda (_process event)


### PR DESCRIPTION
On Mac OS X, "gid" might be the name of id(1) from GNU coreutils,
so add option to allow user to customize the name of gid(1).

As a side note: when I tried `helm-gid` at the beginning ("gid" is not the one from id-utils), `helm-gid` just didn't show any candidates regardless of any input (I thought it's a bug of helm), so we should remind OSX user to customize the option when someone documents `helm-id-utils` in helm wiki.