### PR TITLE
Respect that emacs config-folder can now be in $XDG_CONFIG_HOME

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,11 @@ PKGDIR := .
 
 # Additional emacs loadpath
 LOADPATH	:= -L $(PKGDIR)
-ELPA_DIR        =  $(HOME)/.emacs.d/elpa
+
+# Prefer emacs config folder in XDG_CONFIG_HOME to ~/.emacs.d
+XDG_ELPA_DIR	:= $(if $(XDG_CONFIG_HOME), $(XDG_CONFIG_HOME)/emacs/elpa, $(HOME)/.config/emacs/elpa)
+ELPA_DIR := $(if $(shell test -d $(XDG_ELPA_DIR)), $(HOME)/.emacs.d/elpa, $(XDG_ELPA_DIR))
+
 ASYNC_ELPA_DIR  =  $(shell \
 	test -d $(ELPA_DIR) && \
 	find -L $(ELPA_DIR) -maxdepth 1 -regex '.*/async-[.0-9]*' 2> /dev/null | \

--- a/emacs-helm.sh
+++ b/emacs-helm.sh
@@ -179,7 +179,7 @@ cat > $CONF_FILE <<EOF
 ;; User may be using a non standard \`package-user-dir'.
 ;; Modify \`package-directory-list' instead of \`package-user-dir'
 ;; in case the user starts Helm from a non-ELPA installation.
-(unless (file-equal-p package-user-dir "~/.emacs.d/elpa")
+(unless (file-equal-p package-user-dir (locate-user-emacs-file "elpa"))
   (add-to-list 'package-directory-list (directory-file-name
                                         (file-name-directory
                                          (directory-file-name default-directory)))))

--- a/helm-adaptive.el
+++ b/helm-adaptive.el
@@ -29,7 +29,7 @@
   :group 'helm)
 
 (defcustom helm-adaptive-history-file
-  "~/.emacs.d/helm-adaptive-history"
+  (locate-user-emacs-file "helm-adaptive-history")
   "Path of file where history information is stored.
 When nil history is not saved nor restored after emacs restart unless
 you save/restore `helm-adaptive-history' with something else like

--- a/helm-files.el
+++ b/helm-files.el
@@ -4263,7 +4263,7 @@ inversed."
 ;;
 ;;
 (defvar helm-ff-delete-log-file
-  (expand-file-name "helm-delete-file.log" user-emacs-directory)
+  (locate-user-emacs-file "helm-delete-file.log")
   "The file use to communicate with emacs child when deleting files async.")
 
 (defvar helm-ff--trash-flag nil)


### PR DESCRIPTION
* Make use of locate-user-emacs-file
* Change Makefile to check first if $(XDG_CONFIG_HOME)/emacs/elpa or
~/.config/emacs/elpa exists and if not, fall back to ~/.emacs.d/elpa

Fixes #2278 