### PR TITLE
Comply with `confirm-nonexistent-file-or-buffer` variable.

### DIFF
--- a/helm-files.el
+++ b/helm-files.el
@@ -2688,7 +2688,8 @@ Called with a prefix arg open files in background without selecting them."
         (find-file-wildcards nil)
         (make-dir-fn
          (lambda (dir &optional helm-ff)
-             (when (y-or-n-p (format "Create directory `%s'? " dir))
+             (when (or (not confirm-nonexistent-file-or-buffer)
+                     (y-or-n-p (format "Create directory `%s'? " dir)))
                (let ((dirfname (directory-file-name dir)))
                  (if (file-exists-p dirfname)
                      (error


### PR DESCRIPTION
If `confirm-nonexistent-file-or-buffer` is nil then helm-find-files will
not ask for confirmation to create directories, when trying to create a
file in a non-existent directory.

This fixes https://github.com/emacs-helm/helm/issues/1292