### PR TITLE
helm-grep.el: Only add tramp prefix to fname when needed

### DIFF
--- a/helm-grep.el
+++ b/helm-grep.el
@@ -604,7 +604,7 @@ WHERE can be one of other-window, other-frame."
          (tramp-host   (file-remote-p (or helm-ff-default-directory
                                           default-directory) 'host))
          (tramp-prefix (concat "/" tramp-method ":" tramp-host ":"))
-         (fname        (if tramp-host
+         (fname        (if (and tramp-host (not (file-remote-p loc-fname)))
                            (concat tramp-prefix loc-fname) loc-fname)))
     (cl-case where
       (other-window (helm-window-show-buffers


### PR DESCRIPTION
When using helm-projectile-grep over tramp, the tramp prefix is added
twice to the candidate path. See: bbatsov/helm-projectile#76

In the function helm-grep-action, only add the tramp prefix to the fname if
it does not already include it.