### PR TITLE
Use consistent pretty major name

### DIFF
--- a/helm-buffers.el
+++ b/helm-buffers.el
@@ -193,7 +193,7 @@ Only buffer names are fuzzy matched when this is enabled,
   (let ((result (cl-loop for b in helm-buffers-list-cache
                          maximize (length b) into len-buf
                          maximize (length (with-current-buffer b
-                                            (symbol-name major-mode)))
+                                            (format-mode-line mode-name)))
                          into len-mode
                          finally return (cons len-buf len-mode))))
     (unless (default-value 'helm-buffer-max-length)


### PR DESCRIPTION
Because `helm-buffer--details` uses pretty major name. 

This should be able to reduce the width of major mode (some helm user asked about this in Emacs SE: http://emacs.stackexchange.com/q/19192/3889) on some level since pretty major name is usually shorter.