### PR TITLE
Fix helm--follow-action's arg calling

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -4098,8 +4098,8 @@ current source (i.e don't move to next source if some)."
               (eq last-command 'helm-follow-action-backward)
               (eq last-command 'helm-execute-persistent-action))
       (if (> arg 0)
-          (helm-next-line)
-        (helm-previous-line)))
+          (helm-next-line 1)
+        (helm-previous-line 1)))
     (helm-execute-persistent-action)))
 
 (defun helm-follow-action-forward ()


### PR DESCRIPTION
* helm.el (helm--follow-action): Use default arg for next/previous line.

This makes it so that `helm-move-to-line-cycle-in-source` is respected.