### PR TITLE
Allow displaying helm-buffer in separate frame (#1932)

### DIFF
--- a/helm-elisp.el
+++ b/helm-elisp.el
@@ -101,6 +101,11 @@ fuzzy completion is not available in `completion-at-point'."
   :group 'helm-elisp
   :type '(repeat (choice symbol)))
 
+(defcustom helm-show-completion-display-function
+  #'helm-show-completion-default-display-function
+  "The function to use to display completion buffer."
+  :group 'helm-elisp
+  :type 'function)
 
 ;;; Faces
 ;;
@@ -154,7 +159,7 @@ fuzzy completion is not available in `completion-at-point'."
   (overlay-put helm-show-completion-overlay
                'face 'helm-lisp-show-completion))
 
-(defun helm-show-completion-display-function (buffer &rest _args)
+(defun helm-show-completion-default-display-function (buffer &rest _args)
   "A special resized helm window is used depending on position in BUFFER."
   (with-selected-window (selected-window)
     (if (window-dedicated-p)
@@ -193,7 +198,7 @@ If `helm-turn-on-show-completion' is nil do nothing."
               (helm-set-local-variable
                'helm-display-function
                (if helm-show-completion-use-special-display
-                   'helm-show-completion-display-function
+                   helm-show-completion-display-function
                  'helm-default-display-buffer))
               (helm-show-completion-init-overlay ,beg ,end)
               ,@body)

--- a/helm-mode.el
+++ b/helm-mode.el
@@ -156,6 +156,13 @@ So you should not change the default setting of this variable unless you
 know what you are doing."
   :group 'helm-mode
   :type 'boolean)
+
+(defcustom helm-completion-in-region-display-function nil
+  "Function used to display helm window in `completion-in-region'.
+
+Default is `helm-display-function' value."
+  :group 'helm-mode
+  :type 'function)
 
 (defvar helm-comp-read-map
   (let ((map (make-sparse-keymap)))
@@ -1165,7 +1172,9 @@ Can be used as value for `completion-in-region-function'."
      'lisp--local-variables
      :around #'helm-mode--advice-lisp--local-variables)
     (unwind-protect
-        (let* ((enable-recursive-minibuffers t)
+        (let* ((helm-display-function (or helm-completion-in-region-display-function
+                                          helm-display-function))
+               (enable-recursive-minibuffers t)
                (input (buffer-substring-no-properties start end))
                (current-command (or (helm-this-command) this-command))
                (crm (eq current-command 'crm-complete))

--- a/helm.el
+++ b/helm.el
@@ -703,6 +703,15 @@ so it have only effect when `helm-always-two-windows' is non-nil."
   :type 'float
   :group 'helm)
 
+(defcustom helm-display-buffer-width 60
+  "Frame width when displaying helm-buffer in own frame."
+  :group 'helm
+  :type 'integer)
+
+(defcustom helm-display-buffer-height 20
+  "Frame height when displaying helm-buffer in own frame."
+  :group 'helm
+  :type 'integer)
 
 ;;; Faces
 ;;
@@ -2596,8 +2605,8 @@ splitting helm window, frame setting are hard coded for now, and
 position of frame is limited to top right corner for now.
 IOW use this with caution."
   (setq helm--buffer-in-new-frame-p t)
-  (let ((default-frame-alist `((width . 60)
-                               (height . 20)
+  (let ((default-frame-alist `((width . ,helm-display-buffer-width)
+                               (height . ,helm-display-buffer-height)
                                (tool-bar-lines . 0)
                                (vertical-scroll-bars . nil)
                                (menu-bar-lines . 0)

--- a/helm.el
+++ b/helm.el
@@ -2601,8 +2601,8 @@ IOW use this with caution."
                                (tool-bar-lines . 0)
                                (vertical-scroll-bars . nil)
                                (menu-bar-lines . 0)
-                               (left . ,(- (* (window-width) 8) 60))
-                               (fullscreen . nil))))
+                               (fullscreen . nil)
+                               (minibuffer . t))))
     (display-buffer
      buffer '(display-buffer-pop-up-frame . nil)))
   (helm-log-run-hook 'helm-window-configuration-hook))

--- a/helm.el
+++ b/helm.el
@@ -2598,12 +2598,14 @@ value of `helm-full-frame' or `helm-split-window-default-side'."
 (defun helm-display-buffer-in-own-frame (buffer)
   "Display `helm-buffer' in a separate frame.
 
-Function suitable for `helm-display-function'
+Function suitable for `helm-display-function',
+`helm-completion-in-region-display-function'
 and/or `helm-show-completion-default-display-function'.
-This is experimental, persistent actions are limited to actions not
-splitting helm window, frame setting are hard coded for now, and
-position of frame is limited to top right corner for now.
-IOW use this with caution."
+
+See `helm-display-buffer-height' and `helm-display-buffer-width' to
+configure frame size.
+
+When using this persistent actions splitting helm window will be disabled."
   (setq helm--buffer-in-new-frame-p t)
   (let ((default-frame-alist `((width . ,helm-display-buffer-width)
                                (height . ,helm-display-buffer-height)

--- a/helm.el
+++ b/helm.el
@@ -2587,6 +2587,14 @@ value of `helm-full-frame' or `helm-split-window-default-side'."
     (helm-log-run-hook 'helm-window-configuration-hook)))
 
 (defun helm-display-buffer-in-own-frame (buffer)
+  "Display `helm-buffer' in a separate frame.
+
+Function suitable for `helm-display-function'
+and/or `helm-show-completion-default-display-function'.
+This is experimental, persistent actions are limited to actions not
+splitting helm window, frame setting are hard coded for now, and
+position of frame is limited to top right corner for now.
+IOW use this with caution."
   (setq helm--buffer-in-new-frame-p t)
   (let ((default-frame-alist `((width . 60)
                                (height . 20)


### PR DESCRIPTION
It is done by setting helm-display-function.
Persistent actions are limited to non-splitting actions when using this.

* helm-elisp.el (helm-show-completion-display-function): New.
(helm-show-completion-default-display-function): Renamed from helm-show-completion-display-function.
(with-helm-show-completion): Use helm-show-completion-display-function.
* helm.el (helm--buffer-in-new-frame-p): New internal flag.
(helm-default-display-buffer): Docstring.
(helm-display-buffer-in-own-frame): New function suitable for helm-display-function.
(helm-cleanup): Delete frame if needed.
(helm-execute-persistent-action): Persistent action that split window
are not allowed when using helm-buffer in own frame.