### PR TITLE
delay highlighting file-attribute retrieval

### DIFF
--- a/helm-files.el
+++ b/helm-files.el
@@ -3470,28 +3470,28 @@ Colorize only symlinks, directories and files."
                                          (string-match ffap-url-regexp i)))
                                (not (string-match helm-ff-url-regexp i)))
                           (helm-basename i) i)
-           for type = (car (file-attributes i))
            collect
-           (cond ((and helm-ff-tramp-not-fancy
-                       (string-match helm-tramp-file-name-regexp i))
-                  (cons disp i))
-                 ((stringp type)
-                  (cons (propertize disp
-                                    'face 'helm-ff-symlink
-                                    'match-part (funcall mp-fn disp)
-                                    'help-echo (expand-file-name i))
-                        i))
-                 ((eq type t)
-                  (cons (propertize disp
-                                    'face 'helm-ff-directory
-                                    'match-part (funcall mp-fn disp)
-                                    'help-echo (expand-file-name i))
-                        i))
-                 (t (cons (propertize disp
-                                      'face 'helm-ff-file
-                                      'match-part (funcall mp-fn disp)
-                                      'help-echo (expand-file-name i))
-                          i)))))
+           (if (and helm-ff-tramp-not-fancy
+                    (string-match helm-tramp-file-name-regexp i))
+               (cons disp i)
+             (let ((type (car (file-attributes i))))
+               (cond ((stringp type)
+                      (cons (propertize disp
+                                        'face 'helm-ff-symlink
+                                        'match-part (funcall mp-fn disp)
+                                        'help-echo (expand-file-name i))
+                            i))
+                     ((eq type t)
+                      (cons (propertize disp
+                                        'face 'helm-ff-directory
+                                        'match-part (funcall mp-fn disp)
+                                        'help-echo (expand-file-name i))
+                            i))
+                     (t (cons (propertize disp
+                                          'face 'helm-ff-file
+                                          'match-part (funcall mp-fn disp)
+                                          'help-echo (expand-file-name i))
+                              i)))))))
 
 (defclass helm-files-in-current-dir-source (helm-source-sync helm-type-file)
   ((candidates :initform (lambda ()


### PR DESCRIPTION
This is a change that was discussed heavily in #749, fixed
incorrectly in c26d3a9 (this change ignored whether the file
in question was remote or not) and then essentially reverted
in 46687d1.

Here is the correct fix and speeds up my heavy TRAMP usage a ton
(from ~5 seconds pulling up helm-mini to instantaneous).

In order to recreate this, populate your recentf with remote files,
open one of these remote files (this part is 100% necessary), and
then do a helm-mini.  Since the connection to the remote files is open
the file-attribute will retrieve all the attributes of the files.

* helm-files.el (helm-highlight-files): delay file-attribute check