### PR TITLE
Require `format-spec` in `helm-grep.el`

### DIFF
--- a/helm-grep.el
+++ b/helm-grep.el
@@ -17,6 +17,7 @@
 
 ;;; Code:
 (require 'cl-lib)
+(require 'format-spec)
 (require 'helm)
 (require 'helm-help)
 (require 'helm-regexp)


### PR DESCRIPTION
Fix #1992