### PR TITLE
Don't widen indirect Org buffers when getting candidates

### DIFF
--- a/helm-org.el
+++ b/helm-org.el
@@ -173,7 +173,10 @@ Note this have no effect in `helm-org-in-buffer-headings'."
                                   (apply old-fn args)))))
       (save-excursion
         (save-restriction
-          (widen)
+          (unless (and (bufferp filename)
+                       (buffer-base-buffer filename))
+            ;; Only widen direct buffers, not indirect ones.
+            (widen))
           (unless parents (goto-char (point-min)))
           ;; clear cache for new version of org-get-outline-path
           (and (boundp 'org-outline-path-cache)


### PR DESCRIPTION
* helm-org.el: (helm-org--get-candidates-in-buffer): Do it.

This way, if a buffer is created with org-tree-to-indirect-buffer, this
function will only return headings in that buffer's subtree.  In a
direct, narrowed buffer, all headings in the buffer will still be
returned.  This may not be a perfect solution, because if a user runs
`clone-indirect-buffer' on an entire Org buffer and then narrows it, he
might prefer this function to return all headings, but the former case
seems much more common and useful, so this behavior is probably best.

Thanks for your continued work on Helm, Thierry.