### PR TITLE
Fix #1451 by storing external commands with paths.

### DIFF
--- a/helm-external.el
+++ b/helm-external.el
@@ -24,7 +24,7 @@
 
 
 (defgroup helm-external nil
-  "External related Applications and libraries for Helm." 
+  "External related Applications and libraries for Helm."
   :group 'helm)
 
 (defcustom helm-raise-command nil
@@ -54,89 +54,88 @@ Windows users should set that to \"explorer.exe\"."
 
 ;;; Internals
 (defvar helm-external-command-history nil)
+
 (defvar helm-external-commands-list nil
-  "A list of all external commands the user can execute.
+  "A list of all user-executable external commands.
 If this variable is not set by the user, it will be calculated
 automatically.")
 
 (defun helm-external-commands-list-1 (&optional sort)
-  "Returns a list of all external commands the user can execute.
-If `helm-external-commands-list' is non-nil it will
-return its contents.  Else it calculates all external commands
-and sets `helm-external-commands-list'."
+  "Return a list of all user-executable external commands.
+Commands are path-qualified, e.g. \"/usr/bin/xdg-open\".
+
+If `helm-external-commands-list' is non-nil, use its values.
+Else, find all external commands in the user's path and set
+`helm-external-commands-list'."
   (helm-aif helm-external-commands-list
       it
     (setq helm-external-commands-list
-          (cl-loop
-                for dir in (split-string (getenv "PATH") path-separator)
-                when (and (file-exists-p dir) (file-accessible-directory-p dir))
-                for lsdir = (cl-loop for i in (directory-files dir t)
-                                  for bn = (file-name-nondirectory i)
-                                  when (and (not (member bn completions))
-                                            (not (file-directory-p i))
-                                            (file-executable-p i))
-                                  collect bn)
-                append lsdir into completions
-                finally return
-                (if sort (sort completions 'string-lessp) completions)))))
+          (cl-loop for dir in (parse-colon-path (getenv "PATH"))
+                   when (file-accessible-directory-p dir)
+                   for lsdir = (cl-loop for i in (directory-files dir t)
+                                        when (and (not (file-directory-p i))
+                                                  (file-executable-p i)
+                                                  (not (member i completions)))
+                                        collect i)
+                   append lsdir into completions
+                   finally return
+                   (if sort (sort completions 'string-lessp) completions)))))
 
 (defun helm-run-or-raise (exe &optional file)
-  "Generic command that run asynchronously EXE.
-If EXE is already running just jump to his window if `helm-raise-command'
-is non--nil.
-When FILE argument is provided run EXE with FILE.
-In this case EXE must be provided as \"EXE %s\"."
-  (let* ((real-com (car (split-string (replace-regexp-in-string
-                                       "%s" "" exe))))
-         (proc     (if file (concat real-com " " file) real-com))
+  "Run command EXE asynchronously.
+
+If EXE is already running and `helm-raise-command' is non-nil,
+jump to the process window.
+
+If FILE is provided, run EXE with FILE as \"EXE FILE\"."
+  (let* ((proc     (if file (concat exe " " file) exe))
          process-connection-type)
     (if (get-process proc)
         (if helm-raise-command
-            (shell-command  (format helm-raise-command real-com))
-          (error "Error: %s is already running" real-com))
-      (when (cl-loop for i in helm-external-commands-list thereis (string= real-com i))
-        (message "Starting %s..." real-com)
-        (if file
-            (start-process-shell-command
-             proc nil (format exe (shell-quote-argument
-                                   (if (eq system-type 'windows-nt)
-                                       (helm-w32-prepare-filename file)
-                                     file))))
-          (start-process-shell-command proc nil real-com))
-        (set-process-sentinel
-         (get-process proc)
-         (lambda (process event)
-             (when (and (string= event "finished\n")
-                        helm-raise-command
-                        (not (helm-get-pid-from-process-name real-com)))
-               (shell-command  (format helm-raise-command "emacs")))
-             (message "%s process...Finished." process))))
+            (shell-command  (format helm-raise-command exe))
+          (error "Error: %s is already running" exe))
+      (message "Starting %s..." exe)
+      (if file
+          (start-process-shell-command
+           proc nil (concat exe " " (shell-quote-argument
+                                     (if (eq system-type 'windows-nt)
+                                         (helm-w32-prepare-filename file)
+                                       file))))
+        (start-process-shell-command proc nil exe))
+      (set-process-sentinel
+       (get-process proc)
+       (lambda (process event)
+         (when (and (string= event "finished\n")
+                    helm-raise-command
+                    (not (helm-get-pid-from-process-name exe)))
+           (shell-command  (format helm-raise-command "emacs")))
+         (message "%s process...Finished." process)))
       (setq helm-external-commands-list
-            (cons real-com
-                  (delete real-com helm-external-commands-list))))))
+            (cons exe (delete exe helm-external-commands-list))))))
 
 (defun helm-get-mailcap-for-file (filename)
-  "Get the command to use for FILENAME from mailcap files.
-The command is like <command %s> and is meant to use with `format'."
+  "Get the command to use for FILENAME from mailcap files."
   (mailcap-parse-mailcaps)
   (let* ((ext  (file-name-extension filename))
          (mime (when ext (mailcap-extension-to-mime ext)))
          (result (when mime (mailcap-mime-info mime))))
     ;; If elisp file have no associations in .mailcap
     ;; `mailcap-maybe-eval' is returned, in this case just return nil.
-    (when (stringp result) result)))
+    (when (stringp result)
+      (replace-regexp-in-string "\\s-%s" "" result))))
 
 (defun helm-get-default-program-for-file (filename)
-  "Try to find a default program to open FILENAME.
-Try first in `helm-external-programs-associations' and then in mailcap file
-if nothing found return nil."
+  "Return default program to open FILENAME, or nil if none.
+
+Look for command first in `helm-external-programs-associations',
+then in mailcap file."
   (let* ((ext      (file-name-extension filename))
          (def-prog (assoc-default ext helm-external-programs-associations)))
     (cond ((and def-prog (not (string= def-prog "")))
-           (concat def-prog " %s"))
+           def-prog)
           ((and helm-default-external-file-browser
                 (file-directory-p filename))
-           (concat helm-default-external-file-browser " %s"))
+           helm-default-external-file-browser)
           (t (helm-get-mailcap-for-file filename)))))
 
 (defun helm-open-file-externally (file)
@@ -145,8 +144,8 @@ Try to guess which program to use with `helm-get-default-program-for-file'.
 If not found or a prefix arg is given query the user which tool to use."
   (let* ((fname          (expand-file-name file))
          (collection     (helm-external-commands-list-1 'sort))
-         (def-prog       (helm-get-default-program-for-file fname))
-         (real-prog-name (if (or helm-current-prefix-arg (not def-prog))
+         (default-program       (helm-get-default-program-for-file fname))
+         (program (if (or helm-current-prefix-arg (not default-program))
                              ;; Prefix arg or no default program.
                              (prog1
                                  (helm-comp-read
@@ -156,32 +155,31 @@ If not found or a prefix arg is given query the user which tool to use."
                                   :del-input nil
                                   :history helm-external-command-history)
                                ;; Always prompt to set this program as default.
-                               (setq def-prog nil))
+                               (setq default-program nil))
                            ;; No prefix arg or default program exists.
-                           (replace-regexp-in-string " %s\\| '%s'" "" def-prog)))
-         (program        (concat real-prog-name " %s")))
-    (unless (or def-prog ; Association exists, no need to record it.
+                           default-program)))
+    (unless (or default-program ; Association exists, no need to record it.
                 ;; Don't try to record non--filenames associations (e.g urls).
                 (not (file-exists-p fname)))
       (when
           (y-or-n-p
            (format
             "Do you want to make `%s' the default program for this kind of files? "
-            real-prog-name))
+            program))
         (helm-aif (assoc (file-name-extension fname)
                          helm-external-programs-associations)
             (setq helm-external-programs-associations
                   (delete it helm-external-programs-associations)))
         (push (cons (file-name-extension fname)
                     (helm-read-string
-                     "Program (Add args maybe and confirm): " real-prog-name))
+                     "Program (Add args maybe and confirm): " program))
               helm-external-programs-associations)
         (customize-save-variable 'helm-external-programs-associations
                                  helm-external-programs-associations)))
     (helm-run-or-raise program file)
     (setq helm-external-command-history
-          (cons real-prog-name
-                (delete real-prog-name
+          (cons program
+                (delete program
                         (cl-loop for i in helm-external-command-history
                               when (executable-find i) collect i))))))
 
@@ -194,11 +192,13 @@ You can set your own list of commands with
   (interactive (list
                 (helm-comp-read
                  "RunProgram: "
-                 (helm-external-commands-list-1 'sort)
+                 (delete-dups (mapcar #'file-name-nondirectory
+                                      (helm-external-commands-list-1 'sort)))
                  :must-match t
                  :del-input nil
                  :name "External Commands"
-                 :history helm-external-command-history)))
+                 :history (mapcar #'file-name-nondirectory
+                                  helm-external-command-history))))
   (helm-run-or-raise program)
   (setq helm-external-command-history
         (cons program (delete program


### PR DESCRIPTION
Now, it no longer requires two attempts to open a file of a particular
type externally.

`helm-external-commands-list` now stores commands with fully qualified
paths (e.g. `/usr/bin/xdg-open` instead of `xdg-open`). The only
exception to this is user-invoked commands (through interactive
`helm-run-external-command`). For a good user experience, we should not
qualify the commands the user sees with paths.

Various functions (e.g. `helm-run-and-raise`) no longer require the
command to be a format string (e.g. `/usr/bin/xdg-open %s`). They now
take the command by itself (e.g. `/usr/bin/xdg-open`). This eliminates
several repetitive calls to `replace-regexp-in-string`. This should not
cause any problems, because we were already assuming that the commands
are in the form `COMMAND %s`.