### PR TITLE
Fix additional space suffix in `helm--completion-in-region`

### DIFF
--- a/helm-mode.el
+++ b/helm-mode.el
@@ -1050,7 +1050,9 @@ Can be used as value for `completion-in-region-function'."
                   ;; See Issue #407.
                   (afun (plist-get completion-extra-properties :annotation-function))
                   (data (all-completions input collection predicate))
-                  (init-space-suffix (unless helm-completion-in-region-fuzzy-match " "))
+                  (init-space-suffix (unless (or helm-completion-in-region-fuzzy-match
+                                                 (string-suffix-p " " input))
+                                       " "))
                   ;; Assume that when `afun' and `predicate' are null
                   ;; we are in filename completion.
                   (file-comp-p (or (helm-mode--in-file-completion-p)


### PR DESCRIPTION
Previously, `helm--completion-in-region` always adds a trailing " " to
the input (unless `helm-completion-in-region-fuzzy-match` is true).
This leads to problems e.g. in `sbt-mode` completion, because instead of
`testOnly ` (note the trailing " "), we have `testOnly  ` (two " " at
the end).  I fixed this by adding another check whether the input
already ends with an " ", and if this is the case do not append another
" ".

-- 24pullrequests
[![](http://24pullrequests.com/assets/logo-8a77737f86fec8def19a1c9a605c9841dbd44e59f243ed3bf64bbdf3214d6fa1.png)](http://24pullrequests.com/)
