### PR TITLE
Smonnier defmethod patch

### DIFF
--- a/helm-elisp-package.el
+++ b/helm-elisp-package.el
@@ -250,8 +250,10 @@
 (defun helm-el-package-upgrade-all ()
   (if helm-el-package--upgrades
       (with-helm-display-marked-candidates
-        helm-marked-buffer-name (mapcar (lambda (x) (symbol-name (car x)))
-                                        helm-el-package--upgrades)
+        helm-marked-buffer-name (helm-fast-remove-dups
+                                 (mapcar (lambda (x) (symbol-name (car x)))
+                                         helm-el-package--upgrades)
+                                 :test 'equal)
         (when (y-or-n-p "Upgrade all packages? ")
           (helm-el-package-upgrade-1 helm-el-package--tabulated-list)))
       (message "No packages to upgrade actually!")))

--- a/helm-mode.el
+++ b/helm-mode.el
@@ -1425,8 +1425,7 @@ Actually do nothing."
       (helm-completion--multi-all-completions string table pred point)
     (when all (nconc all (length prefix)))))
 
-(when (and (fboundp 'completion-styles-try-completion)
-           (fboundp 'completion-styles-all-completion))
+(when (fboundp 'completion-styles-all-completions)
   (cl-defmethod completion-styles-try-completion ((_style (eql helm))
                                                   string table pred point &rest _)
     "The try completion function for `completing-styles-alist'.


### PR DESCRIPTION
Update helm-mode to work with Stefan patch using generic functions.

Note: This don't work on any published Emacs (even Emacs-27 as of now).