### PR TITLE
Use Org's startup visibility in Helm

### DIFF
--- a/helm-org.el
+++ b/helm-org.el
@@ -142,8 +142,49 @@ Note this have no effect in `helm-org-in-buffer-headings'."
 
 (defun helm-source-org-headings-for-files (filenames &optional parents)
   (helm-make-source "Org Headings" 'helm-org-headings-class
+    :filtered-candidate-transformer 'helm-org-startup-visibility
     :parents parents
     :candidates filenames))
+
+(defun helm-org-startup-visibility (candidates _source)
+  "Indent headings and hide leading stars displayed in the helm buffer.
+If `org-startup-indented' and `org-hide-leading-stars' are nil, do
+nothing to CANDIDATES."
+  (cl-loop for i in candidates
+	   collect
+	   (cons
+	    (if helm-org-headings-fontify
+		(when (string-match "^\\(\\**\\)\\(\\* \\)\\(.*\n?\\)" (car i))
+		  (replace-match "\\1\\2\\3" nil nil (car i)))
+	      (when (string-match "^\\(\\**\\)\\(\\* \\)\\(.*\n?\\)" (car i))
+		(let ((foreground (org-find-invisible-foreground)))
+		  (with-helm-current-buffer
+		    ;; org-startup-indented is t, and org-hide-leading-stars is t
+		    ;; Or: #+STARTUP: indent hidestars
+		    (cond ((and org-startup-indented org-hide-leading-stars)
+			   (with-helm-buffer
+			     (require 'org-indent)
+			     (org-indent-mode 1)
+			     (replace-match
+			      (format "%s\\2\\3"
+				      (propertize (replace-match "\\1" nil nil (car i))
+						  'face `(:foreground ,foreground)))
+			      nil nil (car i))))
+			  ;; org-startup-indented is nil, org-hide-leading-stars is t
+			  ;; Or: #+STARTUP: noindent hidestars
+			  ((and (not org-startup-indented) org-hide-leading-stars)
+			   (with-helm-buffer
+			     (replace-match
+			      (format "%s\\2\\3"
+				      (propertize (replace-match "\\1" nil nil (car i))
+						  'face `(:foreground ,foreground)))
+			      nil nil (car i))))
+			  ;; org-startup-indented is nil, and org-hide-leading-stars is nil
+			  ;; Or: #+STARTUP: noindent showstars
+			  (t
+			   (with-helm-buffer
+			     (replace-match "\\1\\2\\3" nil nil (car i)))))))))
+	    (cdr i))))
 
 (defun helm-org-get-candidates (filenames &optional parents)
   (apply #'append

--- a/helm-org.el
+++ b/helm-org.el
@@ -155,7 +155,7 @@ nothing to CANDIDATES."
 	   (cons
 	    (if helm-org-headings-fontify
 		(when (string-match "^\\(\\**\\)\\(\\* \\)\\(.*\n?\\)" (car i))
-		  (replace-match "\\1\\2\\3" nil nil (car i)))
+		  (replace-match "\\1\\2\\3" t nil (car i)))
 	      (when (string-match "^\\(\\**\\)\\(\\* \\)\\(.*\n?\\)" (car i))
 		(let ((foreground (org-find-invisible-foreground)))
 		  (with-helm-current-buffer
@@ -167,23 +167,23 @@ nothing to CANDIDATES."
 			     (org-indent-mode 1)
 			     (replace-match
 			      (format "%s\\2\\3"
-				      (propertize (replace-match "\\1" nil nil (car i))
+				      (propertize (replace-match "\\1" t nil (car i))
 						  'face `(:foreground ,foreground)))
-			      nil nil (car i))))
+			      t nil (car i))))
 			  ;; org-startup-indented is nil, org-hide-leading-stars is t
 			  ;; Or: #+STARTUP: noindent hidestars
 			  ((and (not org-startup-indented) org-hide-leading-stars)
 			   (with-helm-buffer
 			     (replace-match
 			      (format "%s\\2\\3"
-				      (propertize (replace-match "\\1" nil nil (car i))
+				      (propertize (replace-match "\\1" t nil (car i))
 						  'face `(:foreground ,foreground)))
-			      nil nil (car i))))
+			      t nil (car i))))
 			  ;; org-startup-indented is nil, and org-hide-leading-stars is nil
 			  ;; Or: #+STARTUP: noindent showstars
 			  (t
 			   (with-helm-buffer
-			     (replace-match "\\1\\2\\3" nil nil (car i)))))))))
+			     (replace-match "\\1\\2\\3" t nil (car i)))))))))
 	    (cdr i))))
 
 (defun helm-org-get-candidates (filenames &optional parents)


### PR DESCRIPTION
Here's an updated version of the code discussed in https://github.com/emacs-helm/helm/issues/1775. It should indent org headings and hide leading stars according to the user's settings. To test:

```
#+STARTUP: indent hidestars
# #+STARTUP: noindent hidestars
# #+STARTUP: noindent showstars

* Heading A
** Subheading A.1
*** Subsubheading A.1.1
**** Subsubsubheading A.1.1.1
*** Subsubheading A.1.2
** Subheading A.2
* Heading B
```

1. Press C-c C-c twice on the #+STARTUP line to refresh
2. M-x helm-org-in-buffer-headings RET C-g
3. Comment that line and uncomment the next line
4. Repeat steps 1, 2 and 3
5. Change the value of helm-org-headings-fontify and repeat steps 1-4
