### PR TITLE
Fix helm-file-name-sans-extension for files beginning with a dot

### DIFF
--- a/helm-lib.el
+++ b/helm-lib.el
@@ -424,7 +424,7 @@ See `kill-new' for argument REPLACE."
 (defun helm-file-name-sans-extension (filename)
   "Same as `file-name-sans-extension' but remove all extensions."
   (helm-aif (file-name-sans-extension filename)
-      (if (string-match "\\." it)
+      (if (string-match "[^\\.]+\\." it)
           (helm-file-name-sans-extension it)
           it)))
 


### PR DESCRIPTION
A file beginning with a dot (`.`) and no further dots should be treated as a file without any extension.

Currently it keeps recursing until it hits `max-lisp-eval-depth`. It happened to me with a file named `._libtool.info`. The error disappeared after the change.

I'm unsure if this introduces any other problems. It seemed like an easy enough fix, so this is just a quick PR. Please tell me if I overlooked anything :-)