### PR TITLE
allow user to choose a different emacs when running ``make''.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@
 ## Floor, Boston, MA 02110-1301, USA.
 
 # Emacs invocation
-EMACS_COMMAND   := emacs
+EMACS_COMMAND   ?= emacs
 
 EMACS		:= $(EMACS_COMMAND) -Q -batch
 


### PR DESCRIPTION
EMACS_COMMAND indicates the emacs to be used in the Makefile. Invoking make
with ``EMACS_COMMAND=/path/to/custom/emacs'' overrides the default.

* Makefile: Do it.