### PR TITLE
Clean up dependencies

### DIFF
--- a/helm-core-pkg.el
+++ b/helm-core-pkg.el
@@ -2,8 +2,7 @@
 
 (define-package "helm-core" "1.9.1"
   "Development files for Helm"
-  '((emacs "24")
-    (cl-lib "0.5")
+  '((emacs "24.3")
     (async "1.6"))
   :url "https://emacs-helm.github.io/helm/")
 

--- a/helm-pkg.el
+++ b/helm-pkg.el
@@ -2,8 +2,7 @@
 
 (define-package "helm" "1.9.1"
   "Helm is an Emacs incremental and narrowing framework"
-  '((emacs "24")
-    (cl-lib "0.5")
+  '((emacs "24.3")
     (async "1.6")
     (helm-core "1.9.1"))
   :url "https://emacs-helm.github.io/helm/")


### PR DESCRIPTION
helm supports Emacs 24.3 and higher versions and cl-lib was bundled
since Emacs 24.3.