### PR TITLE
Resize popup frame width and height when reuse it

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -3245,12 +3245,16 @@ Note that this feature is available only with emacs-25+."
 (defun helm-display-buffer-popup-frame (buffer frame-alist)
   (if helm-display-buffer-reuse-frame
       (let* ((x (cdr (assoc 'left frame-alist)))
-             (y (cdr (assoc 'top frame-alist))))
+             (y (cdr (assoc 'top frame-alist)))
+             (width (cdr (assoc 'width frame-alist)))
+             (height (cdr (assoc 'height frame-alist))))
         (unless (and helm-popup-frame
                      (frame-live-p helm-popup-frame))
           (setq helm-popup-frame (make-frame frame-alist)))
         (select-frame helm-popup-frame)
         (set-frame-position helm-popup-frame x y)
+        (set-frame-width helm-popup-frame width)
+        (set-frame-height helm-popup-frame height)
         (switch-to-buffer buffer)
         (select-frame-set-input-focus helm-popup-frame t))
     ;; If user have changed `helm-display-buffer-reuse-frame' to nil


### PR DESCRIPTION
Hi,

I try to customize helm-display-function to display helm frame alway in the center of the parent frame: 

```elisp
(defun helm-display-child-frame-center (buffer &optional resume)
  "Display `helm-buffer' in a separate frame which centered in
parent frame."
  (if (not (display-graphic-p))
      ;; Fallback to default when frames are not usable.
      (helm-default-display-buffer buffer)
    (setq helm--buffer-in-new-frame-p t)
    (let* ((parent (selected-frame))
           (frame-pos (frame-position parent))
           (parent-left (car frame-pos))
           (parent-top (cdr frame-pos))
           (default-frame-alist
             `((parent . ,parent)
               (width . ,(/ (frame-width parent) 2))
               (height . ,helm-display-buffer-height)
               (undecorated . t)
               (left-fringe . 0)
               (right-fringe . 0)
               (tool-bar-lines . 0)
               (line-spacing . 0)
               (desktop-dont-save . t)
               (no-special-glyphs . t)
               (inhibit-double-buffering . t)
               (tool-bar-lines . 0)
               (left . ,(+ parent-left (/ (* (frame-char-width parent) (frame-width parent)) 4)))
               (top . ,(+ parent-top (/ (* (frame-char-width parent) (frame-height parent)) 6)))
               (title . "Helm")
               (vertical-scroll-bars . nil)
               (menu-bar-lines . 0)
               (fullscreen . nil)
               (visible . ,(null helm-display-buffer-reuse-frame))
               (minibuffer . t)))
           display-buffer-alist)
      (helm-display-buffer-popup-frame buffer default-frame-alist))
    (helm-log-run-hook 'helm-window-configuration-hook)))
```

![image](https://user-images.githubusercontent.com/10190397/80920654-c2773780-8da3-11ea-8581-4af62de08603.png)

The problem is, after resizing parent window, helm frame won't update its width and height, i think this patch will help.