### PR TITLE
helm-org.el (helm-org-in-buffer-headings): Don't nullify helm-org-format-outline-path

### DIFF
--- a/helm-org.el
+++ b/helm-org.el
@@ -325,7 +325,7 @@ will be refiled."
 (defun helm-org-in-buffer-headings ()
   "Preconfigured helm for org buffer headings."
   (interactive)
-  (let (helm-org-show-filename helm-org-format-outline-path)
+  (let (helm-org-show-filename)
     (helm :sources (helm-source-org-headings-for-files
                     (list (current-buffer)))
           :candidate-number-limit 99999


### PR DESCRIPTION
Since this command shows headings in the current buffer, it makes sense to hide the filename, but showing the full outline path can be very useful in narrowing down the list.  For example, in a tree like:

* Languages
** English
*** Alphabet
** Greek
*** Alphabet

If the user wanted to go to the "Greek/Alphabet" heading, without displaying the outline path, he'll see this after typing "alphabet":

*** Alphabet
*** Alphabet

Which wouldn't be useful.  But with full paths, he'd see:

** Languages/English/Alphabet
** Languages/Greek/Alphabet

By leaving helm-org-format-outline-path alone, we respect the user's setting, and allow it to be overridden by binding it around this command.

Thanks.