### PR TITLE
changed: helm-boring-file-regexp-list: do not ignore .gitconfig closed #2009

### DIFF
--- a/helm-lib.el
+++ b/helm-lib.el
@@ -94,19 +94,14 @@ much more convenient to use a simple boolean value here."
               (if (string-match-p "[^/]$" f)
                   ;; files: e.g .o => \\.o$
                   (concat rgx "$")
-                ;; directories: e.g .git/ => \\.git/?
-                (concat rgx "?"))))
+                ;; directories: e.g .git/ => \.git\\(/\\|$\\)
+                (concat (substring rgx 0 -1) "\\(/\\|$\\)"))))
           completion-ignored-extensions)
   "A list of regexps matching boring files.
 
 This list is build by default on `completion-ignored-extensions'.
 The directory names should end with \"/?\" e.g. \"\\.git/?\" and the
 file names should end with \"$\" e.g. \"\\.o$\".
-
-To forbid directories but allow filenames with same prefix e.g. forbid
-\".git\" directories but allow \".gitignore\", you can specify the
-both in list like \"\\.git/\" and \"\\.git$\" to be sure it works both
-in `helm-find-files' and other file tools like locate.
 
 These regexps may be used to match the entire path, not just the file
 name, so for example to ignore files with a prefix \".bak.\", use


### PR DESCRIPTION
I changed regex for helm do not ignore .gitconfig.
And, helm ignore .git directory and .git child directory.