### PR TITLE
Don't append space if input is empty

### DIFF
--- a/helm-mode.el
+++ b/helm-mode.el
@@ -1076,7 +1076,8 @@ Can be used as value for `completion-in-region-function'."
                                 (setcdr last-data nil))
                             0))
                (init-space-suffix (unless (or helm-completion-in-region-fuzzy-match
-                                              (string-suffix-p " " input))
+                                              (string-suffix-p " " input)
+                                              (string= input ""))
                                     " "))
                (file-comp-p (or (eq (completion-metadata-get metadata 'category) 'file)
                                 (helm-mode--in-file-completion-p)
@@ -1115,8 +1116,7 @@ Can be used as value for `completion-in-region-function'."
                           (cond ((and file-comp-p
                                       (not (string-match "/\\'" input)))
                                  (concat (helm-basename input)
-                                         (unless (string= input "")
-                                           init-space-suffix)))
+                                         init-space-suffix))
                                 ((string-match "/\\'" input) nil)
                                 ((or (null require-match)
                                      (stringp require-match))


### PR DESCRIPTION
There are some candidates but `helm--completion-in-region` says `No matches` if input string is empty.

#### Original code
![orig](https://cloud.githubusercontent.com/assets/554281/15985316/d719da76-3023-11e6-9d00-30e09187fe8e.gif)


#### Fixed version
![fixed](https://cloud.githubusercontent.com/assets/554281/15985317/dacbab90-3023-11e6-9323-ac6951ff7f8d.gif)

See also
- https://github.com/syohex/emacs-helm-robe/issues/2

