### PR TITLE
Expand default-directory in helm-do-grep-ag.

### DIFF
--- a/helm-grep.el
+++ b/helm-grep.el
@@ -1424,7 +1424,7 @@ arg INPUT is what you will have by default at prompt on startup."
 With prefix-arg prompt for type if available with your AG version."
   (interactive "P")
   (require 'helm-files)
-  (helm-grep-ag default-directory arg))
+  (helm-grep-ag (expand-file-name default-directory) arg))
 
 ;;;###autoload
 (defun helm-grep-do-git-grep (arg)


### PR DESCRIPTION
If the `default-directory` has a "~" in it, it will be escaped later with `shell-quote-argument` in `helm-grep-ag-prepare-cmd-line`. This causes issues trying to use `helm-do-grep-ag` in the home directory.