### PR TITLE
Use helm-completing-read-symbols for describe-symbol

### DIFF
--- a/helm-mode.el
+++ b/helm-mode.el
@@ -29,6 +29,7 @@
 (defcustom helm-completing-read-handlers-alist
   '((describe-function . helm-completing-read-symbols)
     (describe-variable . helm-completing-read-symbols)
+    (describe-symbol . helm-completing-read-symbols)
     (debug-on-entry . helm-completing-read-symbols)
     (find-function . helm-completing-read-symbols)
     (trace-function . helm-completing-read-symbols)


### PR DESCRIPTION
The `describe-symbol' command is available from 25.1.