### PR TITLE
Add :actions keyword to helm-comp-read and use it in helm-M-x (#1448).

### DIFF
--- a/helm-command.el
+++ b/helm-command.el
@@ -213,6 +213,10 @@ than the default which is OBARRAY."
                 :must-match t
                 :fuzzy helm-M-x-fuzzy-match
                 :nomark t
+                :actions (helm-make-actions
+                          "Execute command" 'identity
+                          "Switch to apropos" (lambda (candidate)
+                                                (helm-apropos candidate)))
                 :candidates-in-buffer t
                 :fc-transformer 'helm-M-x-transformer
                 :hist-fc-transformer 'helm-M-x-transformer-hist))

--- a/helm-elisp.el
+++ b/helm-elisp.el
@@ -680,7 +680,7 @@ Filename completion happen if string start after or between a double quote."
                     (funcall func default))
                   helm-apropos-function-list)
           :buffer "*helm apropos*"
-          :preselect (and default (concat "\\_<" (regexp-quote default) "\\_>")))))
+          :preselect (and default (concat "\\_<" (regexp-quote default) "\\_>"))))
 
 
 ;;; Advices

--- a/helm-elisp.el
+++ b/helm-elisp.el
@@ -672,10 +672,9 @@ Filename completion happen if string start after or between a double quote."
     (helm-attrset 'help-current-symbol candidate)))
 
 ;;;###autoload
-(defun helm-apropos ()
+(defun helm-apropos (default)
   "Preconfigured helm to describe commands, functions, variables and faces."
-  (interactive)
-  (let ((default (thing-at-point 'symbol)))
+  (interactive (list (thing-at-point 'symbol)))
     (helm :sources
           (mapcar (lambda (func)
                     (funcall func default))

--- a/helm-elisp.el
+++ b/helm-elisp.el
@@ -673,7 +673,9 @@ Filename completion happen if string start after or between a double quote."
 
 ;;;###autoload
 (defun helm-apropos (default)
-  "Preconfigured helm to describe commands, functions, variables and faces."
+  "Preconfigured helm to describe commands, functions, variables and faces.
+In non interactives calls DEFAULT argument should be provided as a string,
+i.e the `symbol-name' of any existing symbol."
   (interactive (list (thing-at-point 'symbol)))
     (helm :sources
           (mapcar (lambda (func)

--- a/helm-help.el
+++ b/helm-help.el
@@ -596,7 +596,11 @@ than 1 megabyte:
 
 *** You can save your results in a `helm-grep-mode' buffer, see commands below
 
-Once in this buffer you can use emacs-wgrep to edit your changes.
+Once in this buffer you can use emacs-wgrep (external package not bundled with helm)
+to edit your changes.
+
+*** Helm grep is supporting multi matching starting from version 1.9.4.
+Just add a space between each pattern like in most helm commands.
 
 *** Important
 

--- a/helm-mode.el
+++ b/helm-mode.el
@@ -391,6 +391,11 @@ Keys description:
   `helm-source-in-buffer' which is much faster.
   Argument VOLATILE have no effect when CANDIDATES-IN-BUFFER is non--nil.
 
+- ACTIONS: An alist of actions (see meaning of :action in `helm-source')
+  or a single function defining an action and taking one arg candidate.
+  The best way to provide actions is to use `helm-make-actions' function.
+  If not provided, default action will be 'identity.
+
 Any prefix args passed during `helm-comp-read' invocation will be recorded
 in `helm-current-prefix-arg', otherwise if prefix args were given before
 `helm-comp-read' invocation, the value of `current-prefix-arg' will be used.

--- a/helm-mode.el
+++ b/helm-mode.el
@@ -305,7 +305,8 @@ If COLLECTION is an `obarray', a TEST should be needed. See `obarray'."
                             marked-candidates
                             nomark
                             (alistp t)
-                            (candidate-number-limit helm-candidate-number-limit))
+                            (candidate-number-limit helm-candidate-number-limit)
+                            actions)
   "Read a string in the minibuffer, with helm completion.
 
 It is helm `completing-read' equivalent.
@@ -398,11 +399,12 @@ that use `helm-comp-read' See `helm-M-x' for example."
 
   (when (get-buffer helm-action-buffer)
     (kill-buffer helm-action-buffer))
-  (let ((action-fn `(("Sole action (Identity)"
-                      . (lambda (candidate)
-                          (if ,marked-candidates
-                              (helm-marked-candidates)
-                            (identity candidate)))))))
+  (let ((action-fn (or actions
+                       `(("Sole action (Identity)"
+                          . (lambda (candidate)
+                              (if ,marked-candidates
+                                  (helm-marked-candidates)
+                                  (identity candidate))))))))
     ;; Assume completion have been already required,
     ;; so always use 'confirm.
     (when (eq must-match 'confirm-after-completion)


### PR DESCRIPTION
* helm-command.el (helm-M-x-read-extended-command): Add actions with new keyword.
* helm-elisp.el (helm-apropos): Allow passing default arg for non--interactive calls.
* helm-mode.el (helm-comp-read): Add actions keyword.