### PR TITLE
Follow redirects since google returns 301 Moved

### DIFF
--- a/helm-net.el
+++ b/helm-net.el
@@ -175,7 +175,7 @@ Can be \"-new-tab\" (default) or \"-new-window\"."
 (defun helm-net--url-retrieve-sync (request parser)
   (if helm-net-prefer-curl
       (with-temp-buffer
-        (call-process "curl" nil t nil request)
+        (call-process "curl" nil t nil request "-L")
         (funcall parser))
       (with-current-buffer (url-retrieve-synchronously request)
         (funcall parser))))


### PR DESCRIPTION
I was trying helm-google-suggest with curl enabled.
And came across an error:
```(error \"XML: (Not Well-Formed) Invalid end tag ‘HEAD’ (expecting ‘meta’)\")")```.
It turned out that Google returned 301 status.
```
#<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
#<TITLE>301 Moved</TITLE></HEAD><BODY>
#<H1>301 Moved</H1>
#The document has moved
#<A HREF="http://www.google.com/">here</A>.
#</BODY></HTML>
```

