### PR TITLE
Revert "Clean up save command history logic"

### DIFF
--- a/helm-command.el
+++ b/helm-command.el
@@ -282,17 +282,14 @@ You can get help on each command by persistent action."
         ;; If helm-M-x is called with regular emacs completion (kmacro)
         ;; use the value of arg otherwise use helm-current-prefix-arg.
         (let ((prefix-arg (or helm-current-prefix-arg helm-M-x-prefix-argument)))
-          (cl-flet ((save-hist (command)
-                      (setq extended-command-history
-                            (cons command (delete command extended-command-history)))))
-            (condition-case err
-                (progn
-                  (command-execute sym-com 'record)
-                  (save-hist command-name))
-              (error
-               (when helm-M-x-always-save-history
-                 (save-hist command-name))
-               (signal (car err) (cdr err))))))))))
+          ;; This ugly construct is to save history even on error.
+          (unless helm-M-x-always-save-history
+            (command-execute sym-com 'record))
+          (setq extended-command-history
+                (cons command-name
+                      (delete command-name extended-command-history)))
+          (when helm-M-x-always-save-history
+            (command-execute sym-com 'record)))))))
 (put 'helm-M-x 'interactive-only 'command-execute)
 
 (provide 'helm-command)


### PR DESCRIPTION
Since 5492b6c1, helm-M-x suppress all error signals, thus when error
occurs, user can't be notified (via *Message* or *Backtrace*). I tried
to fix this by re-throwing the error signal with d1165267, but it
still breaks the Lisp debugger by not showing the function that really
fails, e.g.,

    (defun foo ()
      (interactive)
      (+ 1 nil))

    Debugger entered--Lisp error: (wrong-type-argument number-or-marker-p nil)
      signal(wrong-type-argument (number-or-marker-p nil))
      helm-M-x(nil #("foo" 0 3 (match-part "foo")))
      funcall-interactively(helm-M-x nil #("foo" 0 3 (match-part "foo")))
      call-interactively(helm-M-x nil nil)
      command-execute(helm-M-x)