### PR TITLE
Org tag completion improvements

### DIFF
--- a/helm-mode.el
+++ b/helm-mode.el
@@ -37,6 +37,7 @@
     (trace-function-foreground . helm-completing-read-symbols)
     (trace-function-background . helm-completing-read-symbols)
     (find-tag . helm-completing-read-with-cands-in-buffer)
+    (org-capture . not-helm-org-completing-read-tags) ; FIXME: This function doesn't work if its name starts with "helm" ??
     (org-set-tags . not-helm-org-completing-read-tags) ; FIXME: This function doesn't work if its name starts with "helm" ??
     (ffap-alternate-file . nil)
     (tmm-menubar . nil)

--- a/helm-mode.el
+++ b/helm-mode.el
@@ -37,7 +37,7 @@
     (trace-function-foreground . helm-completing-read-symbols)
     (trace-function-background . helm-completing-read-symbols)
     (find-tag . helm-completing-read-with-cands-in-buffer)
-    (org-set-tags . helm-org-completing-read-tags)
+    (org-set-tags . not-helm-org-completing-read-tags) ; FIXME: This function doesn't work if its name starts with "helm" ??
     (ffap-alternate-file . nil)
     (tmm-menubar . nil)
     (find-file . nil)

--- a/helm-mode.el
+++ b/helm-mode.el
@@ -37,6 +37,7 @@
     (trace-function-foreground . helm-completing-read-symbols)
     (trace-function-background . helm-completing-read-symbols)
     (find-tag . helm-completing-read-with-cands-in-buffer)
+    (org-set-tags . helm-org-completing-read-tags)
     (ffap-alternate-file . nil)
     (tmm-menubar . nil)
     (find-file . nil)

--- a/helm-org.el
+++ b/helm-org.el
@@ -273,6 +273,61 @@ current heading."
         :truncate-lines helm-org-truncate-lines
         :buffer "*helm org capture templates*"))
 
+;;; Org tag completion
+
+;; Based on code from Anders Johansson posted on 3 Mar 2016 at
+;; <https://groups.google.com/d/msg/emacs-helm/tA6cn6TUdRY/G1S3TIdzBwAJ>
+
+(defun helm-org-completing-read-tags (prompt coll pred req initial hist def inh)
+  (let* ((initial (and (stringp initial)
+                       (not (string= initial ""))
+                       initial))
+         (curr (when initial
+                 (org-split-string initial ":")))
+         (table (org-uniquify (mapcar 'car org-last-tags-completion-table)))
+         (table (if curr
+                    ;; Remove current tags from list
+                    (cl-delete-if (lambda (x)
+                                    (member x curr))
+                                  table)
+                  table))
+         (prompt (if initial
+                     (concat "Tags " initial)
+                   prompt)))
+    (concat initial
+            (mapconcat 'identity
+                       (nreverse (helm-org-completing-read-multiple
+                                  prompt table pred nil nil hist def
+                                  t "Org tags" "*Helm org tags*" ":"))
+                       ":"))))
+
+(defun helm-org-completing-read-multiple (prompt choices
+                                                 &optional predicate require-match initial-input hist def
+                                                 inherit-input-method name buffer sentinel)
+  "Read multiple items with `helm-completing-read-default-1'. Reading stops
+when the user enters SENTINEL. By default, SENTINEL is
+\"*done*\". SENTINEL is disambiguated with clashing completions
+by appending _ to SENTINEL until it becomes unique. So if there
+are multiple values that look like SENTINEL, the one with the
+most _ at the end is the actual sentinel value. See
+documentation for `ido-completing-read' for details on the
+other parameters."
+  (let ((sentinel (or sentinel "*done*"))
+        this-choice res done-reading)
+    ;; Uniquify the SENTINEL value
+    (while (cl-find sentinel choices)
+      (setq sentinel (concat sentinel "_")))
+    (setq choices (cons sentinel choices))
+    ;; Read some choices
+    (while (not done-reading)
+      (setq this-choice (helm-completing-read-default-1 prompt choices
+                                                        predicate require-match initial-input hist def
+                                                        inherit-input-method name buffer nil t))
+      (if (equal this-choice sentinel)
+          (setq done-reading t)
+        (setq res (cons this-choice res))
+        (setq prompt (concat prompt this-choice ":"))))
+    res))
 
 (provide 'helm-org)
 

--- a/helm-org.el
+++ b/helm-org.el
@@ -278,7 +278,10 @@ current heading."
 ;; Based on code from Anders Johansson posted on 3 Mar 2016 at
 ;; <https://groups.google.com/d/msg/emacs-helm/tA6cn6TUdRY/G1S3TIdzBwAJ>
 
-(defun helm-org-completing-read-tags (prompt coll pred req initial hist def inh)
+;; FIXME: This function fails with a "Wrong number of arguments" error
+;; if its name starts with "helm"?!  If its name starts with anything
+;; else, it works fine!
+(defun not-helm-org-completing-read-tags (prompt coll pred req initial hist def inh)
   (let* ((initial (and (stringp initial)
                        (not (string= initial ""))
                        initial))

--- a/helm-org.el
+++ b/helm-org.el
@@ -282,27 +282,36 @@ current heading."
 ;; if its name starts with "helm"?!  If its name starts with anything
 ;; else, it works fine!
 (defun not-helm-org-completing-read-tags (prompt coll pred req initial hist def inh)
-  (let* ((initial (and (stringp initial)
-                       (not (string= initial ""))
-                       initial))
-         (curr (when initial
-                 (org-split-string initial ":")))
-         (table (org-uniquify (mapcar 'car org-last-tags-completion-table)))
-         (table (if curr
-                    ;; Remove current tags from list
-                    (cl-delete-if (lambda (x)
-                                    (member x curr))
-                                  table)
-                  table))
-         (prompt (if initial
-                     (concat "Tags " initial)
-                   prompt)))
-    (concat initial
-            (mapconcat 'identity
-                       (nreverse (helm-org-completing-read-multiple
-                                  prompt table pred nil nil hist def
-                                  t "Org tags" "*Helm org tags*" ":"))
-                       ":"))))
+  (if (not (string= "Tags: " prompt))
+      ;; Not a tags prompt.  Use normal completion by calling
+      ;; `org-icompleting-read' again without this function in
+      ;; `helm-completing-read-handlers-alist'
+      (let ((helm-completing-read-handlers-alist (rassq-delete-all
+                                                  'not-helm-org-completing-read-tags
+                                                  helm-completing-read-handlers-alist)))
+        (org-icompleting-read prompt coll pred req initial hist def inh))
+    ;; Tags prompt
+    (let* ((initial (and (stringp initial)
+                         (not (string= initial ""))
+                         initial))
+           (curr (when initial
+                   (org-split-string initial ":")))
+           (table (org-uniquify
+                   (mapcar 'car org-last-tags-completion-table)))
+           (table (if curr
+                      ;; Remove current tags from list
+                      (cl-delete-if (lambda (x)
+                                      (member x curr))
+                                    table)
+                    table))
+           (prompt (if initial
+                       (concat "Tags " initial)
+                     prompt)))
+      (concat initial (mapconcat 'identity
+                                 (nreverse (helm-org-completing-read-multiple
+                                            prompt table pred nil nil hist def
+                                            t "Org tags" "*Helm org tags*" ":"))
+                                 ":")))))
 
 (defun helm-org-completing-read-multiple (prompt choices
                                                  &optional predicate require-match initial-input hist def


### PR DESCRIPTION
Thanks to [Anders Johansson](https://groups.google.com/d/msg/emacs-helm/tA6cn6TUdRY/G1S3TIdzBwAJ), here's a fix for Org tag completion in Helm.  It allows completion of multiple tags, whereas the current code only allows completing one tag at a time, requiring multiple invocations of `org-set-tags-command` (`C-c C-q`).  I have been wanting to fix this for years, but Mr. Johansson here finally figured it out for us.  :)

Now, you can press `C-c C-q`, begin typing a tag, hit `RET`, then begin typing another tag, hit `RET`, then hit `RET` again, and both tags will be set on the current heading.

However, while preparing this for Helm upstream, I came across a very strange problem: when the new function used in `helm-completing-read-handlers-alist` is called, it fails with an error saying, `apply: Wrong number of arguments...`.  I nearly pulled my hair out trying to understand it, and then I happened upon the strangest workaround: if the function's name begins with `helm`, it fails, but if it starts with anything else, it works fine.  (The function originally started with `aj/`, and I removed that prefix.)  I'm afraid my elisp-fu is too weak to figure this out.

The first commit has the bug, while the second and third commits in this pull request work properly but have the function renamed to `not-helm-org-completing-read-tags`.

Thanks for your help.