### PR TITLE
Add a slash instead of a space when point is behind a directory

### DIFF
--- a/helm-eshell.el
+++ b/helm-eshell.el
@@ -299,7 +299,9 @@ The function that call this should set `helm-ec-target' to thing at point."
                        (and del-space (looking-back "\\s-" (1- (point)))
                             (delete-char -1))
                        (if (and (null helm-eshell--quit-flag)
-                                (looking-back "[.]\\{1,2\\}\\'" (1- (point))))
+                                (and (stringp last) (file-directory-p last))
+                                (looking-back "\\([.]\\{1,2\\}\\|[^/]\\)\\'"
+                                              (1- (point))))
                            (prog1 t (insert "/"))
                          ;; We need another flag for space here, but
                          ;; global to pass it to `helm-quit-hook', this
@@ -308,7 +310,10 @@ The function that call this should set `helm-ec-target' to thing at point."
                          ;; more completion, see issue #1832.
                          (unless (or helm-eshell--quit-flag
                                      (looking-back "/\\'" (1- (point))))
-                           (prog1 t (insert " ")))))
+                           (prog1 t (insert " ")))
+                         (when (and helm-eshell--quit-flag
+                                    (string-match-p "[.]\\{2\\}\\'" last))
+                           (insert "/"))))
                  (remove-hook 'helm-quit-hook 'helm-eshell--quit-hook-fn)
                  (setq helm-eshell--quit-flag nil)))))))
 


### PR DESCRIPTION
Pressing <tab> when point is behind a directory that does not contain
a / will result in a space being added. If the user wanted to continue
tabbing they would need to backspace, type a / and then they can
continue pressing / for completions.

This is different behaviour to what one might encounter in other
shells or in eshell with the default completion. This change
reintroduces that behaviour by adding a / instead of a space.

For example, taking _ to be point, pressing tab in the following situation:
`` cd /directory_ ``
will result in:
`` cd /directory<space>_``

This can interrupt a user's flow when they wanted to continue specifying either files or directories after the directory name. Continuing on the above example, this change results in the following behaviour:
``cd /directory/_``

The user is then free to continue pressing tab to bring up new completions. 

I see that there have been issues in the past with completions and slashes, especially related to . and .. (issue #1832). I've tested and it looks to me like this change doesn't introduce any regressions for that issue. I could not, however, find an automated to test this. If you have suggestions regarding that, or this change does break any other behaviour please let me know.

My elisp is not that strong so I'm open to any suggestions you have regarding this or if there is a better way to do this. Since this also changes behaviour users might be used to, or like, I'm also unsure if this change is better served with a variable that can enable/disable the new behaviour.