### PR TITLE
Fix return value of helm-execute-selection-action

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -3678,8 +3678,8 @@ function."
   ;; Position can be change when `helm-current-buffer'
   ;; is split, so jump to this position before executing action.
   (helm-current-position 'restore)
-  (helm-execute-selection-action-1)
-  (helm-log-run-hook 'helm-after-action-hook))
+  (prog1 (helm-execute-selection-action-1)
+    (helm-log-run-hook 'helm-after-action-hook)))
 
 (defun helm-execute-selection-action-1 (&optional
                                         selection action


### PR DESCRIPTION
The bug is introduced in commit d72d7dcd3e8bcfd83c0cf1c58bacfcfec631f4fa which is made to solve issue #1412.

Fixes #1415 and #1414.