### PR TITLE
Reenable marked files in dired with a fix to wdired (advice) (#1783).

### DIFF
--- a/helm-files.el
+++ b/helm-files.el
@@ -378,6 +378,7 @@ A function that takes a directory name as only arg."
     (define-key map (kbd "C-x C-d")       'helm-ff-run-browse-project)
     (define-key map (kbd "C-x r m")       'helm-ff-bookmark-set)
     (define-key map (kbd "C-x r b")       'helm-find-files-toggle-to-bookmark)
+    (define-key map (kbd "C-x C-q")       'helm-ff-run-marked-files-in-dired)
     (define-key map (kbd "C-s")           'helm-ff-run-grep)
     (define-key map (kbd "M-g s")         'helm-ff-run-grep)
     (define-key map (kbd "M-g p")         'helm-ff-run-pdfgrep)
@@ -492,6 +493,7 @@ Don't set it directly, use instead `helm-ff-auto-update-initial-value'.")
    "Find file in Dired" 'helm-point-file-in-dired
    "View file" 'view-file
    "Query replace fnames on marked `M-%'" 'helm-ff-query-replace-on-marked
+   "Marked files in dired" 'helm-marked-files-in-dired
    "Query replace contents on marked" 'helm-ff-query-replace
    "Query replace regexp contents on marked" 'helm-ff-query-replace-regexp
    "Attach file(s) to mail buffer" 'helm-ff-mail-attach-files
@@ -1753,6 +1755,28 @@ and should be used carefully elsewhere, or not at all, using
     (let ((target (expand-file-name (helm-substitute-in-filename file))))
       (dired (file-name-directory target))
       (dired-goto-file target))))
+
+(defun helm-marked-files-in-dired (_candidate)
+  "Open a dired buffer with only marked files.
+
+With a prefix arg toggle dired buffer to wdired mode."
+  (advice-add 'wdired-finish-edit :override #'helm--advice-wdired-finish-edit)
+  (let* ((marked (helm-marked-candidates))
+         (current (car marked)))
+    (unless (and ffap-url-regexp
+                 (string-match-p ffap-url-regexp current))
+      (let ((target (expand-file-name (helm-substitute-in-filename current))))
+        (dired (cons helm-ff-default-directory marked))
+        (dired-goto-file target)
+        (when (or helm-current-prefix-arg current-prefix-arg)
+          (call-interactively 'wdired-change-to-wdired-mode))))))
+
+(defun helm-ff-run-marked-files-in-dired ()
+  "Execute `helm-marked-files-in-dired' interactively."
+  (interactive)
+  (with-helm-alive-p
+    (helm-exit-and-execute-action 'helm-marked-files-in-dired)))
+(put 'helm-ff-run-marked-files-in-dired 'helm-only t)
 
 (defun helm-create-tramp-name (fname)
   "Build filename from `helm-pattern' like /su:: or /sudo::."

--- a/helm-help.el
+++ b/helm-help.el
@@ -455,6 +455,11 @@ and are not renamed to current directory, IOW use this (\\#) to rename files ins
 In the second prompt (replace regexp with) shortcut for `upcase', `downcase' and `capitalize'
 are available, respectively `%u', `%d' and `%c'.
 
+*** Edit marked files in a dired buffer
+
+You can open a dired buffer with only marked files with `\\<helm-find-files-map>\\[helm-ff-run-marked-files-in-dired]'
+With a prefix arg you can open this same dired buffer in wdired mode for editing files.
+
 *** Copying renaming asynchronously
 
 If you use async library (if you have installed helm from MELPA you do) you can enable

--- a/helm-locate.el
+++ b/helm-locate.el
@@ -152,6 +152,7 @@ help for more infos."
     (define-key map (kbd "C-c X")   'helm-ff-run-open-file-with-default-tool)
     (define-key map (kbd "M-.")     'helm-ff-run-etags)
     (define-key map (kbd "C-c @")   'helm-ff-run-insert-org-link)
+    (define-key map (kbd "C-x C-q") 'helm-ff-run-marked-files-in-dired)
     map)
   "Generic Keymap for files.")
 

--- a/helm-types.el
+++ b/helm-types.el
@@ -44,6 +44,7 @@
     "Find file other window"                'helm-find-files-other-window
     "Find file other frame"                 'find-file-other-frame
     "Open dired in file's directory"        'helm-open-dired
+    "Marked files in dired"                 'helm-marked-files-in-dired
     "Grep File(s) `C-u recurse'"            'helm-find-files-grep
     "Zgrep File(s) `C-u Recurse'"           'helm-ff-zgrep
     "Pdfgrep File(s)"                       'helm-ff-pdfgrep


### PR DESCRIPTION
* helm-files.el (helm-find-files-map): Bind new action.
(helm-find-files-actions): add new action.
(helm-marked-files-in-dired): New action.
(helm-ff-run-marked-files-in-dired): Interactive action.
* helm-lib.el (helm--advice-wdired-finish-edit): Advice
wdired-finish-edit which is not supporting dired-directory as a cons cell.
* helm-locate.el (helm-generic-files-map): Bind new action in generic map.
* helm-types.el (helm-type-file-actions): Add new action to file type.