### PR TITLE
Fix helm-man-woman in failures of man and woman

### DIFF
--- a/helm-man.el
+++ b/helm-man.el
@@ -61,17 +61,20 @@ source.")
 (defun helm-man-default-action (candidate)
   "Default action for jumping to a woman or man page from helm."
   (let ((wfiles (mapcar #'car (woman-file-name-all-completions candidate))))
-    (let ((file (if (> (length wfiles) 1)
-                    (helm-comp-read "ManFile: " wfiles :must-match t)
-                  (car wfiles))))
-      (if (eq helm-man-or-woman-function 'Man-getpage-in-background)
-          (man file)
-        (condition-case nil
-            (woman-find-file file)
-          ;; If woman is unable to format correctly
-          ;; use man instead.
-          (error (kill-buffer)
-                 (man file)))))))
+    (condition-case nil
+        (let ((file (if (> (length wfiles) 1)
+                        (helm-comp-read "ManFile: " wfiles :must-match t)
+                      (car wfiles))))
+          (if (eq helm-man-or-woman-function 'Man-getpage-in-background)
+              (man (format helm-man-format-switches file))
+            (condition-case nil
+                (woman-find-file file)
+              ;; If woman is unable to format correctly
+              ;; use man instead.
+              (error (kill-buffer)
+                     (man file)))))
+      (error (kill-buffer)
+             (man candidate)))))
 
 (defun helm-man--init ()
   (require 'woman)

--- a/helm-man.el
+++ b/helm-man.el
@@ -62,19 +62,19 @@ source.")
   "Default action for jumping to a woman or man page from helm."
   (let ((wfiles (mapcar #'car (woman-file-name-all-completions candidate))))
     (condition-case nil
-        (let ((file (if (> (length wfiles) 1)
+        (let ((file (if (cdr wfiles)
                         (helm-comp-read "ManFile: " wfiles :must-match t)
                       (car wfiles))))
           (if (eq helm-man-or-woman-function 'Man-getpage-in-background)
-              (man (format helm-man-format-switches file))
+              (manual-entry (format helm-man-format-switches file))
             (condition-case nil
                 (woman-find-file file)
               ;; If woman is unable to format correctly
               ;; use man instead.
               (error (kill-buffer)
-                     (man file)))))
+                     (Man-getpage-in-background file)))))
       (error (kill-buffer)
-             (man candidate)))))
+             (Man-getpage-in-background candidate)))))
 
 (defun helm-man--init ()
   (require 'woman)

--- a/helm-man.el
+++ b/helm-man.el
@@ -60,20 +60,18 @@ source.")
 
 (defun helm-man-default-action (candidate)
   "Default action for jumping to a woman or man page from helm."
-  (let ((wfiles (mapcar
-                 'car (woman-file-name-all-completions candidate))))
-    (condition-case nil
-        (if (> (length wfiles) 1)
-            (let ((file (helm-comp-read
-                         "ManFile: " wfiles :must-match t)))
-              (if (eq helm-man-or-woman-function 'Man-getpage-in-background)
-                  (manual-entry (format helm-man-format-switches file))
-                  (woman-find-file file)))
-          (funcall helm-man-or-woman-function candidate))
-      ;; If woman is unable to format correctly
-      ;; use man instead.
-      (error (kill-buffer)              ; Kill woman buffer.
-             (Man-getpage-in-background candidate)))))
+  (let ((wfiles (mapcar #'car (woman-file-name-all-completions candidate))))
+    (let ((file (if (> (length wfiles) 1)
+                    (helm-comp-read "ManFile: " wfiles :must-match t)
+                  (car wfiles))))
+      (if (eq helm-man-or-woman-function 'Man-getpage-in-background)
+          (man file)
+        (condition-case nil
+            (woman-find-file file)
+          ;; If woman is unable to format correctly
+          ;; use man instead.
+          (error (kill-buffer)
+                 (man file)))))))
 
 (defun helm-man--init ()
   (require 'woman)


### PR DESCRIPTION
Changes:
- Pass absolute man file path to `man' without -l flag.
- When woman fails, the selected man section is retained. This fixes
the undesired behaviour that only the topic (without the section) is 
passed to `man' after such a failure.

The rationale behind the first change is that in BSD, man has no -l
option. Since the file name passed to man is generated from a woman
helper function, it is extremely unlikely to resemble a page
name. (see Help on `man')