### PR TITLE
Fix bug in `helm-revive-visible-mark'

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -5360,11 +5360,14 @@ When key WITH-WILDCARD is specified try to expand a wilcard if some."
   (with-current-buffer helm-buffer
     (save-excursion
       (cl-dolist (o helm-visible-mark-overlays)
-        (let ((o-str (overlay-get o 'string)))
+        (let ((o-src-str (overlay-get o 'source))
+              (o-str (overlay-get o 'string)))
+          ;;Move point to end of source header line
           (goto-char (point-min))
+          (search-forward o-src-str nil t)
           (while (and (search-forward o-str nil t)
                       (not (overlays-at (point-at-bol 0)))
-                      (helm-current-source-name= (overlay-get o 'source)))
+                      (helm-current-source-name= o-src-str))
             ;; Calculate real value of candidate.
             ;; It can be nil if candidate have only a display value.
             (let ((real (get-text-property (point-at-bol 0) 'helm-realvalue)))
@@ -5377,7 +5380,7 @@ When key WITH-WILDCARD is specified try to expand a wilcard if some."
                   (and (equal (overlay-get o 'real) real)
                        (move-overlay o (point-at-bol 0) (1+ (point-at-eol 0))))
                 (and (equal o-str (buffer-substring (point-at-bol 0) (1+ (point-at-eol 0))))
-                 (move-overlay o (point-at-bol 0) (1+ (point-at-eol 0))))))))))))
+                     (move-overlay o (point-at-bol 0) (1+ (point-at-eol 0))))))))))))
 (add-hook 'helm-update-hook 'helm-revive-visible-mark)
 
 (defun helm-next-point-in-list (curpos points &optional prev)


### PR DESCRIPTION
Begin search for candidates to mark revive from the source header string instead of (point-min)

Run the code below with and without my patch to see the difference.  Repro steps in the comments.

```
;; Not a very useful transformer but its just for illustration purposes
(setq xfrmr (lambda (candidates source)
              (helm-get-candidates source)))

(setq source-1 (helm-build-dummy-source "Source 1"
                 :filtered-candidate-transformer (lambda (_c _s)
                                                   (list "5"))
                 :nohighlight t
                 :nomark t))

(setq source-2 (helm-build-sync-source "Source 2"
                 :candidates (mapcar 'prin1-to-string (number-sequence 0 10))
                 :filtered-candidate-transformer xfrmr))

;; Steps to Repro:
;; 1. Run sexp below
;; 2. Select all candidates
;; 3. Enter a character into the prompt
;; 4. Notice how 1 and 5 don't get revived
;; 5. 1 doesn't get revived because it matches the 1 in source-1's header and fails to enter the search loop
;; 6. 5 doesn't get revived because it matches the 5 in source-1's candidate and fails to enter the search loop

;; My PR fixes this behavior because it searches from the sources header rather than (point-min)
(let* ((my-after-update-hook (copy-sequence helm-after-update-hook)))

  (add-hook 'my-after-update-hook (lambda ()
                                          (helm-next-line)))
  
  (helm :sources `(,source-1 ,source-2)
        :helm-after-update-hook my-after-update-hook))
```