### PR TITLE
Fix delete macro from helm-execute-kmacro.

### DIFF
--- a/helm-ring.el
+++ b/helm-ring.el
@@ -155,7 +155,7 @@ use `helm-kill-ring-separator' as default."
      (cl-loop for c in (butlast marked)
               concat (concat c sep) into str
               finally return (concat str (car (last marked)))))))
-  
+
 (defun helm-kill-ring-action-yank-1 (str)
   "Insert STR in `kill-ring' and set STR to the head.
 
@@ -535,6 +535,7 @@ This command is useful when used with persistent action."
 
 (defun helm-kbd-macro-delete-macro (_candidate)
   (let ((mkd (helm-marked-candidates)))
+    (kmacro-push-ring)
     (cl-loop for km in mkd
              do (setq kmacro-ring (delete km kmacro-ring)))
     (kmacro-pop-ring1)))


### PR DESCRIPTION
This is fox for issue #2058.
`(kmacro-push-ring)` was missed so we were losing macro on top of the list when we delete the other macro from helm-execute-kmacro. 

I tested this on Emacs 26.1 and  Emacs 25.3.

Thanks a lot.