### PR TITLE
Make sure pass a string to kill-new

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -5357,6 +5357,8 @@ With a prefix arg set to real value of current selection."
   (interactive "P")
   (with-helm-alive-p
     (let ((str (helm-get-selection nil (not arg))))
+      (when str
+        (setq str (format "%s" str)))
       (kill-new str)
       (helm-set-pattern str))))
 (put 'helm-yank-selection 'helm-only t)
@@ -5370,7 +5372,9 @@ is used to perform actions."
   (with-helm-alive-p
     (helm-run-after-exit
      (lambda (sel)
-       (kill-new (format "%s" sel))
+       (when sel
+         (setq sel (format "%s" sel)))
+       (kill-new sel)
        ;; Return nil to force `helm-mode--keyboard-quit'
        ;; in `helm-comp-read' otherwise the value "Saved to kill-ring: foo"
        ;; is used as exit value for `helm-comp-read'.

--- a/helm.el
+++ b/helm.el
@@ -5370,7 +5370,7 @@ is used to perform actions."
   (with-helm-alive-p
     (helm-run-after-exit
      (lambda (sel)
-       (kill-new sel)
+       (kill-new (format "%s" sel))
        ;; Return nil to force `helm-mode--keyboard-quit'
        ;; in `helm-comp-read' otherwise the value "Saved to kill-ring: foo"
        ;; is used as exit value for `helm-comp-read'.


### PR DESCRIPTION
In buffer source, C-u C-c C-k ('helm-kill-selection-and-quit') raises a
wrong-type-argument error because the real value of candidate is not a
string.  To fix this, (format "%s" ...) is used to convert any kind of
value into a string (its printed representation).