### PR TITLE
Enable helm-shell-prompts in all comint-based modes (SLIME, Geiser)

### DIFF
--- a/helm-comint.el
+++ b/helm-comint.el
@@ -165,6 +165,33 @@ See `helm-comint-prompts-list'."
             :buffer "*helm comint all prompts*")
     (message "Current buffer is not a comint buffer")))
 
+;;; Comint history
+;;
+;;
+(defun helm-comint-input-ring-action (candidate)
+  "Default action for comint history."
+  (with-helm-current-buffer
+    (delete-region (comint-line-beginning-position) (point-max))
+    (insert candidate)))
+
+(defvar helm-source-comint-input-ring
+  (helm-build-sync-source "Comint history"
+    :candidates (lambda ()
+                  (with-helm-current-buffer
+                    (ring-elements comint-input-ring)))
+    :action 'helm-comint-input-ring-action)
+  "Source that provide helm completion against `comint-input-ring'.")
+
+;;;###autoload
+(defun helm-comint-input-ring ()
+  "Preconfigured `helm' that provide completion of `comint' history."
+  (interactive)
+  (when (derived-mode-p 'comint-mode)
+    (helm :sources 'helm-source-comint-input-ring
+          :input (buffer-substring-no-properties (comint-line-beginning-position)
+                                                 (point-at-eol))
+          :buffer "*helm comint history*")))
+
 (provide 'helm-comint)
 
 ;; Local Variables:

--- a/helm-comint.el
+++ b/helm-comint.el
@@ -1,0 +1,176 @@
+;;; helm-comint.el --- Comint prompt navigation for helm. -*- lexical-binding: t -*-
+
+;; Copyright (C) 2019 Pierre Neidhardt <mail@ambrevar.xyz>
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;; You can bind this as follows in .emacs:
+;;
+;; (add-hook 'comint-mode-hook
+;;           (lambda ()
+;;               (define-key comint-mode-map (kbd "M-s f") 'helm-comint-prompts-all)))
+
+;;; Code:
+(require 'cl-lib)
+(require 'helm)
+(require 'helm-lib)
+(require 'helm-help)
+(require 'helm-elisp)
+
+;;; Comint prompts
+;;
+(defface helm-comint-prompts-promptidx
+  '((t (:foreground "cyan")))
+  "Face used to highlight comint prompt index."
+  :group 'helm-comint-faces)
+
+(defface helm-comint-prompts-buffer-name
+  '((t (:foreground "green")))
+  "Face used to highlight comint buffer name."
+  :group 'helm-comint-faces)
+
+(defcustom helm-comint-prompts-promptidx-p t
+  "Show prompt number."
+  :group 'helm-comint
+  :type 'boolean)
+
+(defcustom helm-comint-mode-list '(comint-mode slime-repl-mode)
+  "Supported modes for prompt navigation.
+Derived modes (e.g. Geiser's REPL) are automatically supported."
+  :group 'helm-comint
+  :type '(repeat (choice symbol)))
+
+(defvar helm-comint-prompts-keymap
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map helm-map)
+    (define-key map (kbd "C-c o")   'helm-comint-prompts-other-window)
+    (define-key map (kbd "C-c C-o") 'helm-comint-prompts-other-frame)
+    map)
+  "Keymap for `helm-comint-prompt-all'.")
+
+(defun helm-comint-prompts-list (mode &optional buffer)
+  "List the prompts in BUFFER in mode MODE.
+
+Return a list of (\"prompt\" (point) (buffer-name) prompt-index))
+e.g. (\"ls\" 162 \"*shell*\" 3).
+If BUFFER is nil, use current buffer."
+  (with-current-buffer (or buffer (current-buffer))
+    (when (derived-mode-p mode)
+      (save-excursion
+        (goto-char (point-min))
+        (let (result (count 1))
+          (save-mark-and-excursion
+            (helm-awhile (and (not (eobp)) (comint-next-prompt 1))
+              (push (list (buffer-substring-no-properties
+                           it (point-at-eol))
+                          it (buffer-name) count)
+                    result)
+              (setq count (1+ count))))
+          (nreverse result))))))
+
+(defun helm-comint-prompts-list-all (mode)
+  "List the prompts of all buffers in mode MODE.
+See `helm-comint-prompts-list'."
+  (cl-loop for b in (buffer-list)
+           append (helm-comint-prompts-list mode b)))
+
+(defun helm-comint-prompts-transformer (candidates &optional all)
+  ;; ("ls" 162 "*shell*" 3) => ("*shell*:3:ls" . ("ls" 162 "*shell*" 3))
+  (cl-loop for (prt pos buf id) in candidates
+           collect `(,(concat
+                       (when all
+                         (concat (propertize
+                                  buf
+                                  'face 'helm-comint-prompts-buffer-name)
+                                 ":"))
+                       (when helm-comint-prompts-promptidx-p
+                         (concat (propertize
+                                  (number-to-string id)
+                                  'face 'helm-comint-prompts-promptidx)
+                                 ":"))
+                       prt)
+                      . ,(list prt pos buf id))))
+
+(defun helm-comint-prompts-all-transformer (candidates)
+  (helm-comint-prompts-transformer candidates t))
+
+(cl-defun helm-comint-prompts-goto (candidate &optional (action 'switch-to-buffer))
+  ;; Candidate format: ("ls" 162 "*shell*" 3)
+  (let ((buf (nth 2 candidate)))
+    (unless (and (string= (buffer-name) buf)
+                 (eq action 'switch-to-buffer))
+      (funcall action buf))
+    (goto-char (nth 1 candidate))
+    (recenter)))
+
+(defun helm-comint-prompts-goto-other-window (candidate)
+  (helm-comint-prompts-goto candidate 'switch-to-buffer-other-window))
+
+(defun helm-comint-prompts-goto-other-frame (candidate)
+  (helm-comint-prompts-goto candidate 'switch-to-buffer-other-frame))
+
+(defun helm-comint-prompts-other-window ()
+  (interactive)
+  (with-helm-alive-p
+    (helm-exit-and-execute-action 'helm-comint-prompts-goto-other-window)))
+(put 'helm-comint-prompts-other-window 'helm-only t)
+
+(defun helm-comint-prompts-other-frame ()
+  (interactive)
+  (with-helm-alive-p
+    (helm-exit-and-execute-action 'helm-comint-prompts-goto-other-frame)))
+(put 'helm-comint-prompts-other-frame 'helm-only t)
+
+;;;###autoload
+(defun helm-comint-prompts ()
+  "Pre-configured `helm' to browse the prompts of the current comint buffer."
+  (interactive)
+  (if (cl-member-if 'derived-mode-p helm-comint-mode-list)
+      (helm :sources
+            (helm-build-sync-source "Comint prompts"
+              :candidates (helm-comint-prompts-list major-mode)
+              :candidate-transformer 'helm-comint-prompts-transformer
+              :action '(("Go to prompt" . helm-comint-prompts-goto)))
+            :buffer "*helm comint prompts*")
+    (message "Current buffer is not a comint buffer")))
+
+;;;###autoload
+(defun helm-comint-prompts-all ()
+  "Pre-configured `helm' to browse the prompts of all comint sessions."
+  (interactive)
+  (if (cl-member-if 'derived-mode-p helm-comint-mode-list)
+      (helm :sources
+            (helm-build-sync-source "All comint prompts"
+              :candidates (helm-comint-prompts-list-all major-mode)
+              :candidate-transformer 'helm-comint-prompts-all-transformer
+              :action (quote (("Go to prompt" . helm-comint-prompts-goto)
+                              ("Go to prompt in other window `C-c o`" .
+                               helm-comint-prompts-goto-other-window)
+                              ("Go to prompt in other frame `C-c C-o`" .
+                               helm-comint-prompts-goto-other-frame)))
+              :keymap helm-comint-prompts-keymap)
+            :buffer "*helm comint all prompts*")
+    (message "Current buffer is not a comint buffer")))
+
+(provide 'helm-comint)
+
+;; Local Variables:
+;; byte-compile-warnings: (not obsolete)
+;; coding: utf-8
+;; indent-tabs-mode: nil
+;; End:
+
+;;; helm-comint.el ends here

--- a/helm-misc.el
+++ b/helm-misc.el
@@ -202,23 +202,6 @@ It is added to `extended-command-history'.
           (const :tag "Confirm" 'confirm)
           (const :tag "Always allow" nil)))
 
-;;; Shell history
-;;
-;;
-(defun helm-comint-input-ring-action (candidate)
-  "Default action for comint history."
-  (with-helm-current-buffer
-    (delete-region (comint-line-beginning-position) (point-max))
-    (insert candidate)))
-
-(defvar helm-source-comint-input-ring
-  (helm-build-sync-source "Comint history"
-    :candidates (lambda ()
-                  (with-helm-current-buffer
-                    (ring-elements comint-input-ring)))
-    :action 'helm-comint-input-ring-action)
-  "Source that provide helm completion against `comint-input-ring'.")
-
 
 ;;; Helm ratpoison UI
 ;;
@@ -338,17 +321,6 @@ Default action change TZ environment variable locally to emacs."
               elm))))
     (delete-minibuffer-contents)
     (insert elm)))
-
-;;;###autoload
-(defun helm-comint-input-ring ()
-  "Preconfigured `helm' that provide completion of `comint' history."
-  (interactive)
-  (when (derived-mode-p 'comint-mode)
-    (helm :sources 'helm-source-comint-input-ring
-          :input (buffer-substring-no-properties (comint-line-beginning-position)
-                                                 (point-at-eol))
-          :buffer "*helm comint history*")))
-
 
 (provide 'helm-misc)
 

--- a/helm-shell.el
+++ b/helm-shell.el
@@ -46,6 +46,12 @@
   :group 'helm-shell
   :type 'boolean)
 
+(defcustom helm-shell-comint-mode-list '(comint-mode slime-repl-mode)
+  "Supported modes for prompt navigation.
+Derived modes (e.g. Geiser's REPL) are automatically supported."
+  :group 'helm-shell
+  :type '(repeat (choice symbol)))
+
 (defvar helm-shell-prompts-keymap
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map helm-map)
@@ -54,16 +60,14 @@
     map)
   "Keymap for `helm-shell-prompt-all'.")
 
-(defvar shell-prompt-pattern)
-
-(defun helm-shell-prompts-list (&optional buffer)
-  "List the prompts in Shell BUFFER.
+(defun helm-shell-prompts-list (mode &optional buffer)
+  "List the prompts in BUFFER in mode MODE.
 
 Return a list of (\"prompt\" (point) (buffer-name) prompt-index))
 e.g. (\"ls\" 162 \"*shell*\" 3).
 If BUFFER is nil, use current buffer."
   (with-current-buffer (or buffer (current-buffer))
-    (when (eq major-mode 'shell-mode)
+    (when (derived-mode-p mode)
       (save-excursion
         (goto-char (point-min))
         (let (result (count 1))
@@ -76,11 +80,11 @@ If BUFFER is nil, use current buffer."
               (setq count (1+ count))))
           (nreverse result))))))
 
-(defun helm-shell-prompts-list-all ()
-  "List the prompts of all Shell buffers.
+(defun helm-shell-prompts-list-all (mode)
+  "List the prompts of all buffers in mode MODE.
 See `helm-shell-prompts-list'."
   (cl-loop for b in (buffer-list)
-           append (helm-shell-prompts-list b)))
+           append (helm-shell-prompts-list mode b)))
 
 (defun helm-shell-prompts-transformer (candidates &optional all)
   ;; ("ls" 162 "*shell*" 3) => ("*shell*:3:ls" . ("ls" 162 "*shell*" 3))
@@ -133,10 +137,10 @@ See `helm-shell-prompts-list'."
 (defun helm-shell-prompts ()
   "Pre-configured `helm' to browse the prompts of the current Shell."
   (interactive)
-  (if (eq major-mode 'shell-mode)
+  (if (cl-member-if 'derived-mode-p helm-shell-comint-mode-list)
       (helm :sources
             (helm-build-sync-source "Shell prompts"
-              :candidates (helm-shell-prompts-list)
+              :candidates (helm-shell-prompts-list major-mode)
               :candidate-transformer 'helm-shell-prompts-transformer
               :action '(("Go to prompt" . helm-shell-prompts-goto)))
             :buffer "*helm Shell prompts*")
@@ -146,17 +150,18 @@ See `helm-shell-prompts-list'."
 (defun helm-shell-prompts-all ()
   "Pre-configured `helm' to browse the prompts of all Shell sessions."
   (interactive)
-  (helm :sources
-        (helm-build-sync-source "All Shell prompts"
-          :candidates (helm-shell-prompts-list-all)
-          :candidate-transformer 'helm-shell-prompts-all-transformer
-          :action '(("Go to prompt" . helm-shell-prompts-goto)
-                    ("Go to prompt in other window `C-c o`" .
-                     helm-shell-prompts-goto-other-window)
-                    ("Go to prompt in other frame `C-c C-o`" .
-                     helm-shell-prompts-goto-other-frame))
-          :keymap helm-shell-prompts-keymap)
-        :buffer "*helm Shell all prompts*"))
+  (when (cl-member-if 'derived-mode-p helm-shell-comint-mode-list)
+    (helm :sources
+          (helm-build-sync-source "All Shell prompts"
+            :candidates (helm-shell-prompts-list-all major-mode)
+            :candidate-transformer 'helm-shell-prompts-all-transformer
+            :action '(("Go to prompt" . helm-shell-prompts-goto)
+                      ("Go to prompt in other window `C-c o`" .
+                       helm-shell-prompts-goto-other-window)
+                      ("Go to prompt in other frame `C-c C-o`" .
+                       helm-shell-prompts-goto-other-frame))
+            :keymap helm-shell-prompts-keymap)
+          :buffer "*helm Shell all prompts*")))
 
 (provide 'helm-shell)
 


### PR DESCRIPTION
This is awesome! :)

Now I'm realizing however that my previous commit for "helm-shell" was a bit shortsighted: a "helm-comint.el" file would have made more sense.

If you agree, I will rename everything to `helm-comint`.

Besides, we've already got some `comint` related functions in `helm-misc`.  Maybe we could move them to `helm-comint.el` as well.

Thoughts?