### PR TITLE
fix error in helm-search-match-part

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -4697,7 +4697,7 @@ this function is always called."
                 ;; Fuzzy regexp have already been
                 ;; computed with substring 1.
                 (not (string-match fuzzy-regexp part))
-                (not (funcall matchfn (substring 1 pattern) part)))
+                (not (funcall matchfn (substring pattern 1) part)))
             (funcall matchfn (if helm--in-fuzzy fuzzy-regexp pattern) part)))))
 
 (defun helm-initial-candidates-from-candidate-buffer (get-line-fn limit)


### PR DESCRIPTION
Not sure if there's something deeper to this, but this was causing errors in the extension I was writing. `substring` accepts a string, then an initial index, and the two were transposed for some reason.