### PR TITLE
Append separator when completing multiple candidates

### DIFF
--- a/helm-mode.el
+++ b/helm-mode.el
@@ -1873,7 +1873,7 @@ Can be used for `completion-in-region-function' by advicing it with an
              (when (looking-back crm-separator (1- (point)))
                (setq sep (match-string 0))))
            (funcall completion-list-insert-choice-function
-                    beg end (mapconcat 'identity result sep))))
+                    beg end (mapconcat 'identity (append result '("")) sep))))
         (t nil)))
 
 (defun helm-mode--in-file-completion-p ()


### PR DESCRIPTION
* helm-mode.el (helm-completion-in-region--insert-result): Separator
is auto-appended when completing multiple candidates so that user
doesn't have to type it in explicitly to trigger completion.  It is
safe to submit completion results with trailing separator still in
minibuffer.

I refrained from using `nconc` as `result` is recorded into `history` in `#'helm-comp-read`.