### PR TITLE
Make helm-mark-all-1 return candidates with their properties

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -6420,7 +6420,9 @@ is not needed."
                    (while (< (point) maxpoint)
                      (helm-mark-current-line)
                      (let* ((prefix (get-text-property (point-at-bol) 'display))
-                            (cand   (helm-get-selection nil nil src))
+                            (cand   (helm-get-selection
+                                     nil (helm-attr 'marked-with-props src)
+                                     src))
                             (bn     (and filecomp-p (helm-basename cand))))
                        ;; Don't mark possibles directories ending with . or ..
                        ;; autosave files/links and non--existent files.


### PR DESCRIPTION
`helm-mark-all-1` returns the candidates without their properties even if requested by the source. This pull request fix this issue