### PR TITLE
helm-do-grep-ag: search for text at the cursor position

### DIFF
--- a/helm-grep.el
+++ b/helm-grep.el
@@ -1101,7 +1101,7 @@ in recurse, and ignore EXTS, search being made recursively on files matching
                                (> (- (setq end (match-end 0))
                                      (setq beg (match-beginning 0))) 0))
                      (helm-add-face-text-properties beg end 'helm-grep-match))
-                   do (goto-char (point-min))) 
+                   do (goto-char (point-min)))
           (buffer-string))
       (error nil))))
 
@@ -1364,6 +1364,9 @@ if available with current AG version."
           :candidates-process
           (lambda () (helm-grep-ag-init directory type))))
   (helm :sources 'helm-source-grep-ag
+        :input (if (region-active-p)
+                   (buffer-substring-no-properties (region-beginning) (region-end))
+                 (thing-at-point 'symbol))
         :keymap helm-grep-map
         :truncate-lines helm-grep-truncate-lines
         :buffer (format "*helm %s*" (helm-grep--ag-command))))


### PR DESCRIPTION
Hello,

I did a small improvement over the function `helm-do-grep-ag` that allows automatically inserting the text around the cursor or in the active region as an input of this function. This feature is quite common in some `helm` related functions, for example, `helm-occur`, `helm-projectile-grep`, but has not been updated to `helm-do-grep-ag`. 

So I think that it could be useful, and in some sense more consistent, to have it implemented in `helm-do-grep-ag`.

How do you think about it? Please check if there is something can be improved about it?

Bests,
Trung.