### PR TITLE
declare init-hooks for the grep and moccur sources

### DIFF
--- a/helm-grep.el
+++ b/helm-grep.el
@@ -969,6 +969,12 @@ These extensions will be added to command line with --include arg of grep."
 ;;; Set up source
 ;;
 ;;
+(defvar helm-grep-before-init-hook nil
+  "Hook that runs before initialization of the helm buffer.")
+
+(defvar helm-grep-after-init-hook nil
+  "Hook that runs after initialization of the helm buffer.")
+
 (defclass helm-grep-class (helm-source-async)
   ((candidates-process :initform 'helm-grep-collect-candidates)
    (filter-one-by-one :initform 'helm-grep-filter-one-by-one)
@@ -992,6 +998,8 @@ These extensions will be added to command line with --include arg of grep."
    (persistent-action :initform 'helm-grep-persistent-action)
    (persistent-help :initform "Jump to line (`C-u' Record in mark ring)")
    (requires-pattern :initform 2)
+   (before-init-hook :initform 'helm-grep-before-init-hook)
+   (after-init-hook :initform 'helm-grep-after-init-hook)
    (group :initform 'helm-grep)))
 
 (defvar helm-source-grep nil)

--- a/helm-regexp.el
+++ b/helm-regexp.el
@@ -320,6 +320,12 @@ Same as `helm-moccur-goto-line' but go in new frame."
     (helm-exit-and-execute-action 'helm-moccur-goto-line)))
 (put 'helm-moccur-run-default-action 'helm-only t)
 
+(defvar helm-moccur-before-init-hook nil
+  "Hook that runs before initialization of the helm buffer.")
+
+(defvar helm-moccur-after-init-hook nil
+  "Hook that runs after initialization of the helm buffer.")
+
 (defvar helm-source-moccur nil)
 (defclass helm-source-multi-occur (helm-source-in-buffer)
   ((init :initform (lambda ()
@@ -339,6 +345,8 @@ Same as `helm-moccur-goto-line' but go in new frame."
    (keymap :initform helm-moccur-map)
    (history :initform 'helm-occur-history)
    (requires-pattern :initform 2)
+   (before-init-hook :initform 'helm-moccur-before-init-hook)
+   (after-init-hook :initform 'helm-moccur-after-init-hook)
    (group :initform 'helm-regexp)))
 
 (defun helm-moccur-resume-fn ()


### PR DESCRIPTION
These hooks are useful for external packages. For example, the new after-init-hooks introduced here will be used by the package `[helm-modeless](https://github.com/sameerds/helm-modeless)' that I am working on.