### PR TITLE
fix bug where adaptive history is invalid

### DIFF
--- a/helm-adaptive.el
+++ b/helm-adaptive.el
@@ -179,8 +179,9 @@ Returns nil if `helm-adaptive-history-file' doesn't exist."
       (insert
        ";; -*- mode: emacs-lisp -*-\n"
        ";; History entries used for helm adaptive display.\n")
-      (prin1 `(setq helm-adaptive-history ',helm-adaptive-history)
-             (current-buffer))
+      (let (print-length print-level)
+        (prin1 `(setq helm-adaptive-history ',helm-adaptive-history)
+               (current-buffer)))
       (insert ?\n)
       (write-region (point-min) (point-max) helm-adaptive-history-file nil
                     (unless arg 'quiet)))))


### PR DESCRIPTION
The variables `print-length` and `print-level` control the amount of a sexp that is printed before it is truncated. If `nil`, these variables will let sexp be printed of any length. However if one of them is set to a value and helm-adaptive history is saved, then there is a chance that the output file will have a truncated sexp with invalid `...` symbols. This will cause helm to error when it tries to read `helm-adaptive-history-file`. So we bind these variables to nil before calling `prin1` so that the output will never be truncated. 