### PR TITLE
add fuzzy-match support for session source

### DIFF
--- a/helm-files.el
+++ b/helm-files.el
@@ -3439,7 +3439,8 @@ See `helm-browse-project'."
                    (mapcar 'car session-file-alist)))
     :keymap helm-generic-files-map
     :help-message helm-generic-file-help-message
-    :action 'helm-type-file-actions)
+    :action 'helm-type-file-actions
+    :fuzzy-match helm-recentf-fuzzy-match)
   "File list from emacs-session.")
 
 


### PR DESCRIPTION
Instead of making a new variable, I'm re-using `helm-recentf-fuzzy-match`.  Open to changes, let me know.