### PR TITLE
Split helm-window to display PA (#2050)

### DIFF
--- a/helm-buffers.el
+++ b/helm-buffers.el
@@ -907,7 +907,11 @@ If a prefix arg is given split windows vertically."
             (eql current (get-buffer helm-current-buffer))
             (not (eql current (get-buffer candidate))))
         (switch-to-buffer candidate)
-        (switch-to-buffer helm-current-buffer))))
+      (if (and helm-persistent-action-display-window
+               (window-dedicated-p
+                (next-window helm-persistent-action-display-window 1)))
+          (delete-window helm-persistent-action-display-window)
+        (switch-to-buffer helm-current-buffer)))))
 
 (defun helm-ediff-marked-buffers (_candidate &optional merge)
   "Ediff 2 marked buffers or CANDIDATE and `helm-current-buffer'.

--- a/helm-files.el
+++ b/helm-files.el
@@ -2577,7 +2577,10 @@ in `helm-find-files-persistent-action-if'."
            (message "Can't kill modified buffer, please save it before"))
           ((and buf win)
            (kill-buffer buf)
-           (set-window-buffer win helm-current-buffer)
+           (if (and helm-persistent-action-display-window
+                    (window-dedicated-p (next-window win 1)))
+               (delete-window helm-persistent-action-display-window)
+             (set-window-buffer win helm-current-buffer))
            (message "Buffer `%s' killed" buf-name))
           (t (find-file candidate)))))
 

--- a/helm.el
+++ b/helm.el
@@ -6068,14 +6068,17 @@ If SPLIT-ONEWINDOW is non-`nil' window is split in persistent action."
                   ((and helm--buffer-in-new-frame-p helm-initial-frame)
                    (with-selected-frame helm-initial-frame (selected-window)))
                   (split-onewindow (split-window))
-                  ;; Fix Issue #2050 with dedicatd window.
-                  ((window-dedicated-p
-                    (setq cur-win (get-buffer-window helm-current-buffer)))
-                   (split-window cur-win))
-                  (cur-win)
+                  ;; Fix Issue #2050 with dedicated window.
                   ((window-dedicated-p
                     (setq next-win (next-window (selected-window) 1)))
-                   (split-window next-win))
+                   (with-helm-after-update-hook
+                     (and (window-live-p helm-persistent-action-display-window)
+                          (delete-window helm-persistent-action-display-window)))
+                   (split-window))
+                  ((window-dedicated-p
+                    (setq cur-win (get-buffer-window helm-current-buffer)))
+                   (split-window))
+                  (cur-win)
                   (t next-win))))))
 
 (defun helm-select-persistent-action-window (&optional split-onewindow)


### PR DESCRIPTION
and delete PA window on update, makes the PA themselves for
buffers and files deleting the window when removing the candidate
preview.

* helm-buffers.el (helm-buffers-list-persistent-action): Do it.
* helm-files.el (helm-ff-kill-or-find-buffer-fname):     Do it.
* helm.el (helm-persistent-action-display-window):       Do it.