### PR TITLE
Remove deprecated usage of delayed source (#1400 #1454).

### DIFF
--- a/helm-help.el
+++ b/helm-help.el
@@ -1214,12 +1214,6 @@ HELM-ATTRIBUTE should be a symbol."
 
   It is useful to change interpretation of `helm-pattern'.")
 
-(helm-document-attribute 'delayed "optional"
-  "  Candidates from the source are shown only if the user stops
-  typing and is idle for `helm-idle-delay' seconds.
-  If a value is given to delayed attr, this value is used instead only
-  if it is > to `helm-idle-delay'.")
-
 (helm-document-attribute 'volatile "optional"
   "  Indicates the source assembles the candidate list dynamically,
   so it shouldn't be cached within a single Helm

--- a/helm-source.el
+++ b/helm-source.el
@@ -526,7 +526,15 @@
 
   Should be a variable.
   Can be also an anonymous function or a list of functions
-  directly added to slot, this is not recommended though."))
+  directly added to slot, this is not recommended though.")
+
+   (delayed
+    :initarg :delayed
+    :initform nil
+    :custom (choice null integer)
+    :documentation
+    "  This slot have no more effect and is just kept for backward compatibility.
+  Please don't use it."))
 
   "Main interface to define helm sources."
   :abstract t)
@@ -863,6 +871,9 @@ an eieio class."
 (defmethod helm--setup-source :primary ((_source helm-source)))
 
 (defmethod helm--setup-source :before ((source helm-source))
+  (when (slot-value source 'delayed)
+    (warn "Deprecated usage of helm `delayed' slot in `%s'"
+          (slot-value source 'name)))
   (helm-aif (slot-value source 'keymap)
       (and (symbolp it) (set-slot-value source 'keymap (symbol-value it))))
   (helm-aif (slot-value source 'persistent-help)

--- a/helm-source.el
+++ b/helm-source.el
@@ -124,16 +124,6 @@
 
   Note that the function is executed BEFORE performing action.")
 
-   (delayed
-    :initarg :delayed
-    :initform nil
-    :custom (choice null integer)
-    :documentation
-    "  Candidates from the source are shown only if the user stops
-  typing and is idle for `helm-idle-delay' seconds.
-  If a value is given to delayed attr, this value is used instead only
-  if it is > to `helm-idle-delay'.")
-
    (keymap
     :initarg :keymap
     :initform nil

--- a/helm.el
+++ b/helm.el
@@ -3244,6 +3244,10 @@ not on current source."
                      collect source into sources
                      ;; Export the variables from cl-loop
                      finally (setq all-sources sources))
+            ;; When no normal-sources erase buffer
+            ;; for the already computed normal-source
+            ;; that is no more "updatable" (requires-pattern).
+            (unless all-sources (erase-buffer))
             ;; Compute matches without rendering the sources.
             (helm-log "Matches: %S"
                       (setq matches (helm--collect-matches all-sources)))

--- a/helm.el
+++ b/helm.el
@@ -3239,9 +3239,9 @@ not on current source."
       (unwind-protect
           (progn
             ;; Iterate over all the sources
-            (cl-loop for source in
+            (cl-loop for src in
                      (cl-remove-if-not 'helm-update-source-p (helm-get-sources))
-                     collect source into sources
+                     collect src into sources
                      ;; Export the variables from cl-loop
                      finally (setq all-sources sources))
             ;; When no normal-sources erase buffer


### PR DESCRIPTION
* helm-help.el: Remove delayed doc.
* helm-source.el (helm-source): Remove delayed slot.
* helm.el (helm-idle-delay): Removed.
(helm-quick-update): Removed.
(helm-read-pattern-maybe): Get rid of delayed sources.
(helm-exit-or-quit-maybe): Removed.
(helm-check-new-input): No need to handle helm--maybe-use-default-as-input
for delayed.
(helm-process-delayed-sources): Removed.
(helm-update): Get rid of delayed sources.
(helm-delayed-source-p): Removed.
(helm-force-update): Stop handling quick-update.