### PR TITLE
Preserve order when fuzzy matching in helm-recentf

### DIFF
--- a/helm-files.el
+++ b/helm-files.el
@@ -3845,9 +3845,10 @@ found."
 (defun helm-recentf ()
   "Preconfigured `helm' for `recentf'."
   (interactive)
-  (helm :sources 'helm-source-recentf
-        :ff-transformer-show-only-basename nil
-        :buffer "*helm recentf*"))
+  (let ((helm-fuzzy-matching-sort-ties-by-length nil))
+    (helm :sources 'helm-source-recentf
+          :ff-transformer-show-only-basename nil
+          :buffer "*helm recentf*")))
 
 ;;;###autoload
 (defun helm-delete-tramp-connection ()

--- a/helm.el
+++ b/helm.el
@@ -1174,6 +1174,11 @@ You should not modify this yourself unless you know what you are doing.")
 Should be set in candidates functions if needed, will be restored
 at end of session.")
 (defvar helm--action-prompt "Select action: ")
+(defvar helm-fuzzy-matching-sort-ties-by-length t
+  "When non-nil, fuzzy matches that tie in score will be sorted
+by length, shorter first.  When nil, fuzzy matches that tie in
+score will preserve their existing order, which may be preferable
+in, e.g. `helm-recentf'.")
 
 ;; Utility: logging
 (defun helm-log (format-string &rest args)
@@ -3175,7 +3180,8 @@ and sort on basename of candidates."
                      (scr1 (car data1))
                      (scr2 (car data2)))
                 (cond ((= scr1 scr2)
-                       (< len1 len2))
+                       (when helm-fuzzy-matching-sort-ties-by-length
+                         (< len1 len2)))
                       ((> scr1 scr2)))))))))
 
 (defun helm-fuzzy-matching-default-sort-fn (candidates _source &optional use-real)


### PR DESCRIPTION

Currently, when helm-recentf-fuzzy-match is enabled, matches with equal fuzzy score (e.g. same filename, different path length) are sorted by path length, which partially defeats the purpose of recentf as they are no longer in order of recency.  With this commit, tied fuzzy matches in helm-recentf will preserve their original ordering by recency, making helm-recentf more useful.

* helm.el: helm-fuzzy-matching-sort-ties-by-length: Add var 
                (helm-fuzzy-matching-default-sort-fn-1): Do it.
* helm-files.el (helm-recentf): Do it.

Thanks, Thierry.