### PR TITLE
Mod. to helm-allow-mouse (and doc. improvements) to allow global mouse bindings

### DIFF
--- a/helm-info.el
+++ b/helm-info.el
@@ -21,6 +21,7 @@
 (require 'helm)
 (require 'helm-lib)
 (require 'info)
+(require 'helm-utils) ; for helm-goto-line
 
 (declare-function Info-index-nodes "info" (&optional file))
 (declare-function Info-goto-node "info" (&optional fork))

--- a/helm.el
+++ b/helm.el
@@ -562,56 +562,78 @@ source name in this variable."
 
 ;;; Prevent losing focus when using mouse.
 ;;
+(defconst helm--mouse-keys
+  '([mouse-1] [mouse-2] [mouse-3]
+    [down-mouse-1] [down-mouse-2] [down-mouse-3]
+    [drag-mouse-1] [drag-mouse-2] [drag-mouse-3]
+    [double-mouse-1] [double-mouse-2] [double-mouse-3]
+    [triple-mouse-1] [triple-mouse-2] [triple-mouse-3])
+  "Mouse keys rebound in helm.")
+
 (defun helm-local-mouse-bindings-p ()
   "Return t if helm is configured to use local/mode-specific mouse bindings."
-  (and helm-allow-mouse (not (eq helm-allow-mouse 'no-local-mouse-bindings))))
+  (and helm-allow-mouse (not (eq helm-allow-mouse 'global-mouse-bindings))))
 
-(defun helm--make-mouse-mode-map ()
+(defun helm--make-disable-mouse-mode-map ()
   "Create a keymap that disables all global mouse bindings."
   (let ((map (make-sparse-keymap)))
-    (cl-loop for k in '([mouse-1] [mouse-2] [mouse-3]
-                        [down-mouse-1] [down-mouse-2] [down-mouse-3]
-                        [drag-mouse-1] [drag-mouse-2] [drag-mouse-3]
-                        [double-mouse-1] [double-mouse-2] [double-mouse-3]
-                        [triple-mouse-1] [triple-mouse-2] [triple-mouse-3])
+    (cl-loop for k in helm--mouse-keys
              do (define-key map k 'ignore))
     map))
 
-(defvar helm--remap-mouse-mode-map (helm--make-mouse-mode-map)
+(defvar helm--disable-mouse-mode-map (helm--make-disable-mouse-mode-map)
   "A keymap that disables all global mouse bindings.")
 
-(define-minor-mode helm--remap-mouse-mode
-  "[INTERNAL] Prevent escaping helm minibuffer with mouse clicks.
+(define-minor-mode helm--disable-mouse-mode
+  "[INTERNAL] Disable all mouse clicks; prevents escaping from helm minibuffer.
 Do nothing when used outside of helm context.
 
 WARNING: Do not use this mode yourself, it is internal to helm."
   :group 'helm
   :global t
-  :keymap helm--remap-mouse-mode-map
-  (if (and helm--remap-mouse-mode (not helm--remap-mouse-mode-map))
-      (setq helm--remap-mouse-mode-map (helm--make-mouse-mode-map))
-    (unless helm-alive-p
-      (setq helm--remap-mouse-mode-map nil)))
-  (unless (helm-local-mouse-bindings-p)
-    (helm-disable-local-mouse-bindings)))
-(put 'helm--remap-mouse-mode 'helm-only t)
+  :keymap helm--disable-mouse-mode-map)
+(put 'helm--disable-mouse-mode 'helm-only t)
 
-(defun helm-disable-local-mouse-bindings ()
-  "Disable any local mouse bindings within a helm completion buffer."
-  ;; force disabling of local mouse key bindings.
-  (if helm-alive-p
-      (with-helm-buffer
-        (let ((inhibit-read-only t))
-          (remove-text-properties (point-min) (point-max)
-                                  '(mouse-face nil keymap nil help-echo nil))))))
+(defvar helm--allow-mouse-changed nil
+  "Flag indicated need to refresh helm buffers because mouse support setting changed.")
+
+(defun helm--maybe-refresh ()
+  (when helm--allow-mouse-changed
+    (make-local-variable 'helm--allow-mouse-changed)
+    (setq helm--allow-mouse-changed nil)
+    (add-hook 'helm-after-initialize-hook
+              (lambda ()
+                (setq unread-command-events
+                      (nconc (listify-key-sequence (kbd "C-c C-u")) unread-command-events))))))
+
+(defun helm--set-allow-mouse (symbol value)
+  (let ((lexical-binding t))
+    (set-default symbol value)
+    ;; Force regeneration of helm text property mouse bindings next
+    ;; time helm is invoked in each helm buffer.
+    (setq-default helm--allow-mouse-changed t)
+    ;; Remove any buffer-local values of this variable.
+    (mapc (lambda (buf) (with-current-buffer buf
+                          (kill-local-variable 'helm--allow-mouse-changed)))
+          (buffer-list))
+    (helm--maybe-refresh)))
 
 (defcustom helm-allow-mouse nil
   "Allow mouse usage during the helm session when non-nil.
 
-If set to 'no-local-mouse-bindings, no local nor text-specific mouse bindings
+To modify its value interactively, use M-x customize-option RET.
+
+To modify its value programmatically, set it like so:
+  (custom-set-variables '(helm-allow-mouse <setting>))
+where <setting> is one of: t, nil or 'global-mouse-bindings.  Do not
+use setq.
+
+If set to 'global-mouse-bindings, no local nor text-specific mouse bindings
 are made; global mouse bindings continue in effect.
 
-If t, the following local mouse bindings are made for the helm
+If set to nil, it disables use of all mouse buttons in helm.
+
+If set to t, the following local mouse bindings are made for the helm
 completion buffer:
 
 - mouse-1 selects candidates
@@ -622,13 +644,9 @@ This allows selection of windows other than the minibuffer;
 the minibuffer window must then be selected again to exit helm."
   :group 'helm
   :type '(radio (const :tag "Helm Mouse Buttons" t)
-                (const :tag "Global Mouse Buttons" 'no-local-mouse-bindings)
+                (const :tag "Global Mouse Buttons" 'global-mouse-bindings)
                 (const :tag "No Mouse Buttons" nil))
-  :set (lambda (symbol value)
-         (set-default symbol value)
-         (cond ((eq value 'no-local-mouse-bindings) (helm--remap-mouse-mode -1))
-               (t (helm--remap-mouse-mode 1)))
-         value))
+  :set #'helm--set-allow-mouse)
 
 (defcustom helm-move-to-line-cycle-in-source nil
   "Cycle to the beginning or end of the list after reaching the bottom or top.
@@ -1107,7 +1125,7 @@ do not display line numbers. Line numbers can be enabled with the
 
 ** Using the mouse in helm
 
-Basic usage of the mouse is provided when `helm-allow-mouse' is set to t.
+Helm-specif mouse bindings are provided when `helm-allow-mouse' is set to t:
 
 - mouse-1 selects candidates
 - mouse-2 executes the default action on selected candidates
@@ -1117,21 +1135,22 @@ NOTE: When mouse usage is enabled in helm, it allows selection of windows other 
 minibuffer; the minibuffer window must then be selected again to regain control of your helm
 session.
 
-  ** Marked candidates
+** Marked candidates
 
-  You can mark candidates to execute an action on them instead of the current selected
-  candidate only (See binding below).  Most Helm actions operate on marked candidates unless
-  marking candidates is prevented explicitely for a specific source.
+You can mark candidates to execute an action on them instead of the current selected
+candidate only (See binding below).  Most Helm actions operate on marked candidates unless
+marking candidates is prevented explicitely for a specific source.
 
-  To mark/unmark a candidate use \\[helm-toggle-visible-mark] (See bindings below).
-  To mark all visible unmarked candidates at once in current source use \\[helm-mark-all].
-  To mark/unmark all candidates at once use \\[helm-toggle-all-marks].
+To mark/unmark a candidate use \\[helm-toggle-visible-mark] (See bindings below).
+To mark all visible unmarked candidates at once in current source use \\[helm-mark-all].
+To mark/unmark all candidates at once use \\[helm-toggle-all-marks].
 
-  NOTE: These two functions allow marking candidates in all sources with a prefix argument,
-  but even if you mark all candidates of all sources, only those of current source will be used
-  when executing your action unless this action specify to use candidates of all sources, which
-  is not the case in most sources for evident reasons
-  \(i.e Each action handle only a specific type of candidate).
+NOTE: These two functions allow marking candidates in all sources with a prefix argument,
+but even if you mark all candidates of all sources, only those of current source will be used
+when executing your action unless this action specify to use candidates of all sources, which
+is not the case in most sources for evident reasons
+\(i.e Each action handle only a specific type of candidate).
+
 IOW Unless you use specific sources that have actions handling candidates of all other sources
 you don't need the prefix arg when using \\[helm-mark-all] or \\[helm-toggle-all-marks].
 
@@ -2241,10 +2260,10 @@ ANY-KEYMAP ANY-DEFAULT ANY-HISTORY See `helm'."
                (select-window (helm-window))
                ;; We are now in helm-buffer.
                (unless helm-allow-mouse
-                 (helm--remap-mouse-mode 1)) ; Disable all mouse bindings.
+                 (helm--disable-mouse-mode 1)) ; Disable all mouse bindings.
                (add-hook 'post-command-hook 'helm--maybe-update-keymap)
                ;; Add also to update hook otherwise keymap is not updated
-               ;; until a key is hitted (Issue #1670).
+               ;; until a key is hit (Issue #1670).
                (add-hook 'helm-after-update-hook 'helm--maybe-update-keymap)
                (add-hook 'post-command-hook 'helm--update-header-line)
                (helm-log "show prompt")
@@ -2267,7 +2286,7 @@ ANY-KEYMAP ANY-DEFAULT ANY-HISTORY See `helm'."
         (advice-remove 'cua-delete-region #'cua-delete-region--advice)
         (advice-remove 'copy-region-as-kill #'copy-region-as-kill--advice))
       (helm-log "helm-alive-p = %S" (setq helm-alive-p nil))
-      (helm--remap-mouse-mode -1)       ; Re-enable helm or global mouse bindings.
+      (helm--disable-mouse-mode -1)       ; Re-enable helm or global mouse bindings.
       (setq helm-alive-p nil)
       ;; Reset helm-pattern so that lambda's using it
       ;; before running helm will not start with its old value.
@@ -2458,7 +2477,7 @@ Don't use this directly, use instead `helm' with the keyword
             (ad-activate 'tramp-read-passwd)
             (ad-activate 'ange-ftp-get-passwd))
           (unless helm-allow-mouse
-            (helm--remap-mouse-mode 1)) ; Disable all mouse bindings.
+            (helm--disable-mouse-mode 1)) ; Disable all mouse bindings.
           (unless (cl-loop for h in post-command-hook
                            thereis (memq h '(helm--maybe-update-keymap
                                              helm--update-header-line)))
@@ -3016,9 +3035,8 @@ map)."
     ;; Be sure we call this from helm-buffer.
     (helm-funcall-foreach 'cleanup))
   (helm-kill-async-processes)
-  ;; Remove the temporary hooks added
-  ;; by `with-helm-temp-hook' that
-  ;; may not have been consumed.
+  ;; Remove the temporary hooks added by `with-helm-temp-hook'
+  ;; that may not have been consumed.
   (when helm--temp-hooks
     (cl-loop for (fn . hook) in helm--temp-hooks
              do (set hook (delete fn (symbol-value hook)))))
@@ -3041,8 +3059,8 @@ map)."
 (defun helm-clean-up-minibuffer ()
   "Remove contents of minibuffer."
   (let ((miniwin (minibuffer-window)))
-    ;; Clean only current minibuffer used by helm.
-    ;; i.e The precedent one is active.
+    ;; Clean only current minibuffer used by helm,
+    ;; i.e. the one that is active.
     (unless (minibuffer-window-active-p miniwin)
       (with-current-buffer (window-buffer miniwin)
         (delete-minibuffer-contents)))))
@@ -3611,12 +3629,12 @@ It is used for narrowing list of candidates to the
             (helm-take-first-elements
              (helm-get-cached-candidates source) limit)
             source)
-         ;; Compute candidates according to pattern with their match
-         ;; fns.
-         ;; one-by-one filtered candidates are computed during the
-         ;; execution of next loop in `helm-match-from-candidates'.
-         (helm-match-from-candidates
-          (helm-get-cached-candidates source) matchfns matchpartfn limit source))
+           ;; Compute candidates according to pattern with their match
+           ;; fns.
+           ;; one-by-one filtered candidates are computed during the
+           ;; execution of next loop in `helm-match-from-candidates'.
+           (helm-match-from-candidates
+            (helm-get-cached-candidates source) matchfns matchpartfn limit source))
        source))))
 
 (defun helm--candidates-in-buffer-p (matchfns)
@@ -3893,6 +3911,29 @@ candidates from `helm-async-outer-limit-hook'."
   "Remove SOURCE from `helm-candidate-cache'."
   (remhash (assoc-default 'name source) helm-candidate-cache))
 
+(defvar helm-match-keymap (make-sparse-keymap)
+  "Text property keymap for mouse bindings applied to helm match entries.")
+
+(defun helm-match-propertize (start end map)
+  "On helm matches between START and END, add text property mouse bindings to key MAP.
+Also add mouse navigation properties."
+  ;; Don't overwrite mouse properties when redisplaying.
+  (when (and map (not (get-text-property start 'keymap)))
+    (if (eq helm-allow-mouse 'global-mouse-bindings)
+        (mapc (lambda (key) (define-key map key nil)) helm--mouse-keys)
+      (define-key map [down-mouse-1] 'helm-mouse-select-candidate)
+      (define-key map [mouse-1] 'ignore)
+      (define-key map [down-mouse-3] 'helm-select-action)
+      (mapc (lambda (key) (define-key map key 'ignore))
+            '([mouse-2] [down-mouse-2] [mouse-3]))
+      (add-text-properties
+       start end
+       `(mouse-face highlight
+                    keymap ,map
+                    help-echo ,(helm-aif (get-text-property start 'help-echo)
+                                   (concat it "\nmouse-1: select candidate\nmouse-3: menu actions")
+                                 "mouse-1: select candidate\nmouse-3: menu actions"))))))
+
 (defun helm-insert-match (match insert-function &optional num source)
   "Insert MATCH into `helm-buffer' with INSERT-FUNCTION.
 If MATCH is a cons cell then insert the car as display with
@@ -3902,8 +3943,7 @@ respectively `helm-cand-num' and `helm-cur-source'."
   (let ((start     (point-at-bol (point)))
         (dispvalue (helm-candidate-get-display match))
         (realvalue (cdr-safe match))
-        (map       (and (helm-local-mouse-bindings-p)
-                        (make-sparse-keymap)))
+        (map       (when helm-allow-mouse helm-match-keymap))
         (inhibit-read-only t)
         end)
     (when (and (stringp dispvalue)
@@ -3917,20 +3957,7 @@ respectively `helm-cand-num' and `helm-cur-source'."
         (and realvalue
              (put-text-property start end
                                 'helm-realvalue realvalue)))
-      (when (and map
-                 ;; Don't overwrite mouse properties when
-                 ;; redisplaying.
-                 (not (get-text-property start 'keymap)))
-        (define-key map [mouse-1] 'helm-mouse-select-candidate)
-        (define-key map [mouse-2] 'ignore)
-        (define-key map [mouse-3] 'helm-select-action)
-        (add-text-properties
-         start end
-         `(mouse-face highlight
-                      keymap ,map
-                      help-echo ,(helm-aif (get-text-property start 'help-echo)
-                                     (concat it "\nmouse-1: select candidate\nmouse-3: menu actions")
-                                   "mouse-1: select candidate\nmouse-3: menu actions"))))
+      (helm-match-propertize start end map)
       (when num
         (put-text-property start end 'helm-cand-num num))
       (when source
@@ -3953,15 +3980,19 @@ respectively `helm-cand-num' and `helm-cur-source'."
   (let ((inhibit-read-only t)
         (map (get-text-property pos 'keymap)))
     (when map
-      (define-key map [mouse-2] 'helm-maybe-exit-minibuffer)
-      (put-text-property
-       helm-selection-point
-       (overlay-end helm-selection-overlay)
-       'help-echo (helm-aif (get-text-property pos 'help-echo)
-                      (if (string-match "mouse-1: select candidate" it)
-                          (replace-match "mouse-2: execute action" t t it)
+      (if (eq helm-allow-mouse 'global-mouse-bindings)
+          (progn (define-key map [mouse-2] nil)
+                 (define-key map [down-mouse-2] nil))
+        (define-key map [down-mouse-2] 'helm-maybe-exit-minibuffer)
+        (define-key map [mouse-2] 'ignore)
+        (put-text-property
+         helm-selection-point
+         (overlay-end helm-selection-overlay)
+         'help-echo (helm-aif (get-text-property pos 'help-echo)
+                        (if (string-match "mouse-1: select candidate" it)
+                            (replace-match "mouse-2: execute action" t t it)
                           "mouse-2: execute action\nmouse-3: menu actions")
-                    "mouse-2: execute action\nmouse-3: menu actions")))))
+                      "mouse-2: execute action\nmouse-3: menu actions"))))))
 
 (defun helm-mouse-select-candidate (event)
   (interactive "e")
@@ -3969,6 +4000,7 @@ respectively `helm-cand-num' and `helm-cur-source'."
          (pos    (posn-point (event-end event))))
     (unwind-protect
          (with-current-buffer (window-buffer window)
+           (mouse-set-point event)
            (if (and (helm-action-window)
                     (eql window (get-buffer-window helm-buffer)))
                (user-error "selection in helm-window not available while selecting action")
@@ -4503,7 +4535,7 @@ Key arg DIRECTION can be one of:
     (unless (or (helm-empty-buffer-p (helm-buffer-get))
                 (not (helm-window)))
       (with-helm-window
-        (when (helm-local-mouse-bindings-p)
+        (when helm-allow-mouse
           (helm--mouse-reset-selection-help-echo))
         (helm-log-run-hook 'helm-move-selection-before-hook)
         (funcall move-func)
@@ -4766,7 +4798,7 @@ candidates."
                (point-max)))
        (1+ (point-at-eol))))
     (setq helm-selection-point (overlay-start helm-selection-overlay))
-    (when (and (helm-local-mouse-bindings-p) (null nomouse))
+    (when (and helm-allow-mouse (null nomouse))
       (helm--bind-mouse-for-selection helm-selection-point))))
 
 (defun helm-confirm-and-exit-minibuffer ()
@@ -4990,7 +5022,7 @@ Optional argument SOURCE is a Helm source object."
     (when (helm-pos-multiline-p)
       (helm-move--beginning-of-multiline-candidate))
     (when (helm-pos-header-line-p) (forward-line 1))
-    (when (helm-local-mouse-bindings-p)
+    (when helm-allow-mouse
       (helm--mouse-reset-selection-help-echo))
     (helm-mark-current-line)
     (helm-display-mode-line (or source (helm-get-current-source)))


### PR DESCRIPTION
First, thanks for the great work on helm.

Sometimes one wants to have consistent mouse bindings across many different modes where the global mouse settings determine how to handle the specific context of each mouse click.  This pull request allows for this behavior via a flag setting prior to helm initialization.

This change does not affect helm behavior unless a user explicitly sets helm-allow-mouse to 'no-mode-bindings, in which case all local and text property helm mouse bindings are skipped and never activated.  That is all it does so it should be easy to integrate without affecting any other uses while allowing for more flexible mouse key binding.

One specific use case is with my package, Hyperbole, which provides two context-specific global mouse keys.  If this change is made, the next release of Hyperbole will include helm compatibility and will allow for random access to items in helm completion buffers even when helm is not active (if the completion buffer is still available).  If helm is active, after each click, point is returned to the minibuffer so that mouse usage does not impede keyboard usage.