### PR TITLE
Delete helm-documentation-file variable

### DIFF
--- a/helm-help.el
+++ b/helm-help.el
@@ -30,11 +30,6 @@
   '((t :inherit helm-header))
   "Face for Helm help string in minibuffer."
   :group 'helm-help)
-
-(defcustom helm-documentation-file "~/.emacs.d/helm-doc.org"
-  "The file where to save Helm documentation."
-  :group 'helm-help
-  :type 'string)
 
 (defvar helm-help--string-list '(helm-help-message
                                  helm-buffer-help-message


### PR DESCRIPTION
Commit 230f82c7db201297f4c5a73ef15302542803c646 deleted all references to the `helm-documentation-file` variable but did not delete the variable itself.

* `helm-help.el` (`helm-documentation-file`): Delete it.

---

Looking at history, it does not look like you have not been using `make-obsolete-variable` when a variable is deleted (as opposed to renamed), but if you would prefer to use `make-obsolete-variable` in this situation, I would be happy to modify the PR accordingly.