### PR TITLE
WIP: Set inhibit-quit when creating a process

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -3484,9 +3484,9 @@ WARNING: Do not use this mode yourself, it is internal to helm."
 
 (defun helm-get-candidates (source)
   "Retrieve and return the list of candidates from SOURCE."
-  (let* (inhibit-quit
-         (candidate-fn (assoc-default 'candidates source))
+  (let* ((candidate-fn (assoc-default 'candidates source))
          (candidate-proc (assoc-default 'candidates-process source))
+         (inhibit-quit candidate-proc)
          cfn-error
          (notify-error
           (lambda (&optional e)
@@ -3547,7 +3547,8 @@ WARNING: Do not use this mode yourself, it is internal to helm."
   "Return the cached value of candidates for SOURCE.
 Cache the candidates if there is no cached value yet."
   (let* ((name (assoc-default 'name source))
-         (candidate-cache (gethash name helm-candidate-cache)))
+         (candidate-cache (gethash name helm-candidate-cache))
+         (inhibit-quit (assoc-default 'candidates-process source)))
     (helm-aif candidate-cache
         (prog1 it (helm-log "Use cached candidates"))
       (helm-log "No cached candidates, calculate candidates")


### PR DESCRIPTION
WIP only because I'm not very familiar with helm, so I'm looking for feedback.

This prevents processes from being leaked by ensuring they are added to
helm-async-processes before inhibit-quit is cleared.

Repro steps:
- install cygwin emacs-w32 (tested with 26.1)
- install `helm-ag` and `helm`
- `emacs -q --eval "(progn (package-initialize)(helm-do-ag))"`
- on the 'search in files' prompt select a directory where ag will take a long time to complete
- on the 'pattern' prompt, hold down the 'a' key to continually change the pattern
- C-g
- C-x C-c

Depending on timing, emacs should prompt you to kill a whole bunch of leaked child processes.

This seems to happen because the candidates proc is being called inside `helm-while-no-input`, and emacs is quitting with input events between when the process is created, and when it's added to the async process list.  The way input is signalled is a bit different on win32, so it might not happen on other platforms.