### PR TITLE
Position point at the beginning of the headline

### DIFF
--- a/helm-org.el
+++ b/helm-org.el
@@ -73,7 +73,7 @@ Note this have no effect in `helm-org-in-buffer-headings'."
   (switch-to-buffer (marker-buffer marker))
   (goto-char (marker-position marker))
   (org-show-context)
-  (org-show-entry))
+  (re-search-backward "^\*+ " nil t))
 
 (defun helm-source-org-headings-for-files (filenames &optional parents)
   (helm-build-sync-source "Org Headings"


### PR DESCRIPTION
I think it makes sense to place the point at the beginning of the headline. It makes visibility cycling easier when all headlines are folded. It's also convenient for speed keys (`org-use-speed-commands`).