### PR TITLE
Change: (helm-buffer--details) Handle non-modified, non-file buffers

### DIFF
--- a/helm-buffers.el
+++ b/helm-buffers.el
@@ -375,6 +375,11 @@ See `ido-make-buffer-list' for more infos."
          (helm-buffer--show-details
           name name-prefix file-name size mode dir
           'helm-buffer-file 'helm-buffer-process nil details 'filebuf))
+        ;; A non-file, modified buffer
+        ((buffer-modified-p buf)
+         (helm-buffer--show-details
+          name (and proc name-prefix) dir size mode dir
+          'helm-buffer-modified 'helm-buffer-process proc details 'nofile-mod))
         ;; Any non--file buffer.=>italic
         (t
          (helm-buffer--show-details


### PR DESCRIPTION
Modified, non-file buffers are now shown as modified.  This is useful for, e.g. chat clients, whose room buffers are not file-backed, but it's useful to know when they're modified (i.e. have new messages).

Thanks for your work on Helm!