### PR TITLE
Update eshell commentary

### DIFF
--- a/helm-eshell.el
+++ b/helm-eshell.el
@@ -22,7 +22,7 @@
 ;;           (lambda ()
 ;;               (eshell-cmpl-initialize)
 ;;               (define-key eshell-mode-map [remap eshell-pcomplete] 'helm-esh-pcomplete)
-;;               (define-key eshell-mode-map (kbd "M-p") 'helm-eshell-history)))
+;;               (define-key eshell-mode-map (kbd "M-r") 'helm-eshell-history)))
 
 
 ;;; Code:


### PR DESCRIPTION
`helm-eshell-history` acts more like `eshell-previous-matching-input` (M-r) instead of `eshell-previous-matching-input-from-input` (M-p).