### PR TITLE
Format candidate as string for insert in helm-copy-to-buffer

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -5321,7 +5321,7 @@ is what is used to perform actions."
   (with-helm-buffer
     (cl-loop for cand in (helm-marked-candidates)
              do (with-helm-current-buffer
-                  (insert cand "\n")))))
+                  (insert (format "%s\n" cand))))))
 
 
 ;;; Follow-mode: Automatical execution of persistent-action


### PR DESCRIPTION
The problem I meet is I can't use `C-k C-i` (`helm-copy-to-buffer`) in `helm-buffers-list` to insert selected buffer's name to `helm-current-buffer`, it fails with following error message:

    Wrong type argument: char-or-string-p, #<buffer *Messages*>

The cause is `(helm-marked-candidates)` here doesn't return a list of buffer names (i.e., strings), so in this PR, I use `format` to convert it to string before inserting, however, maybe you have better solution.