### PR TITLE
Do not override helm-always-two-windows in helm-elisp.el

### DIFF
--- a/helm-elisp.el
+++ b/helm-elisp.el
@@ -185,7 +185,6 @@ If `helm-turn-on-show-completion' is nil just do nothing."
           (and helm-turn-on-show-completion
                (append (list 'helm-show-completion)
                        helm-move-selection-after-hook)))
-         (helm-always-two-windows t)
          (helm-split-window-default-side
           (if (eq helm-split-window-default-side 'same)
               'below helm-split-window-default-side))


### PR DESCRIPTION
Setting `(helm-always-two-windows t)` overrides `helm-split-window-default-side` which user may have set intentionally, e.g. to always open helm buffers in the other window when one is available. Imho, we should respect user settings. As an example I have these in my init.el and I expect them to be honored by helm features I load:

```elisp
(setq helm-quick-update t
        helm-split-window-in-side-p nil
        helm-echo-input-in-header-line t
        helm-split-window-default-side 'other
        helm-move-to-line-cycle-in-source nil)
```

This change is made with little understanding of all code-paths, so while it solves my problem it could be breaking someone else's setup. Careful review of someone familiar with the code is required.

Thanks