### PR TITLE
Fixing typo in use of cl-typecase.

### DIFF
--- a/helm-lib.el
+++ b/helm-lib.el
@@ -350,9 +350,9 @@ ARGS is (cand1 cand2 ...) or ((disp1 . real1) (disp2 . real2) ...)
   "Return the representation of ELM as a string.
 ELM can be a string, a number or a symbol."
   (cl-typecase elm
-    (stringp elm)
-    (numberp (number-to-string elm))
-    (symbolp (symbol-name elm))))
+    (string elm)
+    (number (number-to-string elm))
+    (symbol (symbol-name elm))))
 
 (defun helm-substring (str width)
   "Return the substring of string STR from 0 to WIDTH.


### PR DESCRIPTION
Previously instead of using 'string' the code used 'stringp'. The
extra 'p' caused cl-typecase to expand incorrectly. This is obvious
when macroexpanding the old definition and the new one.