### PR TITLE
Overhaul helm-fuzzy-default-highlight-match.

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -3092,7 +3092,7 @@ Returns non-nil if all PATTERNS were found at least once."
 
        ;; Otherwise, highlight occurrences of each character, in that order.
        ;; We assume that helm-pattern is not a regex in this case.
-       ((funcall matcher (mapcar 'rx-form (split-string helm-pattern "" t)))))
+       ((funcall matcher (mapcar 'regexp-quote (split-string helm-pattern "" t)))))
 
       (setq display (concat mp-prefix (buffer-string) mp-suffix)))
     (if real (cons display real) display)))

--- a/helm.el
+++ b/helm.el
@@ -3092,7 +3092,7 @@ Returns non-nil if all PATTERNS were found at least once."
 
        ;; Otherwise, highlight occurrences of each character, in that order.
        ;; We assume that helm-pattern is not a regex in this case.
-       ((funcall matcher (mapc 'rx-form (split-string helm-pattern "" t)))))
+       ((funcall matcher (mapcar 'rx-form (split-string helm-pattern "" t)))))
 
       (setq display (concat mp-prefix (buffer-string) mp-suffix)))
     (if real (cons display real) display)))

--- a/helm.el
+++ b/helm.el
@@ -3034,7 +3034,7 @@ Returns non-nil if all PATTERNS were found at least once."
                 ((regexps (mapcar       ; Patterns converted to regexps
                            (lambda (p)
                              (or (and helm-migemo-mode
-                                      (assoc
+                                      (assoc-default
                                        p helm-mm--previous-migemo-info))
                                  p))
                            patterns))


### PR DESCRIPTION
This is a revision of the `helm-fuzzy-default-highlight-match` function, with the following fixes:

- Highlights all matches, not just the first.
- Fixes sources' `match-part` property being ignored when falling back to multi-word or per-character highlighting.
- Fixes interpreting individual characters as individual regular expressions when falling back to per-character highlighting.
- Adds comments.

Screenshot:
![](http://dump.thecybershadow.net/ff1eb528effd2eae16880f4946bad62c/Spectacle.nS7128.png)

Note that because of the `match-part` fix, a visual "regression" is introduced:
![](http://dump.thecybershadow.net/fcd0447186c6bcbcb725f03fd9a2e8c6/Spectacle.TJ7172.png)

This is because the sources return a `match-part` that does not match the part of the string they actually match. Of course, it does not affect the result list, only highlighting. Still, I think it is an improvement, especially if `match-part` will be fixed accordingly. Ideally, though, I think that the highlighting should be done by the source itself, and the `match-part` property deprecated / removed.

I am relatively new to Emacs and unfamiliar with Helm internals, so please let me know if there is something that can be improved in this PR, and I will revise it.