### PR TITLE
Fix splitting issue when invoking helm from a dedicated window

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -6399,7 +6399,7 @@ If SPLIT-ONEWINDOW is non-`nil' window is split in persistent action."
                    (split-window))
                   ((window-dedicated-p
                     (setq cur-win (get-buffer-window helm-current-buffer)))
-                   (split-window))
+                   (previous-window (selected-window) 1))
                   (cur-win)
                   (t prev-win))))))
 


### PR DESCRIPTION
Continues the work from https://github.com/emacs-helm/helm/pull/2122.
Closes: https://github.com/syl20bnr/spacemacs/issues/11368 (for good this time).

Reproducible on: Spacemacs with 2 windows: one dedicated Treemacs and one non dedicated.

Normally when I press `SPC f f` in Spacemacs from a non dedicated window, then tab complete a directory I have the following:
```elisp
(window-list) ; (#<window 8 on *helm find files*> #<window 2 on  *Minibuf-1*> #<window 4 on  *Treemacs-Framebuffer-1*> #<window 1 on *Messages*>)
(selected-window) ; #<window 8 on *helm find files*>
(previous-window (selected-window) 1) ; #<window 1 on *Messages*>
helm-persistent-action-display-window ; #<window 1 on *Messages*>
```

But when I do the same from the dedicated window I get:
```
split-window: Cannot split side window or parent of side window
```

That's because in the `helm-persistent-action-display-window` function, this condition is evaluated:
```elisp
((window-dedicated-p
    (setq cur-win (get-buffer-window helm-current-buffer)))
  (split-window))
```

In this case `(selected-window)` is `#<window 8 on *helm find files*>` which of course can not be split.

My proposal in this case is to make it behave exactly like the clause above and switch to `previous-window`.

This makes sense because, as I understand the code, once you're checking that the current buffer is dedicated, `cur-win` being `#<window 4 on  *Treemacs-Framebuffer-1*>`, you can not use that as your persistent action display window. But in the clause above you already check the previous windows and the only way the `cond` can evaluate the current condition is if the one above failed, meaning `previous-window` is not dedicated, so it's usable.