### PR TITLE
Make helm-resume honor helm-full-frame

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -1954,7 +1954,7 @@ Call with a prefix arg to choose among existing helm
 buffers (sessions). When calling from lisp, specify a buffer-name
 as a string with ARG."
   (interactive "P")
-  (let (any-buffer helm-full-frame cur-dir)
+  (let (any-buffer cur-dir (helm-full-frame helm-full-frame))
     (if arg
         (if (and (stringp arg) (bufferp (get-buffer arg)))
             (setq any-buffer arg)


### PR DESCRIPTION
Currently, under `helm-resume`, when there is no buffer-local value of `helm-full-frame`, the value `nil` is used rather than the global value of `helm-full-frame`. This PR changes that.

##### Testing
I've tested this manually by setting `helm-full-frame` to `t` globally and confirming that on this branch the resume buffer is in a full frame window.