### PR TITLE
Support truncated index lines in info manuals

### DIFF
--- a/helm-info.el
+++ b/helm-info.el
@@ -64,11 +64,12 @@ files with `helm-info-at-point'."
           (goto-char (point-min))
           (while (search-forward "\n* " nil t)
             (unless (search-forward "Menu:\n" (1+ (point-at-eol)) t)
-              (setq start (point-at-bol)
-                    end (point-at-eol))
-              (with-current-buffer tobuf
-                (insert-buffer-substring infobuf start end)
-                (insert "\n")))))))))
+              (let ((info-index (buffer-substring
+                                 (point-at-bol)
+                                 (point-max))))
+                (with-current-buffer tobuf
+                  (insert (replace-regexp-in-string "\n   " " " info-index) )))
+              (goto-char (point-max)))))))))
 
 (defun helm-info-goto (node-line)
   (Info-goto-node (car node-line))


### PR DESCRIPTION
Issue: selecting certain lines in helm-info-* takes us to the top of the info node but not to the actual selected item .

Cause: long lines in info index are truncated in info file (as per attached screenshot) and `helm-info-init` only insert lines starting with '* '. (line numbers are propertize with invisible in emacs.)

![2016-05-16-18 32 04_1085x151 9 739](https://cloud.githubusercontent.com/assets/3791334/15292743/9979e3fc-1b95-11e6-91f9-84e8b9ecf3b9.png)

Fix: I propose the attached patch. I do not see any case where another two `* Menu:` would be in the same info file index so I insert the whole index at once. let me know if thats not the case.