### PR TITLE
Fix helm-org--get-candidates-in-file for the when it is given a buffe…

### DIFF
--- a/helm-org.el
+++ b/helm-org.el
@@ -221,7 +221,7 @@ nothing to CANDIDATES."
           (search-fn (lambda ()
                        (re-search-forward
                         org-complex-heading-regexp nil t)))
-          (file (unless nofname
+          (file (unless (or (bufferp filename) nofname)
                   (concat (helm-basename filename) ":"))))
       (when parents
         (add-function :around (var search-fn)


### PR DESCRIPTION
…r instead of a filename

`helm-documentation` builds a buffer in org-mode that is not associated with a file. Currently, when `helm-org-show-filename` is non-nil, this generates an error. The pull request fixes that.