### PR TITLE
Customize updatedb function

### DIFF
--- a/helm-locate.el
+++ b/helm-locate.el
@@ -155,6 +155,19 @@ fall back to `default-directory' if FROM-FF is nil."
                  helm-ff-locate-db-filename
                  default-directory))))))
 
+
+(defun helm-locate-create-db-default-function (db-name directory)
+  "Default function used to create a locale locate db file.
+Argument DB-NAME name of the db file.
+Argument DIRECTORY root of file system subtree to scan."
+  (format helm-locate-create-db-command db-name directory))
+
+(defvar helm-locate-create-db-function
+  #'helm-locate-create-db-default-function
+  "Function used to create a locale locate db file.
+It should receive the same arguments as
+`helm-locate-create-db-default-function'.")
+
 (defun helm-locate-1 (&optional localdb init from-ff default)
   "Generic function to run Locate.
 Prefix arg LOCALDB when (4) search and use a local locate db file when it
@@ -169,9 +182,9 @@ See `helm-locate-with-db' and `helm-locate'."
                  (if (file-directory-p candidate)
                      (message "Error: The locate Db should be a file")
                    (if (= (shell-command
-                           (format helm-locate-create-db-command
-                                   candidate
-                                   helm-ff-default-directory))
+                           (funcall helm-locate-create-db-function
+                                    candidate
+                                    helm-ff-default-directory))
                           0)
                        (message "New locatedb file `%s' created" candidate)
                      (error "Failed to create locatedb file `%s'" candidate)))))
@@ -312,9 +325,9 @@ See also `helm-locate'."
 (defun helm-locate-find-dbs-in-projects (&optional update)
   (let* ((pfn (lambda (candidate directory)
                 (unless (= (shell-command
-                            (format helm-locate-create-db-command
-                                    candidate
-                                    directory))
+                            (funcall helm-locate-create-db-function
+                                     candidate
+                                     directory))
                            0)
                   (error "Failed to create locatedb file `%s'" candidate)))))
     (cl-loop for p in helm-locate-project-list


### PR DESCRIPTION
As GNU `updatedb` doesn't have an option of `prunenames`, users should use `prunepaths` only to exclude some paths from being scanned into the DB. The proposed PR brings `helm-locate-create-db-function` and adds an option to redefine it, by default using `format` like it was until now. Hence the user has an option to write something like the following:

```
(defun ig-helm-locate-create-db-function (db-name directory)
  (format helm-locate-create-db-command db-name directory
	  (expand-file-name ".git" directory)))

(setq helm-locate-create-db-command
		"updatedb --output=%s --localpaths='%s' −−prunepaths='%s'")
(setq helm-locate-create-db-function
	      #'ig-helm-locate-create-db-function)
```