### PR TITLE
Fix two docstrings

### DIFF
--- a/helm-lib.el
+++ b/helm-lib.el
@@ -578,9 +578,7 @@ That is what completion commands operate on."
 ;;
 ;;
 (defun helm-yank-text-at-point ()
-  "Yank text at point in `helm-current-buffer' into minibuffer.
-If `helm-yank-symbol-first' is non--nil the first yank
-grabs the entire symbol."
+  "Yank text at point in `helm-current-buffer' into minibuffer."
   (interactive)
   (with-helm-current-buffer
     (let ((fwd-fn (or helm-yank-text-at-point-function #'forward-word)))

--- a/helm.el
+++ b/helm.el
@@ -3055,7 +3055,7 @@ It is meant to use with `filter-one-by-one' slot."
 
 (defun helm-fuzzy-highlight-matches (candidates _source)
   "The filtered-candidate-transformer function to highlight matches in fuzzy.
-See helm-fuzzy-default-highlight-match."
+See `helm-fuzzy-default-highlight-match'."
   (cl-loop for c in candidates
            collect (funcall helm-fuzzy-matching-highlight-fn c)))
 


### PR DESCRIPTION
The user option `helm-yank-symbol-first' has been removed. The [related part](https://github.com/emacs-helm/helm/wiki#yanking-text) of helm wiki also needs to be updated.