### PR TITLE
Update deprecated helm-mode description

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,12 +188,10 @@ a specialized info buffer.
 
 Use these embedded Info screens first before reporting bugs.
 
-`M-x helm-mode` to enable helm completion for common Emacs commands
-(e.g `M-x`, `C-x C-f`, etc...). Note that the helm functionality
-enabled through helm-mode comes from a generic implementation and does
-not include all helm features available through equivalent
-helm-specific commands. For example, `helm-M-x` has more features than
-helm completion through `M-x`.
+`M-x helm-mode` to enable helm completion for common Emacs
+commands. Note that the helm functionality enabled through helm-mode
+comes from a generic implementation and does not include all helm
+features available through equivalent helm-specific commands.
 
 To make helm-mode start with Emacs init file: 
 


### PR DESCRIPTION
`M-x` and `C-x C-f` are no longer modified by helm-mode since
1de1701. This update removes the description of the previous behavior.

Closes #1674 