### PR TITLE
Fix window selection with multiple side windows

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -6209,7 +6209,7 @@ window to maintain visibility."
   "Return the window that will be used for persistent action.
 If SPLIT-ONEWINDOW is non-`nil' window is split in persistent action."
   (with-helm-window
-    (let (next-win cur-win)
+    (let (prev-win cur-win)
       (setq helm-persistent-action-display-window
             (cond ((and (window-live-p helm-persistent-action-display-window)
                         (not (member helm-persistent-action-display-window
@@ -6220,7 +6220,7 @@ If SPLIT-ONEWINDOW is non-`nil' window is split in persistent action."
                   (split-onewindow (split-window))
                   ;; Fix Issue #2050 with dedicated window.
                   ((window-dedicated-p
-                    (setq next-win (next-window (selected-window) 1)))
+                    (setq prev-win (previous-window (selected-window) 1)))
                    (with-helm-after-update-hook
                      (and (window-live-p helm-persistent-action-display-window)
                           (delete-window helm-persistent-action-display-window)))
@@ -6229,7 +6229,7 @@ If SPLIT-ONEWINDOW is non-`nil' window is split in persistent action."
                     (setq cur-win (get-buffer-window helm-current-buffer)))
                    (split-window))
                   (cur-win)
-                  (t next-win))))))
+                  (t prev-win))))))
 
 (defun helm-select-persistent-action-window (&optional split-onewindow)
   "Select the window that will be used for persistent action.


### PR DESCRIPTION
While trying to debug the follwing issues:
- https://github.com/emacs-helm/helm/issues/2120
- https://github.com/syl20bnr/spacemacs/issues/11368

Having:
```
(helm-default-display-buffer-functions '(display-buffer-in-side-window))
```
I ended up in the `helm-persistent-action-display-window` function.

When no other side windows exist here is the list of windows:
```
(window-list): (#<window 8 on *helm find files*> #<window 2 on  *Minibuf-1*> #<window 1 on *Messages*>)
(selected-window): #<window 8 on *helm find files*>
(next-window (selected-window) 1): #<window 1 on *Messages*>
(previous-window (selected-window) 1): #<window 1 on *Messages*>
```

When a side window already exists, for example treemacs:
```
(window-list): (#<window 12 on *helm find files*> #<window 2 on  *Minibuf-1*> #<window 10 on  *Treemacs-Framebuffer-1*> #<window 1 on *Messages*>)
(selected-window): #<window 12 on *helm find files*>
(next-window (selected-window) 1): #<window 10 on  *Treemacs-Framebuffer-1*>
(previous-window (selected-window) 1): #<window 1 on *Messages*>
```

Notice the treemacs window is right after the selected window, not
including the minibuffer, and the window we actually want to check if
it's dedicated or not (window 1) is right at the end.

Using the `previous-window` instead of `next-window` ensures that we
indeed get to check the window we care about (window 1). In the first
place it happend to be the case that both functions returned the same
(correct) value. Also `previous-window` makes sense since `window-list`
behaves like a ring and switching from a normal window to a helm window
means the normal window gets "left behind" in the previous position
while the "next window" would be whatever window was ever touched last.