### PR TITLE
Make "file name at point" the default input for helm-locate

### DIFF
--- a/helm-locate.el
+++ b/helm-locate.el
@@ -389,7 +389,7 @@ Where db_path is a filename matched by
 `helm-locate-db-file-regexp'."
   (interactive "P")
   (setq helm-ff-default-directory default-directory)
-  (helm-locate-1 arg))
+  (helm-locate-1 arg nil nil (thing-at-point 'filename)))
 
 (provide 'helm-locate)
 


### PR DESCRIPTION
Hi Thierry,

I've made "file name at point" the default input for helm-locate so that one can easily press "M-n" to get `locate` to find the file name at point. In my opinion, this is more convenient. What do you think?
Thanks,

York
