### PR TITLE
Deleted helm dep on helm-org.

### DIFF
--- a/helm-pkg.el
+++ b/helm-pkg.el
@@ -5,8 +5,7 @@
   '((emacs "24.4")
     (async "1.9.3")
     (popup "0.5.3")
-    (helm-core "3.0")
-    (helm-org "1.0"))
+    (helm-core "3.0"))
   :url "https://emacs-helm.github.io/helm/")
 
 ;; Local Variables:


### PR DESCRIPTION
Since this dependency leads to recursive mutual dependencies between helm-org and helm, this needs to be removed. Mutual dependencys totally break package.el.