### PR TITLE
Remove trailing whitespace(s)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@
 # Emacs invocation
 EMACS_COMMAND   := emacs
 
-# Use -q to have /usr/local/share/emacs/site-lisp and subdirs in load-path 
+# Use -q to have /usr/local/share/emacs/site-lisp and subdirs in load-path
 EMACS		:= $(EMACS_COMMAND) -q -batch
 
 EVAL := $(EMACS) --eval

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
   Thanks to all the people that are helping or have helped Helm development,<br>
   but they are actually too few to continue serenely.<br>
   By the way, after the release of version 3.0 I will have to stop<br>
-  developing Helm seriously until I get enough financial support,<br> 
+  developing Helm seriously until I get enough financial support,<br>
   only providing a minimal bugfix maintenance.<br>
   Thanks for your understanding<br>
   If you feel Helm is making your daily work easier,<br>

--- a/helm-bookmark.el
+++ b/helm-bookmark.el
@@ -245,7 +245,7 @@ BOOKMARK is a bookmark name or a bookmark record."
 BOOKMARK is a bookmark name or a bookmark record.
 This excludes bookmarks of a more specific kind (Info, Gnus, and W3m)."
   (let* ((filename   (bookmark-get-filename bookmark))
-         (isnonfile  (equal filename helm-bookmark--non-file-filename))) 
+         (isnonfile  (equal filename helm-bookmark--non-file-filename)))
     (and filename (not isnonfile) (not (bookmark-get-handler bookmark)))))
 
 (defun helm-bookmark-org-file-p (bookmark)

--- a/helm-dabbrev.el
+++ b/helm-dabbrev.el
@@ -60,7 +60,7 @@ When nil all buffers are considered related to `current-buffer'."
   :group 'helm-dabbrev
   :type 'function)
 
-(defcustom helm-dabbrev-major-mode-assoc nil 
+(defcustom helm-dabbrev-major-mode-assoc nil
   "Major mode association alist.
 This allow helm-dabbrev searching in buffers with the associated `major-mode'.
 e.g \(emacs-lisp-mode . lisp-interaction-mode\)
@@ -118,7 +118,7 @@ to use this."
 (defvaralias 'helm-dabbrev--regexp 'helm-dabbrev-separator-regexp)
 (make-obsolete-variable 'helm-dabbrev--regexp
                         'helm-dabbrev-separator-regexp "2.8.3")
-;; Check for beginning of line should happen last (^\n\\|^). 
+;; Check for beginning of line should happen last (^\n\\|^).
 (defvar helm-dabbrev-separator-regexp
   "\\s-\\|\t\\|[(\\[\\{\"'`=<$;,@.#+]\\|\\s\\\\|^\n\\|^"
   "Regexp matching the start of a dabbrev candidate.")
@@ -222,7 +222,7 @@ The search starts at (1- BEG) with a regexp starting with
 regexp matching syntactically any word or symbol.
 The possible false positives matching SEP-REGEXP at end are finally
 removed."
-  (let ((eol (point-at-eol))) 
+  (let ((eol (point-at-eol)))
     (save-excursion
       (goto-char (1- beg))
       (when (re-search-forward
@@ -353,7 +353,7 @@ removed."
                      (thread-alive-p helm-dabbrev--current-thread))
             (thread-join helm-dabbrev--current-thread))
           (when (and (null cycling-disabled-p) only-one)
-            (cl-return-from helm-dabbrev 
+            (cl-return-from helm-dabbrev
               (message "[Helm-dabbrev: No expansion found]")))
           (with-helm-show-completion (car limits) (cdr limits)
             (unwind-protect

--- a/helm-elisp-package.el
+++ b/helm-elisp-package.el
@@ -69,7 +69,7 @@
                  ;; properly (empty buffer) when called from lisp
                  ;; with 'no-fetch (emacs-25 WA).
                  (package-show-package-list)
-               (when helm--force-updating-p (message "Refreshing packages list..."))  
+               (when helm--force-updating-p (message "Refreshing packages list..."))
                (list-packages helm-el-package--initialized-p))
              (setq helm-el-package--initialized-p t)
              (message nil))
@@ -404,7 +404,7 @@
 (defun helm-el-package-recompile (_pkg)
   (cl-loop for p in (helm-marked-candidates)
            for pkg-desc = (get-text-property 0 'tabulated-list-id p)
-           for name = (package-desc-name pkg-desc) 
+           for name = (package-desc-name pkg-desc)
            for dir = (package-desc-dir pkg-desc)
            do (if (fboundp 'async-byte-recompile-directory)
                   (async-byte-recompile-directory dir)

--- a/helm-eval.el
+++ b/helm-eval.el
@@ -48,9 +48,9 @@ Should take one arg: the string to display."
     (cl-loop for (f . a) in '((eldoc-current-symbol .
                                elisp--current-symbol)
                               (eldoc-fnsym-in-current-sexp .
-                               elisp--fnsym-in-current-sexp) 
+                               elisp--fnsym-in-current-sexp)
                               (eldoc-get-fnsym-args-string .
-                               elisp-get-fnsym-args-string) 
+                               elisp-get-fnsym-args-string)
                               (eldoc-get-var-docstring .
                                elisp-get-var-docstring))
              unless (fboundp f)
@@ -173,7 +173,7 @@ Should take one arg: the string to display."
 (defvar eldoc-idle-delay)
 ;;;###autoload
 (defun helm-eval-expression-with-eldoc ()
-  "Preconfigured helm for `helm-source-evaluation-result' with `eldoc' support. "
+  "Preconfigured helm for `helm-source-evaluation-result' with `eldoc' support."
   (interactive)
   (let ((timer (run-with-idle-timer
                 eldoc-idle-delay 'repeat

--- a/helm-external.el
+++ b/helm-external.el
@@ -24,7 +24,7 @@
 
 
 (defgroup helm-external nil
-  "External related Applications and libraries for Helm." 
+  "External related Applications and libraries for Helm."
   :group 'helm)
 
 (defcustom helm-raise-command nil

--- a/helm-files.el
+++ b/helm-files.el
@@ -3599,7 +3599,7 @@ is helm-source-find-files."
         ;; "/", e.g. at a beginning of a patch (first bug) and make
         ;; `file-remote-p' returning an error (second bug), so in such
         ;; case returns the region itself instead of the region
-        ;; corrupted by ffap. 
+        ;; corrupted by ffap.
         (if (and str ffap) str ffap)))))
 
 (defun helm-find-files-input (file-at-pt thing-at-pt)

--- a/helm-grep.el
+++ b/helm-grep.el
@@ -1237,7 +1237,7 @@ in recurse, and ignore EXTS, search being made recursively on files matching
                                (> (- (setq end (match-end 0))
                                      (setq beg (match-beginning 0))) 0))
                      (helm-add-face-text-properties beg end 'helm-grep-match))
-                   do (goto-char (point-min))) 
+                   do (goto-char (point-min)))
           (buffer-string))
       (error nil))))
 

--- a/helm-help.el
+++ b/helm-help.el
@@ -760,7 +760,7 @@ For this you can use `helm-list-dir-external' as value
 for `helm-list-directory-function'.
 
 See `helm-list-directory-function' documentation for more infos.
- 
+
 **** Completing host
 
 As soon as you enter the first \":\" after method e.g =/scp:= you will
@@ -957,7 +957,7 @@ with trash-list until you log in as root.
   (let ((name (if helm-alive-p
                   (assoc-default 'name (helm-get-current-source))
                 "generic")))
-    (format 
+    (format
      "* Helm `%s' read file name completion
 
 This is `%s' read file name completion that have been \"helmized\"
@@ -1153,7 +1153,7 @@ M-x helm-popup-tip-mode.
 
 The command \\<helm-grep-map>\\[helm-grep-run-other-window-action] allow you to open file
 in other window horizontally or vertically if a prefix arg is supplied.
- 
+
 *** Performance over TRAMP
 
 Grepping works but it is badly supported as TRAMP doesn't support multiple

--- a/helm-id-utils.el
+++ b/helm-id-utils.el
@@ -61,7 +61,7 @@ MacPorts to install id-utils, it should be `gid32'."
                         '(" " mode-line-buffer-identification " "
                           (:eval (format "L%s" (helm-candidate-number-at-point))) " "
                           (:eval (propertize
-                                  (format "[Helm Gid process finished - (%s results)]" 
+                                  (format "[Helm Gid process finished - (%s results)]"
                                           (max (1- (count-lines
                                                     (point-min) (point-max)))
                                                0))

--- a/helm-imenu.el
+++ b/helm-imenu.el
@@ -203,7 +203,7 @@ Each car is a regexp match pattern of the imenu type string."
           helm-cached-imenu-candidates
         (setq imenu--index-alist nil)
         (prog1 (setq helm-cached-imenu-candidates
-                     (let ((index (imenu--make-index-alist t))) 
+                     (let ((index (imenu--make-index-alist t)))
                        (helm-imenu--candidates-1
                         (delete (assoc "*Rescan*" index) index))))
           (setq helm-cached-imenu-tick tick))))))

--- a/helm-lib.el
+++ b/helm-lib.el
@@ -1032,7 +1032,7 @@ Argument ALIST is an alist of associated major modes."
   ;; to determine if its `major-mode' is:
   ;; - same as the `cur-maj-mode'
   ;; - derived from `cur-maj-mode' and from
-  ;;   START-BUFFER if its mode is derived from the one in START-BUFFER. 
+  ;;   START-BUFFER if its mode is derived from the one in START-BUFFER.
   ;; - have an assoc entry (major-mode . cur-maj-mode)
   ;; - have an rassoc entry (cur-maj-mode . major-mode)
   ;; - check if one of these entries inherit from another one in

--- a/helm-misc.el
+++ b/helm-misc.el
@@ -136,7 +136,7 @@
   (cl-loop for i in candidates
            for (z . p) in display-time-world-list
            collect
-           (cons 
+           (cons
             (cond ((string-match (format-time-string "%H:%M" (current-time)) i)
                    (propertize i 'face 'helm-time-zone-current))
                   ((string-match helm-time-zone-home-location i)

--- a/helm-mode.el
+++ b/helm-mode.el
@@ -64,7 +64,7 @@ provide helm completion in each `completing-read' or `read-file-name'
 found, but other functions can be specified here for specific
 commands. This also allow disabling helm completion for some commands
 when needed.
- 
+
 Each entry is a cons cell like (EMACS_COMMAND . COMPLETING-READ_HANDLER)
 where key and value are symbols.
 
@@ -106,7 +106,7 @@ Example:
 
 We want here to make the regular `completing-read' in `foo/test'
 returns a list of candidate(s) instead of a single candidate.
- 
+
 Note that this function will be reused for ALL the `completing-read'
 of this command, so it should handle all cases, e.g
 If first `completing-read' complete against symbols and
@@ -903,7 +903,7 @@ See documentation of `completing-read' and `all-completions' for details."
                 def-com
                 (apply def-com def-args))
                (;; Use by default a in-buffer handler unless
-                ;; COLLECTION is a function. 
+                ;; COLLECTION is a function.
                 t
                 (funcall default-handler
                          prompt collection predicate require-match

--- a/helm-net.el
+++ b/helm-net.el
@@ -352,7 +352,7 @@ Follows any redirections from Wikipedia, and stores results in
           (when (or (string-match "</table>\\(\n<div.*?</div>\\)?\n<p>" result)
                     ;; otherwise just find the first paragraph
                     (string-match "<p>" result))
-            ;; remove cruft and do a simple formatting 
+            ;; remove cruft and do a simple formatting
             (replace-regexp-in-string
              "Cite error: .*" ""
              (replace-regexp-in-string

--- a/helm-semantic.el
+++ b/helm-semantic.el
@@ -118,7 +118,7 @@ you have completion on these functions with `C-M i' in the customize interface."
   (with-current-buffer helm-buffer
     (when (looking-at " ")
       (goto-char (next-single-property-change
-                  (point-at-bol) 'semantic-tag nil (point-at-eol)))) 
+                  (point-at-bol) 'semantic-tag nil (point-at-eol))))
     (let ((tag (get-text-property (point) 'semantic-tag)))
       (semantic-go-to-tag tag)
       (unless persistent

--- a/helm.el
+++ b/helm.el
@@ -403,7 +403,7 @@ If no local value found and current command is not one of
 `helm-commands-using-frame' use this default value.
 Function in charge of deciding which value use is
 `helm-resolve-display-function'.
- 
+
 To set it locally to `helm-buffer' in helm sources use
 `helm-set-local-variable' in init function or use
 :display-function slot in `helm' call."
@@ -1960,7 +1960,7 @@ i.e functions called with RET."
     ;; If no helm based action run within 0.5 seconds, the next helm
     ;; session will have to resolve again those variable values.
     (run-with-idle-timer 0.5 nil
-      (lambda () (helm-set-local-variable 'helm-display-function nil 
+      (lambda () (helm-set-local-variable 'helm-display-function nil
                                           'helm--last-frame-parameters nil))))
   (helm-exit-minibuffer))
 
@@ -2024,7 +2024,7 @@ IOW Don't use VALUE of previous VAR to set the VALUE of next VAR.
            ;; the first on stack e.g.
            ;; (helm-set-local-variable 'helm-foo 1)
            ;; (helm-set-local-variable 'helm-foo 2)
-           ;; helm--local-variables => 
+           ;; helm--local-variables =>
            ;; '((helm-foo . 2) (helm-foo. 1))
            ;; (helm-foo . 2) is retained and (helm-foo . 1)
            ;; ignored.
@@ -2068,7 +2068,7 @@ candidates only.
 This function is used also to process functions called with no args,
 e.g. init functions, in this case it is called without ARGS.
 See `helm-process-filtered-candidate-transformer'
-\`helm-compute-attr-in-sources' and 
+\`helm-compute-attr-in-sources' and
 \`helm-process-candidate-transformer'.
 
 Arg FUNCTIONS is either a symbol or a list of functions, each function being
@@ -2637,7 +2637,7 @@ Don't use this directly, use instead `helm' with the keyword
           (orig-one-window-p helm-onewindow-p)
           (helm--nested t))
       ;; FIXME Using helm-full-frame here allow showing the new
-      ;; helm-buffer in the same window as old helm-buffer, why? 
+      ;; helm-buffer in the same window as old helm-buffer, why?
       (helm-set-local-variable 'helm-full-frame t)
       (unwind-protect
           (let (helm-current-position
@@ -4059,7 +4059,7 @@ It is used for narrowing list of candidates to the
       ;; candidates.
       ;; NOTE that this next block of code is returning nil on async sources,
       ;; the candidates being processed directly in `helm-output-filter'
-      ;; process-filter. 
+      ;; process-filter.
       (helm-process-filtered-candidate-transformer
        ;; Using in-buffer method or helm-pattern is empty
        ;; in this case compute all candidates.
@@ -5836,7 +5836,7 @@ Acceptable values of BUFFER-SPEC:
 
 - nil (omit)
   Only return the candidates buffer of current source if found.
-  
+
 - A buffer
   Register a buffer as a candidates buffer.
   The buffer needs to exists, it is not created.
@@ -5848,7 +5848,7 @@ Acceptable values of BUFFER-SPEC:
   The buffer is not erased nor deleted.
   Generally it is safer to use a copy of buffer inserted
   in a global or local buffer.
-  
+
 If for some reasons a global buffer and a local buffer exist and are
 belonging to the same source, the local buffer takes precedence on the
 global one and is used instead.


### PR DESCRIPTION
And one case of a whitespace before a closing double quote, the double quotes
are removed when helm-autoloads.el is generated.