### PR TITLE
Attempt to fix empty helm-buffer (#1157).

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -3270,8 +3270,11 @@ is done on whole `helm-buffer' and not on current source."
                    ;; Export the variables from cl-loop
                    finally (setq delayed-sources ds
                                  normal-sources ns))
+             ;; Compute matches without rendering the sources.
              (helm-log "Matches: %S"
                        (setq matches (helm--collect-matches normal-sources)))
+             ;; If computing matches finished and is not interrupted
+             ;; erase the helm-buffer and render results (Fix #1157).
              (when matches
                (erase-buffer)
                (cl-loop for src in normal-sources
@@ -3297,6 +3300,9 @@ is done on whole `helm-buffer' and not on current source."
                  (helm-preselect preselect source))
                (setq helm-force-updating-p nil)))
         (when delayed-sources
+          ;; Erase buffer when there is no normal-sources,
+          ;; otherwise it would erase the already computed normal sources.
+          (unless normal-sources (erase-buffer))
           ;; Allow giving a value to `delayed' attr from inside source.
           ;; Retain the biggest value (the slower) found in DELAYED-SOURCES.
           (let ((helm-idle-delay (cl-loop with delay = helm-idle-delay

--- a/helm.el
+++ b/helm.el
@@ -3194,11 +3194,14 @@ and `helm-pattern'."
        (helm-log "Using here `helm-while-no-input'")
        (helm-while-no-input ,@body))))
 
+(defun helm--collect-matches (src-list)
+  (let ((matches (helm--maybe-use-while-no-input
+                  (cl-loop for src in src-list
+                           collect (helm-compute-matches src)))))
+    (unless (eq matches t) matches)))
+
 (defun helm--compute-sources (src-list)
-  (cl-loop with matches = (helm--maybe-use-while-no-input
-                           (cl-loop for src in src-list
-                                 collect (helm-compute-matches src)))
-        when (eq matches t) do (setq matches nil)
+  (cl-loop with matches = (helm--collect-matches src-list)
         for src in src-list
         for mtc in matches
         do (helm-render-source src mtc)))
@@ -3250,7 +3253,8 @@ is done on whole `helm-buffer' and not on current source."
   (with-current-buffer (helm-buffer-get)
     (set (make-local-variable 'helm-input-local) helm-pattern)
     (let (normal-sources
-          delayed-sources)
+          delayed-sources
+          matches)
       (unwind-protect
            (progn
              ;; Iterate over all the sources
@@ -3266,13 +3270,13 @@ is done on whole `helm-buffer' and not on current source."
                    ;; Export the variables from cl-loop
                    finally (setq delayed-sources ds
                                  normal-sources ns))
-             (erase-buffer)
-             ;; Render all the sources into the helm buffer after
-             ;; calculating all candidates.
-             ;; Candidates must be computed AFTER erasing buffer
-             ;; even if it cause flickering; Doing so avoid
-             ;; unexpected results when executing actions.
-             (helm--compute-sources normal-sources))
+             (helm-log "Matches: %S"
+                       (setq matches (helm--collect-matches normal-sources)))
+             (when matches
+               (erase-buffer)
+               (cl-loop for src in normal-sources
+                        for mtc in matches
+                        do (helm-render-source src mtc))))
         (helm-log "Delayed sources = %S"
                   (mapcar (lambda (s) (assoc-default 'name s))
                           delayed-sources))


### PR DESCRIPTION
* helm.el (helm--collect-matches): New.
(helm--compute-sources): Use it.
(helm-update): Compute matches, and maybe render sources after
erasing helm-buffer.