### PR TITLE
Control insertion of kill-ring entry into buffer.

### DIFF
--- a/helm-ring.el
+++ b/helm-ring.el
@@ -57,6 +57,11 @@ If nil or zero (disabled), don't truncate candidate, show all."
   :group 'helm-ring
   :type '(alist :key-type string :value-type function))
 
+(defcustom helm-show-kill-ring-yank t
+  "*Insert entry from helm-show-kill-ring into the buffer."
+  :type '(boolean)
+  :group 'helm-ring)
+
 
 ;;; Kill ring
 ;;
@@ -116,7 +121,8 @@ replace with STR as yanked string."
   (with-helm-current-buffer
     (setq kill-ring (delete str kill-ring))
     (if (not (eq (helm-attr 'last-command helm-source-kill-ring) 'yank))
-        (insert-for-yank str)
+        (when helm-show-kill-ring-yank
+          (insert-for-yank str))
       ;; from `yank-pop'
       (let ((inhibit-read-only t)
             (before (< (point) (mark t))))


### PR DESCRIPTION
Add a defcustom to control whether an entry selected from
`helm-show-kill-ring` gets inserted into the buffer.  By default,
nothing is different for the user, but when the new defcutsom
`helm-show-kill-ring-yank` is set to nil, selecting an entry from
`helm-show-kill-ring` will not cause that entry to be inserted into the
buffer.  This is useful for users who are using, e.g., clipmon-mode to
synchronize the kill-ring and the X clipboard.  If the user wants to
choose an entry from the kill ring to paste into another application,
s/he can choose it with `helm-show-kill-ring`, then switch to the other
application to paste.