### PR TITLE
Use instead `equal` instead of `string=` to compare display properties

### DIFF
--- a/helm-mode.el
+++ b/helm-mode.el
@@ -478,9 +478,7 @@ If COLLECTION is an `obarray', a TEST should be needed. See `obarray'."
 (defun helm-comp-read--move-to-first-real-candidate ()
   (helm-aif (helm-get-selection nil 'withprop)
       ;; Avoid error with candidates with an image as display (#2296).
-      (when (or (and (stringp it)
-                     (string= (get-text-property 0 'display it) "[?]"))
-                (not (stringp it)))
+      (when (equal (get-text-property 0 'display it) "[?]")
         (helm-next-line))))
 
 (defun helm-cr-default (default cands)


### PR DESCRIPTION
This avoids the error that might occur if the candidates have image set display property, fixes #2296 