### PR TITLE
* helm-command.el (helm-M-x): Re-throw error signal.

### DIFF
--- a/helm-command.el
+++ b/helm-command.el
@@ -285,12 +285,14 @@ You can get help on each command by persistent action."
           (cl-flet ((save-hist (command)
                       (setq extended-command-history
                             (cons command (delete command extended-command-history)))))
-            (condition-case nil
+            (condition-case err
                 (progn
                   (command-execute sym-com 'record)
                   (save-hist command-name))
-              (error (when helm-M-x-always-save-history
-                       (save-hist command-name))))))))))
+              (error
+               (when helm-M-x-always-save-history
+                 (save-hist command-name))
+               (signal (car err) (cdr err))))))))))
 (put 'helm-M-x 'interactive-only 'command-execute)
 
 (provide 'helm-command)


### PR DESCRIPTION
Otherwise, when an error occurs during command execution, the user will not get any feedback. For example,

```el
(defun foo ()
  (interactive)
  (+ 1 "string"))
```