### PR TITLE
Fix issue that some regexps in `helm-boring-file-regexp-list` do not …

### DIFF
--- a/helm-files.el
+++ b/helm-files.el
@@ -2602,73 +2602,74 @@ Return candidates prefixed with basename of `helm-input' first."
 (defun helm-ff-filter-candidate-one-by-one (file)
   "`filter-one-by-one' Transformer function for `helm-source-find-files'."
   ;; Handle boring files
-  (unless (and helm-ff-skip-boring-files
-               (helm-ff-boring-file-p file))
-    ;; Handle tramp files.
-    (if (and (or (string-match-p helm-tramp-file-name-regexp helm-pattern)
-                 (helm-file-on-mounted-network-p helm-pattern))
-             helm-ff-tramp-not-fancy)
-        (if helm-ff-transformer-show-only-basename
-            (if (helm-dir-is-dot file)
-                file
-              (cons (or (helm-ff--get-host-from-tramp-invalid-fname file)
-                        (helm-basename file))
-                    file))
-          file)
-      ;; Now highlight.
-      (let* ((disp (if (and helm-ff-transformer-show-only-basename
-                            (not (helm-dir-is-dot file))
-                            (not (and helm--url-regexp
-                                      (string-match helm--url-regexp file)))
-                            (not (string-match helm-ff-url-regexp file)))
-                       (or (helm-ff--get-host-from-tramp-invalid-fname file)
-                           (helm-basename file)) file))
-             (attr (file-attributes file))
-             (type (car attr)))
+  (let ((basename (helm-basename file)))
+    (unless (and helm-ff-skip-boring-files
+                 (helm-ff-boring-file-p basename))
+      ;; Handle tramp files.
+      (if (and (or (string-match-p helm-tramp-file-name-regexp helm-pattern)
+                   (helm-file-on-mounted-network-p helm-pattern))
+               helm-ff-tramp-not-fancy)
+          (if helm-ff-transformer-show-only-basename
+              (if (helm-dir-is-dot file)
+                  file
+                (cons (or (helm-ff--get-host-from-tramp-invalid-fname file)
+                          basename)
+                      file))
+            file)
+        ;; Now highlight.
+        (let* ((disp (if (and helm-ff-transformer-show-only-basename
+                              (not (helm-dir-is-dot file))
+                              (not (and helm--url-regexp
+                                        (string-match helm--url-regexp file)))
+                              (not (string-match helm-ff-url-regexp file)))
+                         (or (helm-ff--get-host-from-tramp-invalid-fname file)
+                             basename) file))
+               (attr (file-attributes file))
+               (type (car attr)))
 
-        (cond ((string-match "file-error" file) file)
-              ( ;; A not already saved file.
-               (and (stringp type)
-                    (not (helm-ff-valid-symlink-p file))
-                    (not (string-match "^\.#" (helm-basename file))))
-               (cons (helm-ff-prefix-filename
-                      (propertize disp 'face 'helm-ff-invalid-symlink) t)
-                     file))
-              ;; A dotted directory symlinked.
-              ((and (helm-ff-dot-file-p file) (stringp type))
-               (cons (helm-ff-prefix-filename
-                      (propertize disp 'face 'helm-ff-dotted-symlink-directory) t)
-                     file))
-              ;; A dotted directory.
-              ((helm-ff-dot-file-p file)
-               (cons (helm-ff-prefix-filename
-                      (propertize disp 'face 'helm-ff-dotted-directory) t)
-                     file))
-              ;; A symlink.
-              ((stringp type)
-               (cons (helm-ff-prefix-filename
-                      (propertize disp 'face 'helm-ff-symlink) t)
-                     file))
-              ;; A directory.
-              ((eq t type)
-               (cons (helm-ff-prefix-filename
-                      (propertize disp 'face 'helm-ff-directory) t)
-                     file))
-              ;; An executable file.
-              ((and attr (string-match "x" (nth 8 attr)))
-               (cons (helm-ff-prefix-filename
-                      (propertize disp 'face 'helm-ff-executable) t)
-                     file))
-              ;; A file.
-              ((and attr (null type))
-               (cons (helm-ff-prefix-filename
-                      (propertize disp 'face 'helm-ff-file) t)
-                     file))
-              ;; A non--existing file.
-              (t
-               (cons (helm-ff-prefix-filename
-                      (propertize disp 'face 'helm-ff-file) nil 'new-file)
-                     file)))))))
+          (cond ((string-match "file-error" file) file)
+                ( ;; A not already saved file.
+                 (and (stringp type)
+                      (not (helm-ff-valid-symlink-p file))
+                      (not (string-match "^\.#" basename)))
+                 (cons (helm-ff-prefix-filename
+                        (propertize disp 'face 'helm-ff-invalid-symlink) t)
+                       file))
+                ;; A dotted directory symlinked.
+                ((and (helm-ff-dot-file-p file) (stringp type))
+                 (cons (helm-ff-prefix-filename
+                        (propertize disp 'face 'helm-ff-dotted-symlink-directory) t)
+                       file))
+                ;; A dotted directory.
+                ((helm-ff-dot-file-p file)
+                 (cons (helm-ff-prefix-filename
+                        (propertize disp 'face 'helm-ff-dotted-directory) t)
+                       file))
+                ;; A symlink.
+                ((stringp type)
+                 (cons (helm-ff-prefix-filename
+                        (propertize disp 'face 'helm-ff-symlink) t)
+                       file))
+                ;; A directory.
+                ((eq t type)
+                 (cons (helm-ff-prefix-filename
+                        (propertize disp 'face 'helm-ff-directory) t)
+                       file))
+                ;; An executable file.
+                ((and attr (string-match "x" (nth 8 attr)))
+                 (cons (helm-ff-prefix-filename
+                        (propertize disp 'face 'helm-ff-executable) t)
+                       file))
+                ;; A file.
+                ((and attr (null type))
+                 (cons (helm-ff-prefix-filename
+                        (propertize disp 'face 'helm-ff-file) t)
+                       file))
+                ;; A non--existing file.
+                (t
+                 (cons (helm-ff-prefix-filename
+                        (propertize disp 'face 'helm-ff-file) nil 'new-file)
+                       file))))))))
 
 (defun helm-find-files-action-transformer (actions candidate)
   "Action transformer for `helm-source-find-files'."


### PR DESCRIPTION
…take effect

Fix #2017

```diff
└⋊> git show -w -U0
...
diff --git a/helm-files.el b/helm-files.el
index 41f29597..802e8269 100644
--- a/helm-files.el
+++ b/helm-files.el
@@ -2604,0 +2605 @@ Return candidates prefixed with basename of `helm-input' first."
+  (let ((basename (helm-basename file)))
@@ -2606 +2607 @@ Return candidates prefixed with basename of `helm-input' first."
-               (helm-ff-boring-file-p file))
+                 (helm-ff-boring-file-p basename))
@@ -2615 +2616 @@ Return candidates prefixed with basename of `helm-input' first."
-                        (helm-basename file))
+                          basename)
@@ -2625 +2626 @@ Return candidates prefixed with basename of `helm-input' first."
-                           (helm-basename file)) file))
+                             basename) file))
@@ -2633 +2634 @@ Return candidates prefixed with basename of `helm-input' first."
-                    (not (string-match "^\.#" (helm-basename file))))
+                      (not (string-match "^\.#" basename)))
@@ -2671 +2672 @@ Return candidates prefixed with basename of `helm-input' first."
-                     file)))))))
+                       file))))))))
```