### PR TITLE
Introduce same feature as "cp --backup=numbered from to".

### DIFF
--- a/helm-files.el
+++ b/helm-files.el
@@ -54,6 +54,7 @@
 
 (defvar recentf-list)
 (defvar helm-mm-matching-method)
+(defvar dired-async-mode)
 
 
 (defgroup helm-files nil
@@ -2620,7 +2621,6 @@ Find inside `require' and `declare-function' sexp."
              when (eq (car (file-attributes cd)) t)
              return cd)))
 
-(defvar dired-async-mode)
 (cl-defun helm-dired-action (candidate
                              &key action follow (files (dired-get-marked-files)))
   "Execute ACTION on FILES to CANDIDATE.

--- a/helm-files.el
+++ b/helm-files.el
@@ -477,6 +477,7 @@ Don't set it directly, use instead `helm-ff-auto-update-initial-value'.")
    "Delete File(s) `M-D'" 'helm-delete-marked-files
    "Copy file(s) `M-C, C-u to follow'" 'helm-find-files-copy
    "Rename file(s) `M-R, C-u to follow'" 'helm-find-files-rename
+   "Backup files" 'helm-find-files-backup
    "Symlink files(s) `M-S, C-u to follow'" 'helm-find-files-symlink
    "Relsymlink file(s) `C-u to follow'" 'helm-find-files-relsymlink
    "Hardlink file(s) `M-H, C-u to follow'" 'helm-find-files-hardlink
@@ -2226,8 +2227,6 @@ Return candidates prefixed with basename of `helm-input' first."
              (eq major-mode 'message-mode))
            (append actions
                    '(("Gnus attach file(s)" . helm-ff-gnus-attach-files))))
-          ((string-match-p "\\`[*]\\{2\\}\\.[a-z]+\\'" (helm-basename candidate))
-           (helm-append-at-nth actions '(("Backup files" . helm-find-files-backup)) 4))
           ((save-match-data
              (and ffap-url-regexp
                   (not (string-match-p ffap-url-regexp str-at-point))


### PR DESCRIPTION
* helm-files.el (helm-find-files-backup): New action.
(helm-find-files-action-transformer): Add it to actions when
using helm-file-globstar and basename is a recursive wildcard.
(helm-dired-action): Add backup action.