### PR TITLE
Use text in the region as default in helm-surfraw

### DIFF
--- a/helm-net.el
+++ b/helm-net.el
@@ -524,16 +524,23 @@ NOTE: Probably not supported on some systems (e.g Windows)."
 ;;;###autoload
 (defun helm-surfraw (pattern engine)
   "Preconfigured `helm' to search PATTERN with search ENGINE."
-  (interactive (list (read-string "SearchFor: "
-                                  nil 'helm-surfraw-input-history
-                                  (thing-at-point 'symbol))
-                     (helm-comp-read
-                      "Engine: "
-                      (helm-build-elvi-list)
-                      :must-match t
-                      :name "Surfraw Search Engines"
-                      :del-input nil
-                      :history helm-surfraw-engines-history)))
+  (interactive
+   (list
+    (let* ((default (if (use-region-p)
+                        (buffer-substring-no-properties
+                         (region-beginning) (region-end))
+                      (thing-at-point 'symbol)))
+           (prompt (if default
+                       (format "SearchFor (default %s): " default)
+                     "SearchFor: ")))
+      (read-string prompt nil 'helm-surfraw-input-history default))
+    (helm-comp-read
+     "Engine: "
+     (helm-build-elvi-list)
+     :must-match t
+     :name "Surfraw Search Engines"
+     :del-input nil
+     :history helm-surfraw-engines-history)))
   (let* ((engine-nodesc (car (split-string engine)))
          (url (if (string= engine-nodesc "duckduckgo")
                   ;; "sr duckduckgo -p foo" is broken, workaround.


### PR DESCRIPTION
See https://emacs.stackexchange.com/questions/40601/call-helm-on-region for the request.

I also changed the prompt by following Emacs convenience.