### PR TITLE
First attempt to fix tramp multi hops (#1598, #981).

### DIFF
--- a/helm-files.el
+++ b/helm-files.el
@@ -1716,23 +1716,23 @@ purpose."
 
 (defun helm-ff-tramp-postfixed-p (str methods)
   (let (result)
-    (with-temp-buffer
-      (save-excursion (insert str))
-      (helm-awhile (search-forward ":" nil t)
-        (if (save-excursion
-              (forward-char -1)
-              (looking-back (mapconcat 'identity methods "\\|")
-                            (point-at-bol)))
-            (setq result nil)
-            (setq result it))))
+    (save-match-data
+      (with-temp-buffer
+        (save-excursion (insert str))
+        (helm-awhile (search-forward ":" nil t)
+          (if (save-excursion
+                (forward-char -1)
+                (looking-back (mapconcat 'identity methods "\\|")
+                              (point-at-bol)))
+              (setq result nil)
+              (setq result it)))))
     result))
 
 (defun helm-ff-set-pattern (pattern)
   "Handle tramp filenames in `helm-pattern'."
   (let* ((methods (mapcar 'car tramp-methods))
-         (postfixed (save-match-data
-                      ;; Returns the position of last ":".
-                      (helm-ff-tramp-postfixed-p pattern methods)))
+         ;; Returns the position of last ":" entered.
+         (postfixed (helm-ff-tramp-postfixed-p pattern methods))
          (reg "\\`/\\([^[/:]+\\|[^/]+]\\):.*:")
          cur-method tramp-name)
     ;; In some rare cases tramp can return a nil input,

--- a/helm-files.el
+++ b/helm-files.el
@@ -1768,13 +1768,12 @@ purpose."
                              (match-string 0 pattern)))
            (replace-match tramp-name nil t pattern))
           ;; Match "/hostname:"
-          ((and (string-match  helm-tramp-file-name-regexp pattern)
+          ((and (string-match helm-tramp-file-name-regexp pattern)
                 postfixed
                 (setq cur-method (match-string 1 pattern))
                 (and cur-method (not (member cur-method methods))))
-           (setq tramp-name (expand-file-name
-                             (helm-create-tramp-name
-                              (match-string 0 pattern))))
+           (setq tramp-name (helm-create-tramp-name
+                             (match-string 0 pattern)))
            (replace-match tramp-name nil t pattern))
           ;; Match "/method:" in this case don't try to connect.
           ((and (null postfixed)

--- a/helm-files.el
+++ b/helm-files.el
@@ -1801,6 +1801,9 @@ purpose."
              (string= path "Invalid tramp file name")
              ;; An empty pattern
              (string= path "")
+             (and (string-match-p ":\\'" path)
+                  (helm-ff-tramp-postfixed-p
+                   path (mapcar 'car tramp-methods)))
              ;; Check if base directory of PATH is valid.
              (helm-aif (file-name-directory path)
                  ;; If PATH is a valid directory IT=PATH,

--- a/helm-files.el
+++ b/helm-files.el
@@ -1532,7 +1532,7 @@ or when `helm-pattern' is equal to \"~/\"."
                                      "Read File Name History"))
                (pat         (if (string-match helm-tramp-file-name-regexp
                                               helm-pattern)
-                                (file-remote-p helm-pattern)
+                                (helm-create-tramp-name helm-pattern)
                                 helm-pattern))
                (completed-p (string= (file-name-as-directory
                                       (expand-file-name
@@ -1676,6 +1676,12 @@ and should be used carefully elsewhere, or not at all, using
       (dired (file-name-directory target))
       (dired-goto-file target))))
 
+(defun helm-create-tramp-name (fname)
+  "Build filename for `helm-pattern' like /su:: or /sudo::."
+  (apply #'tramp-make-tramp-file-name
+         (cl-loop with v = (tramp-dissect-file-name fname)
+               for i across v collect i)))
+
 (cl-defun helm-ff-tramp-hostnames (&optional (pattern helm-pattern))
   "Get a list of hosts for tramp method found in `helm-pattern'.
 Argument PATTERN default to `helm-pattern', it is here only for debugging
@@ -1750,7 +1756,7 @@ purpose."
                 (setq cur-method (match-string 1 pattern))
                 (member cur-method methods))
            (setq tramp-name (expand-file-name
-                             (file-remote-p
+                             (helm-create-tramp-name
                               (match-string 0 pattern))))
            (replace-match tramp-name nil t pattern))
           ;; Match "/method:maybe_hostname:"
@@ -1758,7 +1764,7 @@ purpose."
                 postfixed
                 (setq cur-method (match-string 1 pattern))
                 (member cur-method methods))
-           (setq tramp-name (file-remote-p
+           (setq tramp-name (helm-create-tramp-name
                              (match-string 0 pattern)))
            (replace-match tramp-name nil t pattern))
           ;; Match "/hostname:"
@@ -1766,7 +1772,7 @@ purpose."
                 postfixed
                 (setq cur-method (match-string 1 pattern))
                 (and cur-method (not (member cur-method methods))))
-           (setq tramp-name (file-remote-p
+           (setq tramp-name (helm-create-tramp-name
                              (match-string 0 pattern)))
            (replace-match tramp-name nil t pattern))
           ;; Match "/method:" in this case don't try to connect.

--- a/helm-files.el
+++ b/helm-files.el
@@ -1532,7 +1532,7 @@ or when `helm-pattern' is equal to \"~/\"."
                                      "Read File Name History"))
                (pat         (if (string-match helm-tramp-file-name-regexp
                                               helm-pattern)
-                                (helm-create-tramp-name helm-pattern)
+                                (file-remote-p helm-pattern)
                                 helm-pattern))
                (completed-p (string= (file-name-as-directory
                                       (expand-file-name
@@ -1676,12 +1676,6 @@ and should be used carefully elsewhere, or not at all, using
       (dired (file-name-directory target))
       (dired-goto-file target))))
 
-(defun helm-create-tramp-name (fname)
-  "Build filename for `helm-pattern' like /su:: or /sudo::."
-  (apply #'tramp-make-tramp-file-name
-         (cl-loop with v = (tramp-dissect-file-name fname)
-               for i across v collect i)))
-
 (cl-defun helm-ff-tramp-hostnames (&optional (pattern helm-pattern))
   "Get a list of hosts for tramp method found in `helm-pattern'.
 Argument PATTERN default to `helm-pattern', it is here only for debugging
@@ -1756,7 +1750,7 @@ purpose."
                 (setq cur-method (match-string 1 pattern))
                 (member cur-method methods))
            (setq tramp-name (expand-file-name
-                             (helm-create-tramp-name
+                             (file-remote-p
                               (match-string 0 pattern))))
            (replace-match tramp-name nil t pattern))
           ;; Match "/method:maybe_hostname:"
@@ -1764,7 +1758,7 @@ purpose."
                 postfixed
                 (setq cur-method (match-string 1 pattern))
                 (member cur-method methods))
-           (setq tramp-name (helm-create-tramp-name
+           (setq tramp-name (file-remote-p
                              (match-string 0 pattern)))
            (replace-match tramp-name nil t pattern))
           ;; Match "/hostname:"
@@ -1772,7 +1766,7 @@ purpose."
                 postfixed
                 (setq cur-method (match-string 1 pattern))
                 (and cur-method (not (member cur-method methods))))
-           (setq tramp-name (helm-create-tramp-name
+           (setq tramp-name (file-remote-p
                              (match-string 0 pattern)))
            (replace-match tramp-name nil t pattern))
           ;; Match "/method:" in this case don't try to connect.


### PR DESCRIPTION
* helm-files.el (helm-ff-tramp-postfixed-p): New,
REturns position of last ":" entered.
(helm-ff-set-pattern): Use it.