### PR TITLE
Fix bugs in 'helm-revive-visible-mark' function

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -5358,22 +5358,24 @@ When key WITH-WILDCARD is specified try to expand a wilcard if some."
   (with-current-buffer helm-buffer
     (save-excursion
       (cl-dolist (o helm-visible-mark-overlays)
-        (goto-char (point-min))
-        (while (and (search-forward (overlay-get o 'string) nil t)
-                    (not (overlays-at (point-at-bol 0)))
-                    (helm-current-source-name= (overlay-get o 'source)))
-          ;; Calculate real value of candidate.
-          ;; It can be nil if candidate have only a display value.
-          (let ((real (get-text-property (point-at-bol 0) 'helm-realvalue)))
-            (if real
-                ;; Check if real value of current candidate is the same
-                ;; than the one stored in overlay.
-                ;; This is needed when some cands have same display names.
-                ;; Using equal allow testing any type of value for real cand.
-                ;; Issue (#706).
-                (and (equal (overlay-get o 'real) real)
-                     (move-overlay o (point-at-bol 0) (1+ (point-at-eol 0))))
-                (move-overlay o (point-at-bol 0) (1+ (point-at-eol 0))))))))))
+        (let ((o-str (overlay-get o 'string)))
+          (goto-char (point-min))
+          (while (and (search-forward o-str nil t)
+                      (not (overlays-at (point-at-bol 0)))
+                      (helm-current-source-name= (overlay-get o 'source)))
+            ;; Calculate real value of candidate.
+            ;; It can be nil if candidate have only a display value.
+            (let ((real (get-text-property (point-at-bol 0) 'helm-realvalue)))
+              (if real
+                  ;; Check if real value of current candidate is the same
+                  ;; than the one stored in overlay.
+                  ;; This is needed when some cands have same display names.
+                  ;; Using equal allow testing any type of value for real cand.
+                  ;; Issue (#706).
+                  (and (equal (overlay-get o 'real) real)
+                       (move-overlay o (point-at-bol 0) (1+ (point-at-eol 0))))
+                (and (equal o-str (buffer-substring (point-at-bol 0) (1+ (point-at-eol 0))))
+                 (move-overlay o (point-at-bol 0) (1+ (point-at-eol 0))))))))))))
 (add-hook 'helm-update-hook 'helm-revive-visible-mark)
 
 (defun helm-next-point-in-list (curpos points &optional prev)


### PR DESCRIPTION
I've found some issues with ```helm-revive-visible-mark``` and this PR addresses them.  You can use the code below to repro.

```
;; Not a very useful transformer but its just for illustration purposes
(setq xfrmr (lambda (candidates source)
              (helm-get-candidates source)))

;; `helm-revive-visible-mark' doesn't respect the 'allow-dups slot and it
;; doesn't match candidates well for candidates with only a display value.

;; To reproduce, select all candidates and then enter a character into the pattern prompt.
;; You'll see that dups get visibly unmarked, and the "0" gets unmarked as well because
;; it matches the "0" chars within the subsequent "100" candidates
(helm :sources (helm-build-sync-source "Marking Bugs Demo"
                 :allow-dups t
                 :candidates (cons "0" (make-list 10 "100"))
                 :filtered-candidate-transformer xfrmr))
```