### PR TITLE
Update documentation

### DIFF
--- a/helm-adaptive.el
+++ b/helm-adaptive.el
@@ -31,9 +31,9 @@
 (defcustom helm-adaptive-history-file
   (locate-user-emacs-file "helm-adaptive-history")
   "Path of file where history information is stored.
-When nil history is not saved nor restored after emacs restart unless
-you save/restore `helm-adaptive-history' with something else like
-psession or desktop."
+When nil history is not saved nor restored after Emacs restart
+unless you save/restore `helm-adaptive-history' with something
+else like psession or desktop."
   :type 'string
   :group 'helm-adapt)
 
@@ -48,8 +48,8 @@ psession or desktop."
 When nil sort on frequency usage only.
 
 Only frequency:
-When candidate have low frequency, you have to hit on it many times to
-make it going up on top.
+When candidate have low frequency, you have to hit on it many
+times to make it going up on top.
 
 Frequency+recent:
 Even with a low frequency, candidate go up on top. If a candidate
@@ -172,7 +172,7 @@ Returns nil if `helm-adaptive-history-file' doesn't exist."
     (load-file helm-adaptive-history-file)))
 
 (defun helm-adaptive-save-history (&optional arg)
-  "Save history information to file given by `helm-adaptive-history-file'."
+  "Save history information to the file given by `helm-adaptive-history-file'."
   (interactive "p")
   (when helm-adaptive-history-file
     (with-temp-buffer
@@ -253,7 +253,8 @@ you should reinitialize it with `helm-reset-adaptive-history'"
 ;;;###autoload
 (defun helm-reset-adaptive-history ()
   "Delete all `helm-adaptive-history' and his file.
-Useful when you have a old or corrupted `helm-adaptive-history-file'."
+Useful when you have a old or corrupted
+`helm-adaptive-history-file'."
   (interactive)
   (when (y-or-n-p "Really delete all your `helm-adaptive-history'? ")
     (setq helm-adaptive-history nil)
@@ -262,7 +263,8 @@ Useful when you have a old or corrupted `helm-adaptive-history-file'."
 (defun helm-adaptive-compare (x y)
   "Compare display parts if some of candidates X and Y.
 
-Arguments X and Y are cons cell in (DISPLAY . REAL) format or atoms."
+Arguments X and Y are cons cell in (DISPLAY . REAL) format or
+atoms."
   (equal (if (listp x) (car x) x)
          (if (listp y) (car y) y)))
 

--- a/helm-bookmark.el
+++ b/helm-bookmark.el
@@ -105,7 +105,7 @@
     (define-key map (kbd "C-]")     'helm-bookmark-toggle-filename)
     (define-key map (kbd "M-e")     'helm-bookmark-run-edit)
     map)
-  "Generic Keymap for emacs bookmark sources.")
+  "Generic Keymap for Emacs bookmark sources.")
 
 (defclass helm-source-basic-bookmarks (helm-source-in-buffer helm-type-bookmark)
    ((init :initform (lambda ()
@@ -292,8 +292,8 @@ BOOKMARK is a bookmark name or a bookmark record."
 (defvar w3m-async-exec)
 (defun helm-bookmark-jump-w3m (bookmark)
   "Jump to W3m bookmark BOOKMARK, setting a new tab.
-If `browse-url-browser-function' is set to something else
-than `w3m-browse-url' use it."
+If `browse-url-browser-function' is set to something else than
+`w3m-browse-url' use it."
   (require 'helm-net)
   (let* ((file  (or (bookmark-prop-get bookmark 'filename)
                     (bookmark-prop-get bookmark 'url)))
@@ -596,7 +596,8 @@ than `w3m-browse-url' use it."
 ;;
 (defun helm-bookmark-edit-bookmark (bookmark-name)
   "Edit bookmark's name and file name, and maybe save them.
-BOOKMARK-NAME is the current (old) name of the bookmark to be renamed."
+BOOKMARK-NAME is the current (old) name of the bookmark to be
+renamed."
   (let ((bmk (helm-bookmark-get-bookmark-from-name bookmark-name))
         (handler (bookmark-prop-get bookmark-name 'handler)))
     (if (eq handler 'addressbook-bookmark-jump)
@@ -644,8 +645,8 @@ If NEW is nil, then prompt for its string value.
 
 If BATCH is non-nil, then do not rebuild the menu list.
 
-While the user enters the new name, repeated `C-w' inserts consecutive
-words from the buffer into the new bookmark name."
+While the user enters the new name, repeated `C-w' inserts
+consecutive words from the buffer into the new bookmark name."
   (interactive (list (bookmark-completing-read "Old bookmark name")))
   (bookmark-maybe-historicize-string old)
   (bookmark-maybe-load-default-file)
@@ -694,7 +695,7 @@ words from the buffer into the new bookmark name."
 
 (defun helm-bookmark-get-bookmark-from-name (bmk)
   "Return bookmark name even if it is a bookmark with annotation.
-e.g prepended with *."
+E.g. prepended with *."
   (let ((bookmark (replace-regexp-in-string "\\`\\*" "" bmk)))
     (if (assoc bookmark bookmark-alist) bookmark bmk)))
 
@@ -716,9 +717,9 @@ e.g prepended with *."
 
 ;;;###autoload
 (defun helm-filtered-bookmarks ()
-  "Preconfigured helm for bookmarks (filtered by category).
-Optional source `helm-source-bookmark-addressbook' is loaded
-only if external addressbook-bookmark package is installed."
+  "Preconfigured `helm' for bookmarks (filtered by category).
+Optional source `helm-source-bookmark-addressbook' is loaded only
+if external addressbook-bookmark package is installed."
   (interactive)
   (helm :sources helm-bookmark-default-filtered-sources
         :prompt "Search Bookmark: "

--- a/helm-buffers.el
+++ b/helm-buffers.el
@@ -60,18 +60,18 @@ These buffers will be displayed even if they match one of
 
 (defcustom helm-buffer-max-length 20
   "Max length of buffer names before truncate.
-When disabled (nil) use the longest buffer-name length found."
+When disabled (nil) use the longest `buffer-name' length found."
   :group 'helm-buffers
   :type  '(choice (const :tag "Disabled" nil)
            (integer :tag "Length before truncate")))
 
 (defcustom helm-buffer-details-flag t
-  "Always show details in buffer list when non--nil."
+  "Always show details in buffer list when non-nil."
   :group 'helm-buffers
   :type 'boolean)
 
 (defcustom helm-buffers-fuzzy-matching nil
-  "Fuzzy matching buffer names when non--nil.
+  "Fuzzy matching buffer names when non-nil.
 Only buffer names are fuzzy matched when this is enabled,
 `major-mode' matching is not affected by this."
   :group 'helm-buffers
@@ -83,7 +83,7 @@ Only buffer names are fuzzy matched when this is enabled,
   :type 'boolean)
 
 (defcustom helm-buffers-truncate-lines t
-  "Truncate lines in `helm-buffers-list' when non--nil."
+  "Truncate lines in `helm-buffers-list' when non-nil."
   :group 'helm-buffers
   :type 'boolean)
 
@@ -97,8 +97,8 @@ Only buffer names are fuzzy matched when this is enabled,
                                        helm-source-buffer-not-found)
   "Default sources list used in `helm-mini'.
 
-When adding a source here it is up to you to ensure the library of
-this source is accessible and properly loaded."
+When adding a source here it is up to you to ensure the library
+of this source is accessible and properly loaded."
   :group 'helm-buffers
   :type '(repeat (choice symbol)))
 
@@ -115,18 +115,18 @@ this source is accessible and properly loaded."
 (defcustom helm-buffer--pretty-names '((dired-mode . "Dired")
                                        (lisp-interaction-mode . "Lisp Inter"))
   "An alist specifying pretty names for modes.
-Most of the time buffer's `mode-name' is a string so no need to add it
-here as there is no need to compute it, but sometimes it may be a
-mode-line specification which may be costly to compute, in this case
-add here the pretty name as a string to avoid this costly computation.
-Also if some pretty names are too long you can add your own
-abbreviation here."
+Most of the time buffer's `mode-name' is a string so no need to
+add it here as there is no need to compute it, but sometimes it
+may be a mode-line specification which may be costly to compute,
+in this case add here the pretty name as a string to avoid this
+costly computation.  Also if some pretty names are too long you
+can add your own abbreviation here."
   :type '(alist :key-type symbol :value-type string)
   :group 'helm-buffers)
 
 (defcustom helm-buffers-maybe-switch-to-tab nil
   "Switch to buffer in its tab when non nil.
-This have no effect when `tab-bar-mode' is not available."
+This has no effect when `tab-bar-mode' is not available."
   :group 'helm-buffers
   :type 'boolean)
 
@@ -135,9 +135,10 @@ This have no effect when `tab-bar-mode' is not available."
 It takes two arguments VISIBLES buffers and OTHERS buffers.
 Arg VISIBLES handles the buffers visibles in this frame.
 Arg OTHERS handles all the other buffers.
-You can write a function that reorder VISIBLES and OTHERS as you want.
-Default function returns OTHERS buffers on top and VISIBLES buffer at the
-end.  See `helm-buffers-reorder-buffer-list'."
+You can write a function that reorder VISIBLES and OTHERS as you
+want.
+Default function returns OTHERS buffers on top and VISIBLES
+buffer at the end.  See `helm-buffers-reorder-buffer-list'."
   :group 'helm-buffers
   :type 'function)
 
@@ -199,10 +200,10 @@ end.  See `helm-buffers-reorder-buffer-list'."
 
 (defvar helm-buffers-tick-counter nil
   "Allows recording local changes to a non-file buffer.
-Typical usage of this var is for modes that want to see if
-their buffers have changed since last visit.
-Such programs may want to record tick counter after visiting their
-buffers like this:
+Typical usage of this var is for modes that want to see if their
+buffers have changed since last visit.
+Such programs may want to record tick counter after visiting
+their buffers like this:
 
     (setq helm-buffers-tick-counter (buffer-modified-tick))
 
@@ -371,8 +372,8 @@ Note that this variable is buffer-local.")
   "Default function to reorder buffer-list.
 Arg VISIBLES handles the buffers visibles in this frame.
 Arg OTHERS handles all the other buffers.
-This function returns OTHERS buffers on top and VISIBLES buffer at the
-end."
+This function returns OTHERS buffers on top and VISIBLES buffer
+at the end."
   (nconc others visibles))
 
 (defun helm-buffer-list ()
@@ -490,7 +491,8 @@ The list is reordered with `helm-buffer-list-reorder-fn'."
 
 (defun helm-highlight-buffers (buffers _source)
   "Transformer function to highlight BUFFERS list.
-Should be called after others transformers i.e (boring buffers)."
+Should be called after others transformers i.e. (boring
+buffers)."
   (cl-loop for i in buffers
            for (name size mode meta) = (if helm-buffer-details-flag
                                            (helm-buffer--details i 'details)
@@ -604,7 +606,7 @@ Should be called after others transformers i.e (boring buffers)."
 
 (defun helm-buffers-mark-similar-buffers ()
     "Mark All buffers that have same property `type' than current.
-i.e same color."
+I.e. same color."
   (interactive)
   (with-helm-alive-p
     (let ((marked (helm-marked-candidates)))
@@ -812,7 +814,7 @@ If REGEXP-FLAG is given use `query-replace-regexp'."
   (helm-buffer-save-and-update nil))
 
 (defun helm-buffer-run-save-some-buffers ()
-  "Save unsaved file buffers without quitting helm."
+  "Save unsaved file buffers without quitting Helm."
   (interactive)
   (with-helm-alive-p
     (helm-attrset 'save-some-action '(helm-buffer-save-some-buffers . never-split))
@@ -820,7 +822,7 @@ If REGEXP-FLAG is given use `query-replace-regexp'."
 (put 'helm-buffer-run-save-some-buffers 'helm-only t)
 
 (defun helm-buffer-save-persistent ()
-  "Save buffer without quitting helm."
+  "Save buffer without quitting Helm."
   (interactive)
   (with-helm-alive-p
     (helm-attrset 'save-action '(helm-buffer-save-and-update . never-split))
@@ -839,7 +841,7 @@ If REGEXP-FLAG is given use `query-replace-regexp'."
 (put 'helm-buffer-run-rename-buffer 'helm-only t)
 
 (defun helm-buffer-run-kill-persistent ()
-  "Kill buffer without quitting helm."
+  "Kill buffer without quitting Helm."
   (interactive)
   (with-helm-alive-p
     (helm-attrset 'kill-action '(helm-buffers-persistent-kill . never-split))
@@ -915,8 +917,9 @@ If REGEXP-FLAG is given use `query-replace-regexp'."
 (defun helm-buffer-switch-buffers (_candidate)
   "Switch to buffer candidates and replace current buffer.
 
-If more than one buffer marked switch to these buffers in separate windows.
-If a prefix arg is given split windows vertically."
+If more than one buffer marked switch to these buffers in
+separate windows.  If a prefix arg is given split windows
+vertically."
   (let ((buffers (helm-marked-candidates)))
     (helm-window-show-buffers buffers)))
 
@@ -1070,7 +1073,7 @@ Can be used by any source that list buffers."
 (put 'helm-buffers-toggle-show-hidden-buffers 'helm-only t)
 
 (defun helm-buffers-browse-project (buf)
-  "Browse project from buffer."
+  "Browse project from buffer BUF."
   (with-current-buffer buf
     (helm-browse-project helm-current-prefix-arg)))
 

--- a/helm-color.el
+++ b/helm-color.el
@@ -84,25 +84,25 @@
   (kill-new (helm-colors-get-rgb candidate)))
 
 (defun helm-color-run-insert-name ()
-  "Insert name of color from `helm-source-colors'"
+  "Insert name of color from `helm-source-colors'."
   (interactive)
   (with-helm-alive-p (helm-exit-and-execute-action 'helm-color-insert-name)))
 (put 'helm-color-run-insert-name 'helm-only t)
 
 (defun helm-color-run-kill-name ()
-  "Kill name of color from `helm-source-colors'"
+  "Kill name of color from `helm-source-colors'."
   (interactive)
   (with-helm-alive-p (helm-exit-and-execute-action 'helm-color-kill-name)))
 (put 'helm-color-run-kill-name 'helm-only t)
 
 (defun helm-color-run-insert-rgb ()
-  "Insert RGB of color from `helm-source-colors'"
+  "Insert RGB of color from `helm-source-colors'."
   (interactive)
   (with-helm-alive-p (helm-exit-and-execute-action 'helm-color-insert-rgb)))
 (put 'helm-color-run-insert-rgb 'helm-only t)
 
 (defun helm-color-run-kill-rgb ()
-  "Kill RGB of color from `helm-source-colors'"
+  "Kill RGB of color from `helm-source-colors'."
   (interactive)
   (with-helm-alive-p (helm-exit-and-execute-action 'helm-color-kill-rgb)))
 (put 'helm-color-run-kill-rgb 'helm-only t)

--- a/helm-comint.el
+++ b/helm-comint.el
@@ -49,7 +49,7 @@
 
 (defcustom helm-comint-mode-list '(comint-mode slime-repl-mode sly-mrepl-mode sql-interactive-mode)
   "Supported modes for prompt navigation.
-Derived modes (e.g. Geiser's REPL) are automatically supported."
+Derived modes (e.g., Geiser's REPL) are automatically supported."
   :group 'helm-comint
   :type '(repeat (choice symbol)))
 
@@ -57,8 +57,8 @@ Derived modes (e.g. Geiser's REPL) are automatically supported."
                                                                   (sly-mrepl-next-prompt)
                                                                   (point))))
   "Alist of (MODE . NEXT-PROMPT-FUNCTION) to use.
- If the current major mode is a key in this list, the associated function will be
- used to navigate the prompts.
+ If the current major mode is a key in this list, the associated
+ function will be used to navigate the prompts.
  The function must return the point after the prompt.
  Otherwise (comint-next-prompt 1) will be used."
   :group 'helm-comint
@@ -66,11 +66,11 @@ Derived modes (e.g. Geiser's REPL) are automatically supported."
 
 (defcustom helm-comint-max-offset 400
   "Max number of chars displayed per candidate in comint-input-ring browser.
-When `t', don't truncate candidate, show all.
-By default it is approximatively the number of bits contained in five lines
-of 80 chars each i.e 80*5.
-Note that if you set this to nil multiline will be disabled, i.e you
-will not have anymore separators between candidates."
+When t, don't truncate candidate, show all.
+By default it is approximatively the number of bits contained in
+five lines of 80 chars each i.e 80*5.
+Note that if you set this to nil multiline will be disabled, i.e
+you will not have anymore separators between candidates."
   :type '(choice (const :tag "Disabled" t)
           (integer :tag "Max candidate offset"))
   :group 'helm-misc)
@@ -87,7 +87,7 @@ will not have anymore separators between candidates."
   "List the prompts in BUFFER in mode MODE.
 
 Return a list of (\"prompt\" (point) (buffer-name) prompt-index))
-e.g. (\"ls\" 162 \"*shell*\" 3).
+E.g. (\"ls\" 162 \"*shell*\" 3).
 If BUFFER is nil, use current buffer."
   (with-current-buffer (or buffer (current-buffer))
     (when (derived-mode-p mode)

--- a/helm-command.el
+++ b/helm-command.el
@@ -29,12 +29,12 @@
   :group 'helm)
 
 (defcustom helm-M-x-always-save-history nil
-  "`helm-M-x' Save command in `extended-command-history' even when it fail."
+  "`helm-M-x' save command in `extended-command-history' even when it fails."
   :group 'helm-command
   :type  'boolean)
 
 (defcustom helm-M-x-reverse-history nil
-  "The history source of `helm-M-x' appear in second position when non--nil."
+  "The history source of `helm-M-x' appear in second position when non-nil."
   :group 'helm-command
   :type 'boolean)
 
@@ -68,8 +68,8 @@
 
 (defun helm-get-mode-map-from-mode (mode)
   "Guess the mode-map name according to MODE.
-Some modes don't use conventional mode-map name
-so we need to guess mode-map name. e.g python-mode ==> py-mode-map.
+Some modes don't use conventional mode-map name so we need to
+guess mode-map name. E.g. `python-mode' ==> py-mode-map.
 Return nil if no mode-map found."
   (cl-loop ;; Start with a conventional mode-map name.
         with mode-map    = (intern-soft (format "%s-map" mode))
@@ -92,10 +92,12 @@ Return nil if no mode-map found."
 
 (defun helm-M-x-transformer-1 (candidates &optional sort)
   "Transformer function to show bindings in emacs commands.
-Show global bindings and local bindings according to current `major-mode'.
+Show global bindings and local bindings according to current
+`major-mode'.
 If SORT is non nil sort list with `helm-generic-sort-fn'.
 Note that SORT should not be used when fuzzy matching because
-fuzzy matching is running its own sort function with a different algorithm."
+fuzzy matching is running its own sort function with a different
+algorithm."
   (with-helm-current-buffer
     (cl-loop with local-map = (helm-M-x-current-mode-map-alist)
           for cand in candidates
@@ -196,16 +198,17 @@ fuzzy matching is running its own sort function with a different algorithm."
 (defun helm-M-x-read-extended-command (collection &optional predicate history)
   "Read or execute action on command name in COLLECTION or HISTORY.
 
-When `helm-M-x-use-completion-styles' is used, several actions as of
-`helm-type-command' are used and executed from here, otherwise this
-function returns the command as a symbol.
+When `helm-M-x-use-completion-styles' is used, several actions as
+of `helm-type-command' are used and executed from here, otherwise
+this function returns the command as a symbol.
 
-Helm completion is not provided when executing or defining kbd macros.
+Helm completion is not provided when executing or defining kbd
+macros.
 
-Arg COLLECTION should be an `obarray' but can be any object suitable
-for `try-completion'.  Arg PREDICATE is a function that default to
-`commandp' see also `try-completion'.
-Arg HISTORY default to `extended-command-history'."
+Arg COLLECTION should be an `obarray' but can be any object
+suitable for `try-completion'.  Arg PREDICATE is a function that
+default to `commandp' see also `try-completion'.  Arg HISTORY
+default to `extended-command-history'."
   (let* ((helm--mode-line-display-prefarg t)
          (tm (run-at-time 1 0.1 'helm-M-x--notify-prefix-arg))
          (minibuffer-completion-confirm t)
@@ -294,12 +297,14 @@ Save COMMAND to `extended-command-history'."
 ;;;###autoload
 (defun helm-M-x (_arg)
   "Preconfigured `helm' for Emacs commands.
-It is `helm' replacement of regular `M-x' `execute-extended-command'.
+It is `helm' replacement of regular `M-x'
+`execute-extended-command'.
 
-Unlike regular `M-x' emacs vanilla `execute-extended-command' command,
-the prefix args if needed, can be passed AFTER starting `helm-M-x'.
-When a prefix arg is passed BEFORE starting `helm-M-x', the first `C-u'
-while in `helm-M-x' session will disable it.
+Unlike regular `M-x' Emacs vanilla `execute-extended-command'
+command, the prefix args if needed, can be passed AFTER starting
+`helm-M-x'.  When a prefix arg is passed BEFORE starting
+`helm-M-x', the first `C-u' while in `helm-M-x' session will
+disable it.
 
 You can get help on each command by persistent action."
   (interactive

--- a/helm-config.el
+++ b/helm-config.el
@@ -131,7 +131,7 @@
 
 ;;;###autoload
 (defun helm-configuration ()
-  "Customize `helm'."
+  "Customize Helm."
   (interactive)
   (customize-group "helm"))
 

--- a/helm-dabbrev.el
+++ b/helm-dabbrev.el
@@ -28,8 +28,8 @@
 
 (defcustom helm-dabbrev-always-search-all t
   "Always search in all buffers when non--nil.
-Note that even if nil, a search in all buffers
-will occur if the length of candidates is <= than
+Note that even if nil, a search in all buffers will occur if the
+length of candidates is <= than
 `helm-dabbrev-max-length-result'."
   :group 'helm-dabbrev
   :type 'boolean)
@@ -37,27 +37,31 @@ will occur if the length of candidates is <= than
 (defcustom helm-dabbrev-candidates-number-limit 1000
   "Maximum number of candidates to collect.
 
-Higher this number is, slower the computation of candidates will be.
-You can use safely a higher value with emacs-26+.
-Note that this have nothing to do with `helm-candidate-number-limit',
-this mean that computation of candidates stop when this value is
-reached but only `helm-candidate-number-limit' candidates are
-displayed in helm buffer."
+The higher this number is, the slower the computation of
+candidates will be.  You can use safely a higher value with
+emacs-26+.
+Note that this have nothing to do with
+`helm-candidate-number-limit', this means that computation of
+candidates stop when this value is reached but only
+`helm-candidate-number-limit' candidates are displayed in the
+Helm buffer."
   :group 'helm-dabbrev
   :type 'integer)
 
 (defcustom helm-dabbrev-ignored-buffers-regexps
   '("\\*helm" "\\*Messages" "\\*Echo Area" "\\*Buffer List")
-  "List of regexps matching names of buffers that helm-dabbrev should not check."
+  "List of regexps matching names of buffers that `helm-dabbrev' should not check."
   :group 'helm-dabbrev
   :type '(repeat regexp))
 
 (defcustom helm-dabbrev-related-buffer-fn #'helm-dabbrev--same-major-mode-p
-  "A function that decide if a buffer to search in is related to `current-buffer'.
-This is actually determined by comparing `major-mode' of the buffer to search
-and the `current-buffer'.
+  "A function that decide if a buffer to search in its related to `current-buffer'.
+
+This is actually determined by comparing `major-mode' of the
+buffer to search and the `current-buffer'.
+
 The function take one arg, the buffer which is current, look at
-`helm-dabbrev--same-major-mode-p' for example.
+`helm-dabbrev--same-major-mode-p' for an example.
 
 When nil all buffers are considered related to `current-buffer'."
   :group 'helm-dabbrev
@@ -65,16 +69,21 @@ When nil all buffers are considered related to `current-buffer'."
 
 (defcustom helm-dabbrev-major-mode-assoc nil
   "Major mode association alist.
-This allow helm-dabbrev searching in buffers with the associated `major-mode'.
-e.g \(emacs-lisp-mode . lisp-interaction-mode\)
-will allow searching in the lisp-interaction-mode buffer when `current-buffer'
-is an `emacs-lisp-mode' buffer and vice versa i.e
-no need to provide \(lisp-interaction-mode . emacs-lisp-mode\) association.
 
-When nil check is the searched buffer have same `major-mode'
-than the `current-buffer'.
-This have no effect when `helm-dabbrev-related-buffer-fn' is nil or of course
-bound to a function that doesn't handle this var."
+This allow helm-dabbrev searching in buffers with the associated
+`major-mode'.
+E.g. \(emacs-lisp-mode . lisp-interaction-mode\)
+
+will allow searching in the lisp-interaction-mode buffer when
+`current-buffer' is an `emacs-lisp-mode' buffer and vice versa
+i.e. no need to provide \(lisp-interaction-mode .
+emacs-lisp-mode\) association.
+
+When nil check is the searched buffer has same `major-mode' than
+the `current-buffer'.
+
+This has no effect when `helm-dabbrev-related-buffer-fn' is nil
+or of course bound to a function that doesn't handle this var."
   :type '(alist :key-type symbol :value-type symbol)
   :group 'helm-dabbrev)
 
@@ -92,8 +101,8 @@ When nil or 0 disable cycling."
 (defcustom helm-dabbrev-case-fold-search 'smart
   "Set `case-fold-search' in `helm-dabbrev'.
 Same as `helm-case-fold-search' but for `helm-dabbrev'.
-Note that this is not affecting searching in helm buffer,
-but the initial search for all candidates in buffer(s)."
+Note that this is not affecting searching in Helm buffer, but the
+initial search for all candidates in buffer(s)."
   :group 'helm-dabbrev
   :type '(choice (const :tag "Ignore case" t)
           (const :tag "Respect case" nil)
@@ -229,12 +238,13 @@ Argument DIRECTION can be:
 
 (defun helm-dabbrev--search (pattern beg sep-regexp)
   "Search word or symbol at point matching PATTERN.
-Argument BEG is corresponding to the previous match-beginning search.
+Argument BEG is corresponding to the previous `match-beginning'
+search.
 The search starts at (1- BEG) with a regexp starting with
 `helm-dabbrev-separator-regexp' followed by PATTERN followed by a
 regexp matching syntactically any word or symbol.
-The possible false positives matching SEP-REGEXP at end are finally
-removed."
+The possible false positives matching SEP-REGEXP at end are
+finally removed."
   (let ((eol (point-at-eol)))
     (save-excursion
       (goto-char (1- beg))

--- a/helm-elisp-package.el
+++ b/helm-elisp-package.el
@@ -35,7 +35,7 @@
           (const :tag "Show upgradable packages" upgrade)))
 
 (defcustom helm-el-truncate-lines t
-  "Truncate lines in helm-buffer when non--nil."
+  "Truncate lines in `helm-buffer' when non-nil."
   :group 'helm-el-package
   :type 'boolean)
 
@@ -461,7 +461,7 @@ See `package-autoremove'."
 
 ;;;###autoload
 (defun helm-list-elisp-packages (arg)
-  "Preconfigured helm for listing and handling emacs packages."
+  "Preconfigured `helm' for listing and handling Emacs packages."
   (interactive "P")
   (when arg (setq helm-el-package--initialized-p nil))
   (unless helm-source-list-el-package
@@ -474,10 +474,11 @@ See `package-autoremove'."
 
 ;;;###autoload
 (defun helm-list-elisp-packages-no-fetch (arg)
-  "Preconfigured helm for emacs packages.
+  "Preconfigured Helm for Emacs packages.
 
-Same as `helm-list-elisp-packages' but don't fetch packages on remote.
-Called with a prefix ARG always fetch packages on remote."
+Same as `helm-list-elisp-packages' but don't fetch packages on
+remote.  Called with a prefix ARG always fetch packages on
+remote."
   (interactive "P")
   (let ((helm-el-package--initialized-p (null arg)))
     (helm-list-elisp-packages nil)))

--- a/helm-elisp.el
+++ b/helm-elisp.el
@@ -53,14 +53,14 @@ This is used in macro `with-helm-show-completion'."
     callf callf2 cl-callf cl-callf2 fset
     fboundp fmakunbound symbol-function)
   "List of function where quoted function completion happen.
-e.g give only function names after \(funcall '."
+E.g. give only function names after \(funcall '."
   :group 'helm-elisp
   :type '(repeat (choice symbol)))
 
 (defcustom helm-lisp-unquoted-function-list
   '(function defadvice)
   "List of function where unquoted function completion happen.
-e.g give only function names after \(function ."
+E.g. give only function names after \(function ."
   :group 'helm-elisp
   :type '(repeat (choice symbol)))
 
@@ -71,9 +71,9 @@ e.g give only function names after \(function ."
 
 (defcustom helm-lisp-fuzzy-completion nil
   "Enable fuzzy matching in emacs-lisp completion when non-nil.
-NOTE: This enable fuzzy matching in helm native implementation of
-elisp completion, but not on helmized elisp completion, i.e
-fuzzy completion is not available in `completion-at-point'."
+NOTE: This enables fuzzy matching in Helm native implementation of
+elisp completion, but not on helmized elisp completion, i.e. fuzzy
+completion is not available in `completion-at-point'."
   :group 'helm-elisp
   :type 'boolean)
 
@@ -162,7 +162,7 @@ display."
                'face 'helm-lisp-show-completion))
 
 (defun helm-show-completion-default-display-function (buffer &rest _args)
-  "A special resized helm window is used depending on position in BUFFER."
+  "A special resized Helm window is used depending on position in BUFFER."
   (with-selected-window (selected-window)
     (if (window-dedicated-p)
         (helm-default-display-buffer buffer)
@@ -181,10 +181,10 @@ display."
                            buffer)))))
 
 (defmacro with-helm-show-completion (beg end &rest body)
-  "Show helm candidate in an overlay at point.
-BEG and END are the beginning and end position of the current completion
-in `helm-current-buffer'.
-BODY is an helm call where we want to enable show completion.
+  "Show Helm candidate in an overlay at point.
+BEG and END are the beginning and end position of the current
+completion in `helm-current-buffer'.
+BODY is an Helm call where we want to enable show completion.
 If `helm-turn-on-show-completion' is nil do nothing."
   (declare (indent 2) (debug t))
   `(unwind-protect
@@ -291,7 +291,7 @@ Return a cons \(beg . end\)."
 (defvar helm-lgst-len nil)
 ;;;###autoload
 (defun helm-lisp-completion-at-point ()
-  "Preconfigured helm for lisp symbol completion at point."
+  "Preconfigured Helm for Lisp symbol completion at point."
   (interactive)
   (setq helm-lgst-len 0)
   (let* ((target     (helm-thing-before-point))
@@ -343,8 +343,9 @@ Return a cons \(beg . end\)."
 
 (defun helm-lisp-completion-persistent-action (candidate &optional name)
   "Show documentation for the function.
-Documentation is shown briefly in mode-line or completely
-in other window according to the value of `helm-elisp-help-function'."
+Documentation is shown briefly in mode-line or completely in
+other window according to the value of
+`helm-elisp-help-function'."
   (funcall helm-elisp-help-function candidate name))
 
 (defun helm-lisp-completion-persistent-help ()
@@ -368,15 +369,15 @@ in other window according to the value of `helm-elisp-help-function'."
 
 (defun helm-elisp-show-help (candidate &optional name)
   "Show full help for the function CANDIDATE.
-Arg NAME specify the name of the top level function
-calling helm generic completion (e.g \"describe-function\")
-which allow calling the right function when CANDIDATE symbol
-refers at the same time to variable and a function."
+Arg NAME specifies the name of the top level function calling
+Helm generic completion (e.g., \"describe-function\") which
+allows calling the right function when CANDIDATE symbol refers at
+the same time to variable and a function."
   (helm-elisp--persistent-help
    candidate 'helm-elisp--show-help-1 name))
 
 (defun helm-elisp-show-doc-modeline (candidate &optional name)
-  "Show brief documentation for the function in modeline."
+  "Show brief documentation for the function in the mode-line."
   (let ((cursor-in-echo-area t)
         mode-line-in-non-selected-windows)
     (helm-show-info-in-mode-line
@@ -386,7 +387,7 @@ refers at the same time to variable and a function."
       'face 'helm-lisp-completion-info))))
 
 (defun helm-lisp-completion-transformer (candidates _source)
-  "Helm candidates transformer for lisp completion."
+  "Helm candidates transformer for Lisp completion."
   (cl-loop for c in candidates
         for sym = (intern c)
         for annot = (cl-typecase sym
@@ -426,7 +427,7 @@ If SYM is not documented, return \"Not documented\"."
 
 ;;;###autoload
 (defun helm-complete-file-name-at-point (&optional force)
-  "Preconfigured helm to complete file name at point."
+  "Preconfigured Helm to complete file name at point."
   (interactive)
   (require 'helm-mode)
   (let* ((tap (thing-at-point 'filename))
@@ -464,8 +465,9 @@ If SYM is not documented, return \"Not documented\"."
 
 ;;;###autoload
 (defun helm-lisp-completion-or-file-name-at-point ()
-  "Preconfigured helm to complete lisp symbol or filename at point.
-Filename completion happen if string start after or between a double quote."
+  "Preconfigured Helm to complete Lisp symbol or filename at point.
+Filename completion happens if string start after or between a
+double quote."
   (interactive)
   (let* ((tap (thing-at-point 'filename)))
     (if (and tap (save-excursion
@@ -728,9 +730,9 @@ Filename completion happen if string start after or between a double quote."
 
 ;;;###autoload
 (defun helm-apropos (default)
-  "Preconfigured helm to describe commands, functions, variables and faces.
-In non interactives calls DEFAULT argument should be provided as a string,
-i.e the `symbol-name' of any existing symbol."
+  "Preconfigured Helm to describe commands, functions, variables and faces.
+In non interactives calls DEFAULT argument should be provided as
+a string, i.e. the `symbol-name' of any existing symbol."
   (interactive (list (thing-at-point 'symbol)))
     (helm :sources
           (mapcar (lambda (func)
@@ -951,7 +953,7 @@ i.e the `symbol-name' of any existing symbol."
 
 ;;;###autoload
 (defun helm-complex-command-history ()
-  "Preconfigured helm for complex command history."
+  "Preconfigured `helm' for complex command history."
   (interactive)
   (helm :sources 'helm-source-complex-command-history
         :buffer "*helm complex commands*"))

--- a/helm-eshell.el
+++ b/helm-eshell.el
@@ -44,12 +44,12 @@
 
 
 (defgroup helm-eshell nil
-  "Helm eshell completion and history."
+  "Helm completion and history for Eshell."
   :group 'helm)
 
 
 (defcustom helm-eshell-fuzzy-match nil
-  "Enable fuzzy matching in `helm-esh-pcomplete' when non--nil."
+  "Enable fuzzy matching in `helm-esh-pcomplete' when non-nil."
   :group 'helm-eshell
   :type 'boolean)
 
@@ -75,7 +75,8 @@
 (defvar helm-ec-target "")
 (defun helm-ec-insert (_candidate)
   "Replace text at point with CANDIDATE.
-The function that call this should set `helm-ec-target' to thing at point."
+The function that call this should set `helm-ec-target' to thing
+at point."
   (set (make-local-variable 'comint-file-name-quote-list)
        eshell-special-chars-outside-quoting)
   (let ((pt (point)))
@@ -133,7 +134,7 @@ The function that call this should set `helm-ec-target' to thing at point."
   "Helm class to define source for Eshell completion.")
 
 (defun helm-esh-get-candidates ()
-  "Get candidates for eshell completion using `pcomplete'."
+  "Get candidates for Eshell completion using `pcomplete'."
   (catch 'pcompleted
     (with-helm-current-buffer
       (let* ((pcomplete-stub)
@@ -251,7 +252,7 @@ The function that call this should set `helm-ec-target' to thing at point."
 
 ;;;###autoload
 (defun helm-esh-pcomplete ()
-  "Preconfigured helm to provide helm completion in eshell."
+  "Preconfigured `helm' to provide Helm completion in Eshell."
   (interactive)
   (let* ((helm-quit-if-no-candidate t)
          (helm-execute-action-at-once-if-one t)
@@ -332,7 +333,7 @@ The function that call this should set `helm-ec-target' to thing at point."
 
 ;;;###autoload
 (defun helm-eshell-history ()
-  "Preconfigured helm for eshell history."
+  "Preconfigured Helm for Eshell history."
   (interactive)
   (let* ((end   (point))
          (beg   (save-excursion (eshell-bol) (point)))
@@ -387,7 +388,7 @@ The function that call this should set `helm-ec-target' to thing at point."
   "List the prompts in Eshell BUFFER.
 
 Return a list of (\"prompt\" (point) (buffer-name) prompt-index))
-e.g. (\"ls\" 162 \"*eshell*\" 3).
+E.g. (\"ls\" 162 \"*eshell*\" 3).
 If BUFFER is nil, use current buffer."
   (with-current-buffer (or buffer (current-buffer))
     (when (eq major-mode 'eshell-mode)

--- a/helm-eval.el
+++ b/helm-eval.el
@@ -162,7 +162,7 @@ Should take one arg: the string to display."
 
 ;;;###autoload
 (defun helm-eval-expression (arg)
-  "Preconfigured helm for `helm-source-evaluation-result'."
+  "Preconfigured `helm' for `helm-source-evaluation-result'."
   (interactive "P")
   (helm :sources (helm-build-evaluation-result-source)
         :input (when arg (thing-at-point 'sexp))
@@ -173,7 +173,7 @@ Should take one arg: the string to display."
 (defvar eldoc-idle-delay)
 ;;;###autoload
 (defun helm-eval-expression-with-eldoc ()
-  "Preconfigured helm for `helm-source-evaluation-result' with `eldoc' support."
+  "Preconfigured `helm' for `helm-source-evaluation-result' with `eldoc' support."
   (interactive)
   (let ((timer (run-with-idle-timer
                 eldoc-idle-delay 'repeat
@@ -188,7 +188,7 @@ Should take one arg: the string to display."
 
 ;;;###autoload
 (defun helm-calcul-expression ()
-  "Preconfigured helm for `helm-source-calculation-result'."
+  "Preconfigured `helm' for `helm-source-calculation-result'."
   (interactive)
   (helm :sources 'helm-source-calculation-result
         :buffer "*helm calcul*"))

--- a/helm-external.el
+++ b/helm-external.el
@@ -37,16 +37,16 @@ This will be use with `format', so use something like \"wmctrl -xa %s\"."
 (defcustom helm-external-programs-associations nil
   "Alist to store externals programs associated with file extension.
 This variable overhide setting in .mailcap file.
-e.g : '\(\(\"jpg\" . \"gqview\"\) (\"pdf\" . \"xpdf\"\)\) "
+E.g.: '\(\(\"jpg\" . \"gqview\"\) (\"pdf\" . \"xpdf\"\)\) "
   :type '(alist :key-type string :value-type string)
   :group 'helm-external)
 
 (defcustom helm-default-external-file-browser "nautilus"
   "Default external file browser for your system.
-Directories will be opened externally with it when
-opening file externally in `helm-find-files'.
-Set to nil if you do not have external file browser
-or do not want to use it.
+Directories will be opened externally with it when opening file
+externally in `helm-find-files'.
+Set to nil if you do not have an external file browser or do not
+want to use it.
 Windows users should set that to \"explorer.exe\"."
   :group 'helm-external
   :type  'string)
@@ -61,9 +61,9 @@ automatically.")
 
 (defun helm-external-commands-list-1 (&optional sort)
   "Returns a list of all external commands the user can execute.
-If `helm-external-commands-list' is non-nil it will
-return its contents.  Else it calculates all external commands
-and sets `helm-external-commands-list'."
+If `helm-external-commands-list' is non-nil it will return its
+contents.  Else it calculates all external commands and sets
+`helm-external-commands-list'."
   (helm-aif helm-external-commands-list
       it
     (setq helm-external-commands-list
@@ -82,8 +82,8 @@ and sets `helm-external-commands-list'."
 
 (defun helm-run-or-raise (exe &optional file)
   "Run asynchronously EXE or jump to the application window.
-If EXE is already running just jump to his window if `helm-raise-command'
-is non--nil.
+If EXE is already running just jump to his window if
+`helm-raise-command' is non-nil.
 When FILE argument is provided run EXE with FILE."
   (let* ((real-com (car (split-string exe)))
          (proc     (if file (concat real-com " " file) real-com))
@@ -127,8 +127,8 @@ When FILE argument is provided run EXE with FILE."
 
 (defun helm-get-default-program-for-file (filename)
   "Try to find a default program to open FILENAME.
-Try first in `helm-external-programs-associations' and then in mailcap file
-if nothing found return nil."
+Try first in `helm-external-programs-associations' and then in
+mailcap file.  If nothing found return nil."
   (let* ((ext      (file-name-extension filename))
          (def-prog (assoc-default ext helm-external-programs-associations)))
     (cond ((and def-prog (not (string= def-prog ""))) def-prog)
@@ -138,8 +138,10 @@ if nothing found return nil."
 
 (defun helm-open-file-externally (file)
   "Open FILE with an external program.
-Try to guess which program to use with `helm-get-default-program-for-file'.
-If not found or a prefix arg is given query the user which tool to use."
+Try to guess which program to use with
+`helm-get-default-program-for-file'.
+If not found or a prefix arg is given query the user which tool
+to use."
   (let* ((fname      (expand-file-name file))
          (collection (helm-external-commands-list-1 'sort))
          (def-prog   (helm-get-default-program-for-file fname))

--- a/helm-files.el
+++ b/helm-files.el
@@ -64,18 +64,18 @@
   :group 'helm)
 
 (defcustom helm-tramp-verbose 0
-  "Just like `tramp-verbose' but specific to helm.
-When set to 0 don't show tramp messages in helm.
+  "Just like `tramp-verbose' but specific to Helm.
+When set to 0 don't show tramp messages in Helm.
 If you want to have the default tramp messages set it to 3."
   :type 'integer
   :group 'helm-files)
 
 (defcustom helm-ff-auto-update-initial-value nil
   "Auto update when only one candidate directory is matched.
-Default value when starting `helm-find-files' is nil to not confuse
-new users.
-For a better experience with `helm-find-files' set this to non--nil
-and use C-<backspace> to toggle it."
+Default value when starting `helm-find-files' is nil to not
+confuse new users.
+For a better experience with `helm-find-files' set this to
+non-nil and use C-<backspace> to toggle it."
   :group 'helm-files
   :type  'boolean)
 
@@ -108,8 +108,8 @@ This set `ffap-newfile-prompt'."
 
 (defcustom helm-ff-avfs-directory "~/.avfs"
   "The default avfs directory, usually '~/.avfs'.
-When this is set you will be able to expand archive filenames with `C-j'
-inside an avfs directory mounted with mountavfs.
+When this is set you will be able to expand archive filenames
+with `C-j' inside an avfs directory mounted with mountavfs.
 See <http://sourceforge.net/projects/avf/>."
   :type  'string
   :group 'helm-files)
@@ -121,10 +121,11 @@ See <http://sourceforge.net/projects/avf/>."
 
 (defcustom helm-ff-printer-list nil
   "A list of available printers on your system.
-When non--nil let you choose a printer to print file.
+When non-nil let you choose a printer to print file.
 Otherwise when nil the variable `printer-name' will be used.
-On Unix based systems (lpstat command needed) you don't need to set this,
-`helm-ff-find-printers' will find a list of available printers for you."
+On Unix based systems (lpstat command needed) you don't need to
+set this, `helm-ff-find-printers' will find a list of available
+printers for you."
   :type '(repeat (choice string))
   :group 'helm-files)
 
@@ -136,9 +137,10 @@ This can be toggled at anytime from `helm-find-files' with \
   :group 'helm-files)
 
 (defcustom helm-ff-signal-error-on-dot-files t
-  "Signal error when file is `.' or `..' on file deletion when non--nil.
-Default is non--nil.
-WARNING: Setting this to nil is unsafe and can cause deletion of a whole tree."
+  "Signal error when file is `.' or `..' on file deletion when non-nil.
+Default is non-nil.
+WARNING: Setting this to nil is unsafe and can cause deletion of
+a whole tree."
   :group 'helm-files
   :type  'boolean)
 
@@ -158,44 +160,45 @@ WARNING: Setting this to nil is unsafe and can cause deletion of a whole tree."
   :type 'boolean)
 
 (defcustom helm-ff-skip-boring-files nil
-  "Non--nil to skip boring files.
-
+  "Non-nil to skip boring files.
 I.e. the files matching regexps in `helm-boring-file-regexp-list'.
-This take effect in `helm-find-files' and file completion used by `helm-mode'
-i.e `helm-read-file-name'.
+This takes effect in `helm-find-files' and file completion used by
+`helm-mode' i.e. `helm-read-file-name'.
 Note that when non-nil this will slow down slightly `helm-find-files'."
   :group 'helm-files
   :type  'boolean)
 
 (defcustom helm-ff-skip-git-ignored-files nil
-  "Non--nil to skip git ignored files.
-
+  "Non-nil to skip git ignored files.
 This take effect only in `helm-find-files'.
 Check is not done on remote files.
-Note that when non-nil this will slow down slightly `helm-find-files'."
+Note that when non-nil this will slow down slightly
+`helm-find-files'."
   :group 'helm-files
   :type 'boolean)
 
 (defcustom helm-ff-candidate-number-limit 5000
   "The `helm-candidate-number-limit' for `helm-find-files' and friends.
-Note that when going one level up with `\\<helm-find-files-map>\\[helm-find-files-up-one-level]'
-The length of directory will be used instead if it is higher than this
-value, this to avoid failing to preselect the previous directory/file if
-this one is situated lower than `helm-ff-candidate-number-limit' num
-candidate."
+Note that when going one level up with
+`\\<helm-find-files-map>\\[helm-find-files-up-one-level]' the
+length of directory will be used instead if it is higher than
+this value.  This is to avoid failing to preselect the previous
+directory/file if this one is situated lower than
+`helm-ff-candidate-number-limit' num candidate."
   :group 'helm-files
   :type 'integer)
 
 (defcustom helm-ff-up-one-level-preselect t
   "Always preselect previous directory when going one level up.
 
-When non nil `candidate-number-limit' source value is modified
+When non-nil `candidate-number-limit' source value is modified
 dynamically when going one level up if the position of previous
-candidate in its directory is > to `helm-ff-candidate-number-limit'.
+candidate in its directory is > to
+`helm-ff-candidate-number-limit'.
 
-This can be helpful to disable this and reduce
-`helm-ff-candidate-number-limit' if you often navigate across very
-large directories."
+It can be helpful to disable this and reduce
+`helm-ff-candidate-number-limit' if you often navigate across
+very large directories."
   :group 'helm-files
   :type 'boolean)
 
@@ -230,14 +233,15 @@ This doesn't disable url or mail at point, see
 
 (defcustom helm-ff-guess-ffap-urls t
   "Use ffap to guess local urls at point in `helm-find-files'.
-This doesn't disable guessing filenames at point,
-see `helm-ff-guess-ffap-filenames' for this.
-See also `ffap-url-unwrap-remote' that may override this variable."
+This doesn't disable guessing filenames at point, see
+`helm-ff-guess-ffap-filenames' for this.
+See also `ffap-url-unwrap-remote' that may override this
+variable."
   :group 'helm-files
   :type 'boolean)
 
 (defcustom helm-ff-no-preselect nil
-  "When non--nil `helm-find-files' starts at root of current directory."
+  "When non-nil `helm-find-files' starts at root of current directory."
   :group 'helm-files
   :type 'boolean)
 
@@ -248,9 +252,9 @@ See also `ffap-url-unwrap-remote' that may override this variable."
 
 (defcustom helm-find-files-ignore-thing-at-point nil
   "Use only `default-directory' as default input in `helm-find-files'.
-I.e text under cursor in `current-buffer' is ignored.
-Note that when non-nil you will be unable to complete filename at point
-in `current-buffer'."
+I.e. text under cursor in `current-buffer' is ignored.
+Note that when non-nil you will be unable to complete filename at
+point in `current-buffer'."
   :group 'helm-files
   :type 'boolean)
 
@@ -267,8 +271,8 @@ in `current-buffer'."
 (defcustom helm-mounted-network-directories nil
   "A list of directories used for mounting remotes filesystem.
 
-When nil `helm-file-on-mounted-network-p' always return nil otherwise
-it checks if a file is in one of these directories.
+When nil `helm-file-on-mounted-network-p' always return nil
+otherwise check if a file is in one of these directories.
 
 Remote filesystem are generally mounted with sshfs."
   :group 'helm-files
@@ -290,21 +294,22 @@ A function that takes a directory name as only arg."
   #'helm-ff-kill-or-find-buffer-fname
   "Default function used to expand non-directory filenames in `helm-find-files'.
 
-This variable will take effect only in `helm-find-files', it affects
-the behavior of persistent-action on filenames and non-existing
-filenames.
+This variable will take effect only in `helm-find-files'.  It
+affects the behavior of persistent-action on filenames and
+non-existing filenames.
 
 The default is to expand filename on first hit on
-\\<helm-map>\\[helm-execute-persistent-action], pop buffer in other
-window on second hit and finally kill this buffer on third hit, this
-is very handy to create several new buffers, or when navigating, show
-quickly the buffer of file to see its contents briefly before killing
-it and continue navigating.
+\\<helm-map>\\[helm-execute-persistent-action], pop buffer in
+other window on second hit and finally kill this buffer on third
+hit.  This is very handy to create several new buffers, or when
+navigating, show quickly the buffer of file to see its contents
+briefly before killing it and continue navigating.
 
-However some users may not want this, so to disable this behavior just
-set this to `ignore' function.
+However some users may not want this, so to disable this behaviour
+just set this to `ignore' function.
 
-Of course you can also write your own function to do something else."
+Of course you can also write your own function to do something
+else."
   :group 'helm-files
   :type 'function)
 
@@ -315,11 +320,11 @@ Of course you can also write your own function to do something else."
   :type '(repeat symbol))
 
 (defcustom helm-ff-allow-recursive-deletes nil
-  "when 'always don't prompt for recursive deletion of directories.
+  "When 'always don't prompt for recursive deletion of directories.
 When nil, will ask for recursive deletion.
-Note that when deleting multiple directories you can answer ! when
-prompted to avoid beeing asked for next directories, so it is probably
-better to not modify this variable."
+Note that when deleting multiple directories you can answer !
+when prompted to avoid being asked for next directories, so it
+is probably better to not modify this variable."
   :group 'helm-files
   :type '(choice
           (const :tag "Delete non-empty directories" t)
@@ -328,15 +333,16 @@ better to not modify this variable."
 (defcustom helm-ff-delete-files-function #'helm-delete-marked-files
   "The function to use by default to delete files.
 
-Default is to delete files synchronously, other choice is to delete
-files asynchronously.
+Default is to delete files synchronously, other choice is to
+delete files asynchronously.
 
 BE AWARE that when deleting async you will not be warned about
-recursive deletion of directories, IOW non empty directories will be
-deleted with no warnings in background!!!
+recursive deletion of directories, IOW non-empty directories will
+be deleted with no warnings in background!!!
 
-It is the function that will be used when using `\\<helm-find-files-map>\\[helm-ff-run-delete-file]'
-from `helm-find-files'."
+It is the function that will be used when using
+`\\<helm-find-files-map>\\[helm-ff-run-delete-file]' from
+`helm-find-files'."
   :group 'helm-files
   :type '(choice (function :tag "Delete files synchronously."
                   helm-delete-marked-files)
@@ -346,17 +352,18 @@ from `helm-find-files'."
 (defcustom helm-trash-remote-files nil
   "Allow trashing remote files when non-nil.
 
-Trashing remote files with tramp doesn't work out of the box unless
-'trash-cli' package is installed, it is why trashing remote files from
-helm is disabled by default.
+Trashing remote files with tramp doesn't work out of the box
+unless the 'trash-cli' package is installed.  This is why trashing
+remote files from Helm is disabled by default.
 
 Tramp is using external 'trash' command in its `delete-file' and
-`delete-directory' handlers when using `delete-by-moving-to-trash',
-which is documented nowhere in Emacs.
+`delete-directory' handlers when using
+`delete-by-moving-to-trash', which is documented nowhere in
+Emacs.
 
-If you want to enable this you will have to install the 'trash' command
-on remote (and/or locally if you want to trash as root), on Ubuntu
-based distribution it is 'trash-cli'."
+If you want to enable this you will have to install the 'trash'
+command on remote (and/or locally if you want to trash as root).
+On Ubuntu-based distributions it is 'trash-cli'."
   :group 'helm-files
   :type 'boolean)
 
@@ -368,29 +375,29 @@ based distribution it is 'trash-cli'."
     (t #'helm-list-dir-lisp))
   "The function used in `helm-find-files' to list remote directories.
 
-Actually helm provides two functions to do this: `helm-list-dir-lisp'
-and `helm-list-dir-external'.
+Actually Helm provides two functions to do this:
+`helm-list-dir-lisp' and `helm-list-dir-external'.
 
-Using `helm-list-dir-external' will provides a similar display to what
-provided with local files i.e. colorized symlinks, executables files
-etc... whereas using `helm-list-dir-lisp' will allow colorizing only
-directories but is more portable.
+Using `helm-list-dir-external' will provide a similar display to
+what is provided with local files i.e. colorized symlinks,
+executables files etc., whereas using `helm-list-dir-lisp' will
+allow colorizing only directories but it is more portable.
 
-NOTE:  `helm-list-dir-external' needs ls and awk as dependencies.
-Also the ls version installed on the remote side should support the
-same arguments as the GNU/ls version that are -A -1 -F -b and -Q.
-So even if you are using a GNU/ls version locally and you want to
-connect e.g. on a Freebsd server you may have failures due to the
-incompatible ls version installed on remote server.
-In such case use `helm-list-dir-lisp' which work everywhere but is
+NOTE: `helm-list-dir-external' needs ls and awk as dependencies.
+Also the ls version installed on the remote side should support
+the same arguments as the GNU/ls version, which are -A -1 -F -b
+and -Q.  So even if you are using a GNU/ls version locally and you
+want to connect e.g. on a Freebsd server, you may have failures
+due to the incompatible ls version installed on remote server.  In
+such case use `helm-list-dir-lisp' which works everywhere but is
 slower and less featured (only directories colorized)."
   :type 'function
   :group 'helm-files)
 
 (defcustom helm-ff-initial-sort-method nil
   "Sort method to use when initially listing a directory.
-Note that this doesn't affect the listing when matching inside the
-directory (i.e. filenames)."
+Note that this doesn't affect the listing when matching inside
+the directory (i.e. filenames)."
   :group 'helm-files
   :type '(choice
           (const :tag "alphabetically" nil)
@@ -407,8 +414,8 @@ directory (i.e. filenames)."
 
 (defcustom helm-ff-rotate-image-switch '("-i")
   "Options used with `helm-ff-rotate-image-program'.
-If you are using Mogrify or Jpegtran mandatory option is \"-rotate\",
-with Exiftran mandatory option is \"-i\"."
+If you are using Mogrify or Jpegtran mandatory option is
+\"-rotate\", with Exiftran mandatory option is \"-i\"."
   :group 'helm-files
   :type '(repeat string))
 
@@ -609,8 +616,8 @@ with Exiftran mandatory option is \"-i\"."
 
 (defcustom helm-ff-lynx-style-map t
   "Use arrow keys to navigate with `helm-find-files'.
-Note that if you define this variable with `setq' your change will
-have no effect, use customize instead."
+Note that if you define this variable with `setq' your change
+will have no effect, use customize instead."
   :group 'helm-files
   :type 'boolean
   :set (lambda (var val)
@@ -629,8 +636,8 @@ have no effect, use customize instead."
 (defcustom helm-ff-DEL-up-one-level-maybe nil
   "Use DEL to maybe go up one level when non nil.
 
-Going up one level works only when pattern is a directory endings with
-\"/\", otherwise this command delete char backward.
+Going up one level works only when pattern is a directory endings
+with \"/\", otherwise this command deletes char backward.
 
 When nil always delete char backward."
   :group 'helm-files
@@ -808,8 +815,8 @@ Should not be used among other sources.")
 (defcustom helm-dwim-target nil
   "Default target directory for file actions.
 
-Define the directory where you want to start navigating for the target
-directory when copying, renaming etc... You can use the
+Define the directory where you want to start navigating for the
+target directory when copying, renaming, etc..  You can use the
 `default-directory' of `next-window', the current
 `default-directory' or have completion on all the directories
 belonging to each window."
@@ -1082,8 +1089,8 @@ This reproduce the behavior of \"cp --backup=numbered from to\"."
 
 (defun helm-find-files-other-window (_candidate)
   "Keep current-buffer and open files in separate windows.
-When a prefix arg is detected files are opened in a vertical windows
-layout."
+When a prefix arg is detected files are opened in a vertical
+windows layout."
   (let* ((files (helm-marked-candidates))
          (buffers (mapcar 'find-file-noselect files)))
     (helm-window-show-buffers buffers t)))
@@ -1172,18 +1179,18 @@ layout."
 (defvar helm-eshell-command-on-file-input-history nil)
 (cl-defun helm-find-files-eshell-command-on-file-1 (&optional map)
   "Run `eshell-command' on CANDIDATE or marked candidates.
-This is done possibly with an eshell alias, if no alias found, you can type in
-an eshell command.
+This is done possibly with an Eshell alias.  If no alias found,
+you can type in an Eshell command.
 
-Only aliases accepting a file as argument at the end of command line
-are collected, i.e aliases ending with \"$1\" or \"$*\".
+Only aliases accepting a file as argument at the end of command
+line are collected, i.e. aliases ending with \"$1\" or \"$*\".
 
 Basename of CANDIDATE can be a wild-card.
-e.g you can do \"eshell-command command *.el\"
+E.g. you can do \"eshell-command command *.el\"
 Where \"*.el\" is the CANDIDATE.
 
-It is possible to do eshell-command command <CANDIDATE> <some more args>
-like this: \"command %s some more args\".
+It is possible to do eshell-command command <CANDIDATE> <some
+more args> like this: \"command %s some more args\".
 
 If MAP is given run `eshell-command' on all marked files at once,
 Otherwise, run `eshell-command' on each marked files.
@@ -1199,9 +1206,9 @@ otherwise do
 \"eshell-command command baz\"
 
 Note:
-You have to setup some aliases in eshell with the `alias' command or
-by editing yourself the file `eshell-aliases-file' to make this
-working."
+You have to setup some aliases in Eshell with the `alias' command
+or by editing yourself the file `eshell-aliases-file' to make
+this working."
   (require 'em-alias) (eshell-read-aliases-list)
   (when (or eshell-command-aliases-list
             (y-or-n-p "No eshell aliases found, run eshell-command without alias anyway? "))
@@ -1302,11 +1309,12 @@ See `helm-find-files-eshell-command-on-file-1' for more info."
 (defun helm-ff-switch-to-eshell (_candidate)
   "Switch to eshell and cd to `helm-ff-default-directory'.
 
-With a numeric prefix arg switch to numbered eshell buffer, if no
-prefix arg provided and more than one eshell buffer exists, provide
-completions on those buffers.  If only one eshell buffer exists,
-switch to this one, if no eshell buffer exists or if the numeric
-prefix arg eshell buffer doesn't exists, create it and switch to it."
+With a numeric prefix arg switch to numbered eshell buffer.  If no
+prefix arg is provided and more than one Eshell buffer exist,
+provide completions on those buffers.  If only one Eshell buffer
+exists, switch to this one.  If no Eshell buffer exists or if the
+Eshell buffer the numeric prefix arg points to doesn't exist,
+create it and switch to it."
   (let ((cd-eshell (lambda ()
                      (eshell/cd helm-ff-default-directory)
                      (eshell-reset)))
@@ -1449,13 +1457,13 @@ See `helm-ff-serial-rename-1'."
 
 (cl-defun helm-ff-serial-rename-1
     (directory collection new-name start-at-num extension &key (method 'rename))
-  "rename files in COLLECTION to DIRECTORY with the prefix name NEW-NAME.
+  "Rename files in COLLECTION to DIRECTORY with the prefix name NEW-NAME.
 Rename start at number START-AT-NUM - ex: prefixname-01.jpg.
-EXTENSION is the file extension to use, in empty prompt,
-reuse the original extension of file.
+EXTENSION is the file extension to use.  In empty prompt, reuse
+the original extension of file.
 METHOD can be one of rename, copy or symlink.
-Files will be renamed if they are files of current directory, otherwise they
-will be treated with METHOD.
+Files will be renamed if they are files of current directory,
+otherwise they will be treated with METHOD.
 Default METHOD is rename."
   ;; Maybe remove directories selected by error in collection.
   (setq collection (cl-remove-if 'file-directory-p collection))
@@ -1504,8 +1512,8 @@ See `helm-ff-serial-rename-1'."
 
 (defun helm-ff-serial-rename-by-symlink (_candidate)
   "Serial rename all marked files to `helm-ff-default-directory'.
-Rename only file of current directory, and symlink files coming from
-other directories.
+Rename only file of current directory, and symlink files coming
+from other directories.
 See `helm-ff-serial-rename-1'."
   (helm-ff-serial-rename-action 'symlink))
 
@@ -1719,11 +1727,12 @@ This doesn't replace inside the files, only modify filenames."
 (defun helm-ff-delete-char-backward ()
   "Go up one level or disable HFF auto update and delete char backward.
 
-Going up one level works only when pattern is a directory endings with
-\"/\", otherwise this command delete char backward.
+Going up one level works only when pattern is a directory endings
+with \"/\", otherwise this command deletes char backward.
 
-Going up one level can be disabled if necessary by deleting \"/\" at
-end of pattern using \\<helm-map>\\[backward-char] and \\[helm-delete-minibuffer-contents]."
+Going up one level can be disabled if necessary by deleting \"/\"
+at end of pattern using \\<helm-map>\\[backward-char] and
+\\[helm-delete-minibuffer-contents]."
   (interactive)
   (with-helm-alive-p
     (if (and helm-ff-DEL-up-one-level-maybe
@@ -1764,7 +1773,7 @@ If MUST-MATCH is specified exit with
 (defun helm-ff-RET ()
   "Default action for RET in `helm-find-files'.
 
-Behave differently depending of `helm-selection':
+Behave differently depending on `helm-selection':
 
 - candidate basename is \".\" => open it in dired.
 - candidate is a directory    => expand it.
@@ -1785,7 +1794,7 @@ Behave differently depending of `helm-selection':
 (defun helm-ff-TAB (arg)
   "Default action for TAB in `helm-find-files'.
 
-Behave differently depending of `helm-selection':
+Behave differently depending on `helm-selection':
 
 - candidate basename is \".\" => open the action menu.
 - candidate is a directory    => expand it.
@@ -2033,15 +2042,14 @@ When a prefix arg is provided, split is done vertically."
 (defun helm-ff-print (_candidate)
   "Print marked files.
 
-You may to set in order
-variables `lpr-command',`lpr-switches' and/or `printer-name',
-but with no settings helm should detect your printer(s) and
-print with the default `lpr' settings.
+You may to set in order variables `lpr-command',`lpr-switches'
+and/or `printer-name', but with no settings Helm should detect
+your printer(s) and print with the default `lpr' settings.
 
-NOTE: DO NOT set the \"-P\" flag in `lpr-switches', if you really
+NOTE: DO NOT set the \"-P\" flag in `lpr-switches'.  If you really
 have to modify this, do it in `lpr-printer-switch'.
 
-Same as `dired-do-print' but for helm."
+Same as `dired-do-print' but for Helm."
   (require 'lpr)
   (when (or helm-current-prefix-arg
             (not helm-ff-printer-list))
@@ -2089,11 +2097,11 @@ Same as `dired-do-print' but for helm."
 
 (defun helm-ff-checksum (file)
   "Calculate the checksum of FILE.
-The checksum is copied to kill-ring.
-Checksum is calculated with the md5sum, sha1sum, sha224sum, sha256sum,
-sha384sum and sha512sum when available, otherwise the emacs function
-`secure-hash' is used but it is slow and may crash Emacs and even the
-whole system as it eats all memory."
+The checksum is copied to `kill-ring'.
+Checksum is calculated with the md5sum, sha1sum, sha224sum,
+sha256sum, sha384sum and sha512sum when available, otherwise the
+Emacs function `secure-hash' is used but it is slow and may crash
+Emacs and even the whole system as it eats all memory."
   (cl-assert (file-regular-p file)
              nil "`%s' is not a regular file" file)
   (let* ((algo (intern (helm-comp-read
@@ -2244,8 +2252,8 @@ If prefix numeric arg is given go ARG level up."
 
 (defun helm-ff-retrieve-last-expanded ()
   "Move overlay to last visited directory `helm-ff-last-expanded'.
-This happen after using `helm-find-files-up-one-level',
-or hitting C-j on \"..\"."
+This happen after using `helm-find-files-up-one-level', or
+hitting C-j on \"..\"."
   (when helm-ff-last-expanded
     (let ((presel (if helm-ff-transformer-show-only-basename
                       (helm-basename
@@ -2300,8 +2308,8 @@ Ensure disabling `helm-ff-auto-update-flag' before undoing."
   "Expand to directory when sole completion.
 When only one candidate is remaining and it is a directory,
 expand to this directory.
-This happen only when `helm-ff-auto-update-flag' is non--nil
-or when `helm-pattern' is equal to \"~/\"."
+This happen only when `helm-ff-auto-update-flag' is non-nil or
+when `helm-pattern' is equal to \"~/\"."
   (let ((src (helm-get-current-source)))
     (when (and (helm-file-completion-source-p src)
                (not (get-buffer-window helm-action-buffer 'visible))
@@ -2536,7 +2544,7 @@ With a prefix arg toggle dired buffer to wdired mode."
     ((and vec (pred vectorp)) vec)))
 
 (defun helm-ff--get-tramp-methods ()
-  "Returns a list of the car of `tramp-methods'."
+  "Return a list of the car of `tramp-methods'."
   (or helm-ff--tramp-methods
       (setq helm-ff--tramp-methods (mapcar 'car tramp-methods))))
 
@@ -2575,8 +2583,8 @@ Return nil on valid file name remote or not."
 
 (cl-defun helm-ff--tramp-hostnames (&optional (pattern helm-pattern))
   "Get a list of hosts for tramp method found in `helm-pattern'.
-Argument PATTERN default to `helm-pattern', it is here only for debugging
-purpose."
+Argument PATTERN default to `helm-pattern'.  It is here only for
+debugging purpose."
   (when (string-match helm-tramp-file-name-regexp pattern)
     (let* ((mh-method   (helm-ff--previous-mh-tramp-method pattern))
            (method      (or (cadr mh-method) (match-string 1 pattern)))
@@ -2599,7 +2607,7 @@ purpose."
        :test 'equal))))
 
 (defun helm-ff-before-action-hook-fn ()
-  "Exit helm when user try to execute action on an invalid tramp fname."
+  "Exit Helm when user try to execute action on an invalid tramp fname."
   (let* ((src (helm-get-current-source))
          (cand (helm-get-selection nil nil src)))
     (when (and (helm-file-completion-source-p src)
@@ -2610,7 +2618,7 @@ purpose."
 (add-hook 'helm-before-action-hook 'helm-ff-before-action-hook-fn)
 
 (cl-defun helm-ff--invalid-tramp-name-p (&optional (pattern helm-pattern))
-  "Return non--nil when PATTERN is an invalid tramp filename."
+  "Return non-nil when PATTERN is an invalid tramp filename."
   (string= (helm-ff-set-pattern pattern)
            "Invalid tramp file name"))
 
@@ -2815,8 +2823,8 @@ purpose."
 (defun helm-list-directory (directory)
   "List directory DIRECTORY.
 
-If DIRECTORY is remote use `helm-list-directory-function' otherwise use
-`directory-files'."
+If DIRECTORY is remote use `helm-list-directory-function',
+otherwise use `directory-files'."
   (let* ((remote (file-remote-p directory 'method))
          (helm-list-directory-function
           (if (and remote (not (string= remote "ftp")))
@@ -2866,9 +2874,9 @@ Add a `helm-ff-dir' property on each fname ending with \"/\"."
 (defun helm-list-dir-external (dir &optional sort-method)
   "List directory DIR with external shell command as backend.
 
-This function is fast enough to be used for remote files and save the
-type of files at the same time in a property for using it later in the
-transformer."
+This function is fast enough to be used for remote files and save
+the type of files at the same time in a property for using it
+later in the transformer."
   (let ((default-directory (file-name-as-directory
                             (expand-file-name dir))))
     (with-temp-buffer
@@ -2910,8 +2918,8 @@ transformer."
 (defun helm-ff-directory-files (directory)
   "List contents of DIRECTORY.
 Argument FULL mean absolute path.
-It is same as `directory-files' but always returns the
-dotted filename '.' and '..' even on root directories in Windows
+It is same as `directory-files' but always returns the dotted
+filename '.' and '..' even on root directories in Windows
 systems."
   (setq directory (file-name-as-directory
                    (expand-file-name directory)))
@@ -2948,13 +2956,13 @@ systems."
 
 (defun helm-ff--transform-pattern-for-completion (pattern)
   "Maybe return PATTERN with it's basename modified as a regexp.
-This happen only when `helm-ff-fuzzy-matching' is enabled.
-This provide a similar behavior as `ido-enable-flex-matching'.
+This happens only when `helm-ff-fuzzy-matching' is enabled.
+This provides a similar behavior as `ido-enable-flex-matching'.
 See also `helm--mapconcat-pattern'.
-If PATTERN is an url returns it unmodified.
-When PATTERN contain a space fallback to multi-match.
-If basename contain one or more space fallback to multi-match.
-If PATTERN is a valid directory name,return PATTERN unchanged."
+If PATTERN is an url return it unmodified.
+When PATTERN contains a space fallback to multi-match.
+If basename contains one or more space fallback to multi-match.
+If PATTERN is a valid directory name, return PATTERN unchanged."
   ;; handle bad filenames containing a backslash (no more needed in
   ;; emacs-26, also prevent regexp matching with e.g. "\|").
   ;; (setq pattern (helm-ff-handle-backslash pattern))
@@ -3127,7 +3135,7 @@ Note that only existing directories are saved here."
           (t (message "No buffer to kill")))))
 
 (defun helm-ff-kill-or-find-buffer-fname (candidate)
-  "Find file CANDIDATE or kill it's buffer if it is visible.
+  "Find file CANDIDATE or kill its buffer if it is visible.
 Never kill `helm-current-buffer'.
 Never kill buffer modified.
 This is called normally on third hit of \
@@ -3176,9 +3184,10 @@ in `helm-find-files-persistent-action-if'."
 
 (defun helm-ff-prefix-filename (fname &optional file-or-symlinkp new-file)
   "Return filename FNAME maybe prefixed with [?] or [@].
-If FILE-OR-SYMLINKP is non--nil this mean we assume FNAME is an
-existing filename or valid symlink and there is no need to test it.
-NEW-FILE when non--nil mean FNAME is a non existing file and
+If FILE-OR-SYMLINKP is non-nil this means we assume FNAME is an
+existing filename or valid symlink and there is no need to test
+it.
+NEW-FILE when non-nil means FNAME is a non existing file and
 return FNAME prefixed with [?]."
   (let* ((prefix-new (propertize
                       " " 'display
@@ -3420,8 +3429,10 @@ Return candidates prefixed with basename of `helm-input' first."
 (defun helm-ff-trash-action (fn names &rest args)
   "Execute a trash action FN on marked files.
 
-Arg NAMES is a list of strings to pass to messages
-e.g. '(\"delete\" \"deleting\"), ARGS are other args to be passed to FN."
+Arg NAMES is a list of strings to pass to messages.
+E.g. '(\"delete\" \"deleting\")
+
+ARGS are other arguments to be passed to FN."
   (let ((mkd (helm-marked-candidates))
         errors)
     (with-helm-display-marked-candidates
@@ -3457,9 +3468,9 @@ e.g. '(\"delete\" \"deleting\"), ARGS are other args to be passed to FN."
   "Delete marked-files from a Trash directory.
 
 The Trash directory should be a directory compliant with
-<http://freedesktop.org/wiki/Specifications/trash-spec> and each file
-should have its '*.trashinfo' correspondent file in Trash/info
-directory."
+<http://freedesktop.org/wiki/Specifications/trash-spec> and each
+file should have its '*.trashinfo' correspondent file in
+Trash/info directory."
   (helm-ff-trash-action 'helm-ff-trash-rm-1 '("delete" "deleting")))
 
 (defun helm-ff-trash-rm-1 (file)
@@ -3481,9 +3492,9 @@ directory."
   "Restore marked-files from a Trash directory.
 
 The Trash directory should be a directory compliant with
-<http://freedesktop.org/wiki/Specifications/trash-spec> and each file
-should have its '*.trashinfo' correspondent file in Trash/info
-directory."
+<http://freedesktop.org/wiki/Specifications/trash-spec> and each
+file should have its '*.trashinfo' correspondent file in
+Trash/info directory."
   (let* ((default-directory (file-name-as-directory
                              helm-ff-default-directory))
          (trashed-files     (helm-ff-trash-list)))
@@ -3493,8 +3504,8 @@ directory."
 
 (defun helm-restore-file-from-trash-1 (file trashed-files)
   "Restore FILE from a trash directory.
-Arg TRASHED-FILES is an alist of (fname_in_trash . dest) obtained with
-`helm-ff-trash-list'."
+Arg TRASHED-FILES is an alist of (fname_in_trash . dest) obtained
+with `helm-ff-trash-list'."
   ;; Emacs trash duplicate files with a unique name + .trashinfo in
   ;; the filename which is wrong, only files in info directory should
   ;; end with .trashinfo, so fix the filename before looking for dest name.
@@ -3514,7 +3525,7 @@ Arg TRASHED-FILES is an alist of (fname_in_trash . dest) obtained with
     (delete-file info-file)))
 
 (defun helm-ff-trash-file-p (file)
-  "Return `t' when file is a trashed file."
+  "Return t when FILE is a trashed file."
   (and (file-exists-p file)
        (string-match "Trash/files/?\\'" (helm-basedir file))
        (not (member (helm-basename file) '("." "..")))))
@@ -3541,8 +3552,8 @@ Arg TRASHED-FILES is an alist of (fname_in_trash . dest) obtained with
 
 (defun helm-ff-goto-linum (candidate)
   "Find file CANDIDATE and maybe jump to line number found in fname at point.
-line number should be added at end of fname preceded with \":\".
-e.g \"foo:12\"."
+Line number should be added at end of fname preceded with \":\".
+E.g. \"foo:12\"."
   (let ((linum (with-helm-current-buffer
                  (let ((str (buffer-substring-no-properties
                              (point-at-bol) (point-at-eol))))
@@ -3607,12 +3618,12 @@ e.g \"foo:12\"."
 
 (defun helm-ff-rotate-image-left (candidate)
   "Rotate image file CANDIDATE left.
-This affect directly file CANDIDATE."
+This affects directly file CANDIDATE."
   (helm-ff-rotate-current-image-1 candidate 270))
 
 (defun helm-ff-rotate-image-right (candidate)
   "Rotate image file CANDIDATE right.
-This affect directly file CANDIDATE."
+This affects directly file CANDIDATE."
   (helm-ff-rotate-current-image-1 candidate 90))
 
 (defun helm-ff-rotate-left-persistent ()
@@ -3646,9 +3657,10 @@ This affect directly file CANDIDATE."
   "Open subtree CANDIDATE without quitting helm.
 If CANDIDATE is not a directory expand CANDIDATE filename.
 If CANDIDATE is alone, open file CANDIDATE filename.
-That's mean:
-First hit on C-j expand CANDIDATE second hit open file.
-If a prefix arg is given or `helm-follow-mode' is on open file."
+That means:
+First hit on C-j expands CANDIDATE, second hit opens file.
+If a prefix arg is given or `helm-follow-mode' is on, then open
+file."
   (let* ((follow        (or (helm-follow-mode-p)
                             helm--temp-follow-flag))
          (image-cand    (string-match-p (image-file-name-regexp) candidate))
@@ -3850,10 +3862,11 @@ If a prefix arg is given or `helm-follow-mode' is on open file."
   "Insert file name completion at point.
 
 When completing i.e. there is already something at point, insert
-filename abbreviated, relative or full according to initial input,
-whereas when inserting i.e. there is nothing at point, insert filename
-full, abbreviated or relative according to prefix arg, respectively no
-prefix arg, one prefix arg or two prefix arg."
+filename abbreviated, relative or full according to initial
+input, whereas when inserting i.e. there is nothing at point,
+insert filename full, abbreviated or relative according to prefix
+arg, respectively no prefix arg, one prefix arg or two prefix
+arg."
   (with-helm-current-buffer
     (if buffer-read-only
         (error "Error: Buffer `%s' is read-only" (buffer-name))
@@ -3950,7 +3963,7 @@ Show the first `helm-ff-history-max-length' elements of
 (defun helm-find-files-1 (fname &optional preselect)
   "Find FNAME filename with PRESELECT filename preselected.
 
-Use it for non--interactive calls of `helm-find-files'."
+Use it for non-interactive calls of `helm-find-files'."
   (require 'tramp)
   ;; Resolve FNAME now outside of helm.
   ;; [FIXME] When `helm-find-files-1' is used directly from lisp
@@ -3993,8 +4006,8 @@ Use it for non--interactive calls of `helm-find-files'."
 
 (defun helm-ff--update-resume-after-hook (sources &optional nohook)
   "Meant to be used in `helm-resume-after-hook'.
-When NOHOOK is non nil run inconditionally, otherwise only when source
-is helm-source-find-files."
+When NOHOOK is non-nil run inconditionally, otherwise only when
+source is `helm-source-find-files'."
   (when (or nohook (string= "Find Files"
                             (assoc-default 'name (car sources))))
     (helm-attrset 'resume `(lambda ()
@@ -4189,8 +4202,8 @@ Find inside `require' and `declare-function' sexp."
   "Execute ACTION on FILES to CANDIDATE.
 Where ACTION is a symbol that can be one of:
 'copy, 'rename, 'symlink,'relsymlink, 'hardlink or 'backup.
-Argument FOLLOW when non--nil specify to follow FILES to destination for the actions
-copy and rename."
+Argument FOLLOW when non-nil specifies to follow FILES to
+destination for the actions copy and rename."
   (require 'dired-async)
   (require 'dired-x) ; For dired-keep-marker-relsymlink
   (when (get-buffer dired-log-buffer) (kill-buffer dired-log-buffer))
@@ -4258,8 +4271,8 @@ copy and rename."
 
 (defun helm-get-dest-fnames-from-list (flist dest-cand rename-dir-flag)
   "Transform filenames of FLIST to abs of DEST-CAND.
-If RENAME-DIR-FLAG is non--nil collect the `directory-file-name' of transformed
-members of FLIST."
+If RENAME-DIR-FLAG is non-nil collect the `directory-file-name'
+of transformed members of FLIST."
   ;; At this point files have been renamed/copied at destination.
   ;; That's mean DEST-CAND exists.
   (cl-loop
@@ -4276,8 +4289,8 @@ members of FLIST."
 
 (defun helm-ff-maybe-mark-candidates ()
   "Mark all candidates of list `helm-ff-cand-to-mark'.
-This is used when copying/renaming/symlinking etc... and
-following files to destination."
+This is used when copying/renaming/symlinking etc. and following
+files to destination."
   (when (and (string= (assoc-default 'name (helm-get-current-source))
                       (assoc-default 'name helm-source-find-files))
              helm-ff-cand-to-mark)
@@ -4297,7 +4310,7 @@ following files to destination."
 ;;
 ;;
 (defun helm-file-buffers (filename)
-  "Returns a list of buffer names corresponding to FILENAME."
+  "Return a list of buffer names corresponding to FILENAME."
   (cl-loop with name = (expand-file-name filename)
         for buf in (buffer-list)
         for bfn = (buffer-file-name buf)
@@ -4306,7 +4319,7 @@ following files to destination."
 
 (defun helm-ff--delete-by-moving-to-trash (file)
   "Decide to trash or delete FILE.
-Returns non-nil when FILE needs to be trashed."
+Return non-nil when FILE needs to be trashed."
   (let ((remote (file-remote-p file)))
     (or
      (and delete-by-moving-to-trash
@@ -4323,8 +4336,8 @@ Returns non-nil when FILE needs to be trashed."
 (defun helm-ff-quick-delete (_candidate)
   "Delete file CANDIDATE without quitting.
 
-When a prefix arg is given, meaning of `delete-by-moving-to-trash' is
-inversed."
+When a prefix arg is given, meaning of
+`delete-by-moving-to-trash' is the opposite."
   (with-helm-window
     (let ((marked (helm-marked-candidates)))
       (unwind-protect
@@ -4356,11 +4369,11 @@ inversed."
 (defun helm-delete-file (file &optional error-if-dot-file-p synchro trash)
   "Delete FILE after querying the user.
 
-When a prefix arg is given, meaning of `delete-by-moving-to-trash' is
-inversed.
+When a prefix arg is given, meaning of
+`delete-by-moving-to-trash' is the opposite.
 
-Return error when ERROR-IF-DOT-FILE-P is non nil and user tries to
-delete a dotted file i.e. \".\" or \"..\".
+Return error when ERROR-IF-DOT-FILE-P is non-nil and user tries
+to delete a dotted file i.e. \".\" or \"..\".
 
 Ask user when directory are not empty to allow recursive deletion
 unless `helm-ff-allow-recursive-deletes' is non nil.
@@ -4419,8 +4432,8 @@ is nil."
 (defun helm-delete-marked-files (_ignore)
   "Delete marked files with `helm-delete-file'.
 
-When a prefix arg is given, meaning of `delete-by-moving-to-trash' is
-inversed."
+When a prefix arg is given, meaning of
+`delete-by-moving-to-trash' is the opposite."
   (let* ((files (helm-marked-candidates :with-wildcard t))
          (len 0)
          (trash (helm-ff--delete-by-moving-to-trash (car files)))
@@ -4449,7 +4462,7 @@ inversed."
 ;;
 (defvar helm-ff-delete-log-file
   (locate-user-emacs-file "helm-delete-file.log")
-  "The file use to communicate with emacs child when deleting files async.")
+  "The file use to communicate with Emacs child when deleting files async.")
 
 (defvar helm-ff--trash-flag nil)
 
@@ -4470,7 +4483,7 @@ inversed."
     (setq helm-ff--trash-flag nil)))
 
 (defun helm-delete-async-mode-line-message (text face &rest args)
-  "Notify end of async operation in `mode-line'."
+  "Notify end of async operation in mode-line."
   (message nil)
   (let ((mode-line-format (concat
                            " " (propertize
@@ -4485,12 +4498,12 @@ inversed."
 (defun helm-delete-marked-files-async (_ignore)
   "Same as `helm-delete-marked-files' but async.
 
-When a prefix arg is given, meaning of `delete-by-moving-to-trash' is
-inversed.
+When a prefix arg is given, meaning of
+`delete-by-moving-to-trash' is the opposite.
 
-This function is not using `helm-delete-file' and BTW not asking user
-for recursive deletion of directory, be warned that directories are
-always deleted with no warnings."
+This function is not using `helm-delete-file' and BTW not asking
+user for recursive deletion of directory, be warned that
+directories are always deleted with no warnings."
   (let* ((files (helm-marked-candidates :with-wildcard t))
          (trash (helm-ff--delete-by-moving-to-trash (car files)))
          (prmt (if trash "Trash" "Delete"))
@@ -4558,7 +4571,8 @@ always deleted with no warnings."
   "Open file CANDIDATE or open helm marked files in separate windows.
 Called with one prefix arg open files in separate windows in a
 vertical split.
-Called with two prefix arg open files in background without selecting them."
+Called with two prefix arg open files in background without
+selecting them."
   (let ((marked (helm-marked-candidates :with-wildcard t))
         (url-p (and helm--url-regexp ; we should have only one candidate.
                     (string-match helm--url-regexp candidate)))
@@ -4620,14 +4634,14 @@ Called with two prefix arg open files in background without selecting them."
     (or (and helm-ff (helm-find-files-1 dir)) t)))
 
 (defun helm-transform-file-load-el (actions candidate)
-  "Add action to load the file CANDIDATE if it is an emacs lisp
+  "Add action to load the file CANDIDATE if it is an Emacs Lisp
 file.  Else return ACTIONS unmodified."
   (if (member (file-name-extension candidate) '("el" "elc"))
       (append actions '(("Load Emacs Lisp File" . load-file)))
     actions))
 
 (defun helm-transform-file-browse-url (actions candidate)
-  "Add an action to browse the file CANDIDATE if it is a html file or URL.
+  "Add an action to browse the file CANDIDATE if it is a HTML file or URL.
 Else return ACTIONS unmodified."
   (let ((browse-action '("Browse with Browser" . browse-url)))
     (cond ((string-match "^http\\|^ftp" candidate)
@@ -4637,9 +4651,10 @@ Else return ACTIONS unmodified."
           (t actions))))
 
 (defun helm-file-on-mounted-network-p (file)
-  "Returns non-nil when FILE is part of a mounted remote directory.
+  "Return non-nil when FILE is part of a mounted remote directory.
 
-This function is checking `helm-mounted-network-directories' list."
+This function is checking `helm-mounted-network-directories'
+list."
   (when helm-mounted-network-directories
     (cl-loop for dir in helm-mounted-network-directories
              thereis (file-in-directory-p file dir))))
@@ -4680,8 +4695,9 @@ This function is checking `helm-mounted-network-directories' list."
     :action 'helm-type-file-actions))
 
 (defvar helm-source--ff-file-name-history nil
-  "[Internal] This source is build to be used with `helm-find-files'.
-Don't use it in your own code unless you know what you are doing.")
+  "[INTERNAL] This source is build to be used with `helm-find-files'.
+Don't use it in your own code unless you know what you are
+doing.")
 
 (defvar helm--file-name-history-hide-deleted nil)
 
@@ -4819,12 +4835,12 @@ Use RG as backend."
   (helm-browse-project-find-files-1 directory 'rg))
 
 (defun helm-browse-project-ag (_candidate)
-  "helm-grep AG action for helm-browse-project."
+  "A `helm-grep' AG action for `helm-browse-project'."
   (let ((dir (with-helm-buffer (helm-attr 'root-dir))))
     (helm-grep-ag dir helm-current-prefix-arg)))
 
 (defun helm-browse-project-run-ag ()
-  "Runs helm-grep AG from helm-browse-project."
+  "Run `helm-grep' AG from `helm-browse-project'."
   (interactive)
   (with-helm-alive-p
     (helm-exit-and-execute-action 'helm-browse-project-ag)))
@@ -4850,8 +4866,8 @@ Use RG as backend."
                                               'face 'helm-ff-file)
                                   c)
                           (propertize c 'face 'helm-ff-file)))))
-  "Class to define a source in helm-browse-project handling non VC
-handled directories.")
+  "Class to define a source in `helm-browse-project' handling non
+VC handled directories.")
 
 (defmethod helm--setup-source :after ((source helm-browse-project-override-inheritor))
   (let ((actions (slot-value source 'action)))
@@ -4899,15 +4915,16 @@ handled directories.")
 ;;;###autoload
 (defun helm-browse-project (arg)
   "Preconfigured helm to browse projects.
-Browse files and see status of project with its vcs.
+Browse files and see status of project with its VCS.
 Only HG and GIT are supported for now.
-Fall back to `helm-browse-project-find-files'
-if current directory is not under control of one of those vcs.
+Fall back to `helm-browse-project-find-files' if current
+directory is not under control of one of those VCS.
 With a prefix ARG browse files recursively, with two prefix ARG
 rebuild the cache.
 If the current directory is found in the cache, start
 `helm-browse-project-find-files' even with no prefix ARG.
-NOTE: The prefix ARG have no effect on the VCS controlled directories.
+NOTE: The prefix ARG have no effect on the VCS controlled
+directories.
 
 Needed dependencies for VCS:
 <https://github.com/emacs-helm/helm-ls-git>
@@ -4990,7 +5007,8 @@ See `helm-browse-project'."
   "Preconfigured `helm' for helm implementation of `find-file'.
 Called with a prefix arg show history if some.
 Don't call it from programs, use `helm-find-files-1' instead.
-This is the starting point for nearly all actions you can do on files."
+This is the starting point for nearly all actions you can do on
+files."
   (interactive "P")
   (let* ((hist            (and arg helm-ff-history (helm-find-files-history nil)))
          (smart-input     (or hist (helm-find-files-initial-input)))
@@ -5040,10 +5058,11 @@ This is the starting point for nearly all actions you can do on files."
 (defun helm-delete-tramp-connection ()
   "Allow deleting tramp connection or marked tramp connections at once.
 
-This replace `tramp-cleanup-connection' which is partially broken in
-emacs < to 25.1.50.1 (See Emacs Bug#24432).
+This replace `tramp-cleanup-connection' which is partially broken
+in Emacs < to 25.1.50.1 (See Emacs Bug#24432).
 
-It allows additionally to delete more than one connection at once."
+It allows additionally to delete more than one connection at
+once."
   (interactive)
   (let ((helm-quit-if-no-candidate
          (lambda ()

--- a/helm-find.el
+++ b/helm-find.el
@@ -26,8 +26,9 @@
   :type  'boolean)
 
 (defcustom helm-findutils-search-full-path nil
-  "Search in full path with shell command find when non--nil.
-I.e use the -path/ipath arguments of find instead of -name/iname."
+  "Search in full path with shell command find when non-nil.
+I.e. use the -path/ipath arguments of find instead of
+-name/iname."
   :group 'helm-files
   :type 'boolean)
 

--- a/helm-font.el
+++ b/helm-font.el
@@ -23,7 +23,7 @@
 
 
 (defgroup helm-font nil
-  "Related applications to display fonts in helm."
+  "Related applications to display fonts in Helm."
   :group 'helm)
 
 (defcustom helm-ucs-recent-size 10
@@ -111,7 +111,7 @@
            finally return (cons code char)))
 
 (defun helm-calculate-ucs-max-len ()
-  "Calculate the length of longest `ucs-names' candidate."
+  "Calculate the length of the longest `ucs-names' candidate."
   (let ((ucs-struct (ucs-names)))
     (if (hash-table-p ucs-struct)
         (helm-calculate-ucs-hash-table-max-len ucs-struct)
@@ -172,7 +172,7 @@ either be an alist or a hash-table."
     (helm-ucs-collect-symbols-alist ucs-struct)))
 
 (defun helm-ucs-init ()
-  "Initialize an helm buffer with ucs symbols.
+  "Initialize a Helm buffer with ucs symbols.
 Only math* symbols are collected."
   (unless helm-ucs--max-len
     (setq helm-ucs--max-len
@@ -185,7 +185,8 @@ Only math* symbols are collected."
 
 (defun helm-ucs-match (candidate n)
   "Return the N part of an ucs CANDIDATE.
-Where N=1 is the ucs code, N=2 the ucs char and N=3 the ucs name."
+Where N=1 is the ucs code, N=2 the ucs char and N=3 the ucs
+name."
   (when (string-match
          "^(\\(#x[a-f0-9]+\\)): *\\(.\\) *\\([^:]+\\)+"
          candidate)
@@ -310,7 +311,7 @@ Where N=1 is the ucs code, N=2 the ucs char and N=3 the ucs name."
 
 ;;;###autoload
 (defun helm-ucs (arg)
-  "Preconfigured helm for `ucs-names'.
+  "Preconfigured `helm' for `ucs-names'.
 
 Called with a prefix arg force reloading cache."
   (interactive "P")

--- a/helm-for-files.el
+++ b/helm-for-files.el
@@ -35,8 +35,8 @@
     helm-source-locate)
   "Your preferred sources for `helm-for-files' and `helm-multi-files'.
 
-When adding a source here it is up to you to ensure the library of
-this source is accessible and properly loaded."
+When adding a source here it is up to you to ensure the library
+of this source is accessible and properly loaded."
   :type '(repeat (choice symbol))
   :group 'helm-files)
 
@@ -138,10 +138,11 @@ Be aware that a nil value will make tramp display very slow."
 
 (defvar helm-source-recentf nil
   "See (info \"(emacs)File Conveniences\").
-Set `recentf-max-saved-items' to a bigger value if default is too small.")
+Set `recentf-max-saved-items' to a bigger value if default is too
+small.")
 
 (defcustom helm-recentf-fuzzy-match nil
-  "Enable fuzzy matching in `helm-source-recentf' when non--nil."
+  "Enable fuzzy matching in `helm-source-recentf' when non-nil."
   :group 'helm-files
   :type 'boolean
   :set (lambda (var val)
@@ -253,8 +254,8 @@ Run all sources defined in `helm-for-files-preferred-list'."
 
 Allow toggling back and forth from locate to others sources with
 `helm-multi-files-toggle-locate-binding' key.
-This avoid launching needlessly locate when what you search is already
-found."
+This avoids launching locate needlessly when what you are
+searching for is already found."
   (interactive)
   (require 'helm-x-files)
   (unless helm-source-buffers-list

--- a/helm-grep.el
+++ b/helm-grep.el
@@ -63,16 +63,17 @@ Where:
 If your grep version doesn't support the --exclude/include args
 don't specify the '%e' format spec.
 
-Helm also support ack-grep and git-grep ,
-here a default command example for ack-grep:
+Helm also support ack-grep and git-grep.  The following is a
+default command example for ack-grep:
 
 \(setq helm-grep-default-command \"ack-grep -Hn --color --smart-case --no-group %e %p %f\"
        helm-grep-default-recurse-command \"ack-grep -H --color --smart-case --no-group %e %p %f\")
 
-You can ommit the %e spec if you don't want to be prompted for types.
+You can ommit the %e spec if you don't want to be prompted for
+types.
 
 NOTE: Helm for ack-grep support ANSI sequences, so you can remove
-the \"--no-color\" option safely (recommended)
+the \"--no-color\" option safely (recommended).
 However you should specify --color to enable multi matches highlighting
 because ack disable it when output is piped.
 
@@ -87,24 +88,26 @@ you will have to setup this in your .gitconfig:
     [color \"grep\"]
         match = black yellow
 
-where \"black\" is the foreground and \"yellow\" the background.
+Where \"black\" is the foreground and \"yellow\" the background.
 See the git documentation for more infos.
 
-`helm-grep-default-command' and `helm-grep-default-recurse-command'are
-independents, so you can enable `helm-grep-default-command' with ack-grep
-and `helm-grep-default-recurse-command' with grep if you want to be faster
-on recursive grep.
+`helm-grep-default-command' and
+`helm-grep-default-recurse-command' are independent, so you can
+enable `helm-grep-default-command' with ack-grep and
+`helm-grep-default-recurse-command' with grep if you want to be
+faster on recursive grep.
 
-NOTE: Remote grepping is not available with ack-grep,
-      and badly supported with grep because tramp handle badly
-      repeated remote processes in a short delay (< to 5s)."
+NOTE: Remote grepping is not available with ack-grep, and badly
+      supported with grep because tramp handles badly repeated
+      remote processes in a short delay (< to 5s)."
   :group 'helm-grep
   :type  'string)
 
 (defcustom helm-grep-default-recurse-command
   "grep --color=always -a -d recurse %e -n%cH -e %p %f"
   "Default recursive grep format command for `helm-do-grep-1'.
-See `helm-grep-default-command' for format specs and infos about ack-grep."
+See `helm-grep-default-command' for format specs and infos about
+ack-grep."
   :group 'helm-grep
   :type  'string)
 
@@ -112,37 +115,39 @@ See `helm-grep-default-command' for format specs and infos about ack-grep."
   "zgrep --color=always -a -n%cH -e %p %f"
   "Default command for Zgrep.
 See `helm-grep-default-command' for infos on format specs.
-Option --color=always is supported and can be used safely
-to replace the helm internal match highlighting,
-see `helm-grep-default-command' for more infos."
+Option --color=always is supported and can be used safely to
+replace the Helm internal match highlighting.  See
+`helm-grep-default-command' for more infos."
   :group 'helm-grep
   :type  'string)
 
 (defcustom helm-pdfgrep-default-command
   "pdfgrep --color always -niH %s %s"
   "Default command for pdfgrep.
-Option \"--color always\" is supported starting helm version 1.7.8,
-when used matchs will be highlighted according to GREP_COLORS env var."
+Option \"--color always\" is supported starting Helm version
+1.7.8.  When used matches will be highlighted according to
+GREP_COLORS env var."
   :group 'helm-grep
   :type  'string)
 
 (defcustom helm-pdfgrep-default-recurse-command
   "pdfgrep --color always -rniH %s %s"
   "Default recurse command for pdfgrep.
-Option \"--color always\" is supported starting helm version 1.7.8,
-when used matchs will be highlighted according to GREP_COLORS env var."
+Option \"--color always\" is supported starting Helm version
+1.7.8.  When used matches will be highlighted according to
+GREP_COLORS env var."
   :group 'helm-grep
   :type  'string)
 
 (defcustom helm-pdfgrep-default-read-command nil
   "Default command to read pdf files from pdfgrep.
 Where '%f' format spec is filename and '%p' is page number.
-e.g In Ubuntu you can set it to:
+E.g. In Ubuntu you can set it to:
 
     \"evince --page-label=%p '%f'\"
 
-If set to nil either `doc-view-mode' or `pdf-view-mode' will be used
-instead of an external command."
+If set to nil either `doc-view-mode' or `pdf-view-mode' will be
+used instead of an external command."
   :group 'helm-grep
   :type  'string)
 
@@ -163,7 +168,7 @@ instead of an external command."
   :type  'string)
 
 (defcustom helm-grep-save-buffer-name-no-confirm nil
-  "when *hgrep* already exists,auto append suffix."
+  "When *hgrep* already exists, auto append suffix."
   :group 'helm-grep
   :type 'boolean)
 
@@ -210,25 +215,27 @@ Possible value are:
 
 (defcustom helm-grep-pipe-cmd-switches nil
   "A list of additional parameters to pass to grep pipe command.
-This will be used for pipe command for multiple pattern matching
+This will be used to pipe command for multiple pattern matching
 for grep, zgrep ack-grep and git-grep backends.
-If you add extra args for ack-grep, use ack-grep options,
-for others (grep, zgrep and git-grep) use grep options.
+If you add extra args for ack-grep, use ack-grep options, for
+others (grep, zgrep and git-grep) use grep options.
 Here are the commands where you may want to add switches:
 
     grep --color=always
     ack-grep --smart-case --color
 
-You probably don't need to use this unless you know what you are doing."
+You probably don't need to use this unless you know what you are
+doing."
   :group 'helm-grep
   :type '(repeat string))
 
 (defcustom helm-grep-ag-pipe-cmd-switches nil
   "A list of additional parameters to pass to grep-ag pipe command.
 Use parameters compatibles with the backend you are using
-\(i.e AG for AG, PT for PT or RG for RG)
+\(i.e. AG for AG, PT for PT or RG for RG)
 
-You probably don't need to use this unless you know what you are doing."
+You probably don't need to use this unless you know what you are
+doing."
   :group 'helm-grep
   :type '(repeat string))
 
@@ -294,8 +301,8 @@ Have no effect when grep backend use \"--color=\"."
 
 (defcustom helm-grep-use-ioccur-style-keys t
   "Use Arrow keys to jump to occurences.
-Note that if you define this variable with `setq' your change will
-have no effect, use customize instead."
+Note that if you define this variable with `setq' your change
+will have no effect, use customize instead."
   :group 'helm-grep
   :type  'boolean
   :set (lambda (var val)
@@ -512,7 +519,7 @@ It is intended to use as a let-bound variable, DON'T set this globaly.")
                  (cons ?m pipes))))))
 
 (defun helm-grep-init (cmd-line)
-  "Start an asynchronous grep process with CMD-LINE using ZGREP if non--nil."
+  "Start an asynchronous grep process with CMD-LINE using ZGREP if non-nil."
   (let* ((default-directory (or helm-ff-default-directory
                                 (helm-default-directory)
                                 default-directory))
@@ -607,7 +614,7 @@ It is intended to use as a let-bound variable, DON'T set this globaly.")
 ;;
 (defun helm-grep-action (candidate &optional where)
   "Define a default action for `helm-do-grep-1' on CANDIDATE.
-WHERE can be one of other-window, other-frame."
+WHERE can be `other-window' or `other-frame'."
   (let* ((split        (helm-grep-split-line candidate))
          (split-pat    (helm-mm-split-pattern helm-input))
          (lineno       (string-to-number (nth 1 split)))
@@ -720,7 +727,7 @@ If N is positive go forward otherwise go backward."
 
 ;;;###autoload
 (defun helm-goto-precedent-file ()
-  "Go to precedent file in helm grep/etags buffers."
+  "Go to previous file in Helm grep/etags buffers."
   (interactive)
   (with-helm-alive-p
     (with-helm-window
@@ -729,7 +736,7 @@ If N is positive go forward otherwise go backward."
 
 ;;;###autoload
 (defun helm-goto-next-file ()
-  "Go to precedent file in helm grep/etags buffers."
+  "Go to previous file in Helm grep/etags buffers."
   (interactive)
   (with-helm-window
     (helm-goto-next-or-prec-file 1)))
@@ -771,7 +778,7 @@ If N is positive go forward otherwise go backward."
 
 (defvar helm-grep-mode-use-pcre nil)
 (defun helm-grep-save-results-1 ()
-  "Save helm grep result in a `helm-grep-mode' buffer."
+  "Save Helm grep result in a `helm-grep-mode' buffer."
   (let* ((buf "*hgrep*")
          new-buf
          (pattern (with-helm-buffer helm-input-local))
@@ -974,7 +981,8 @@ Special commands:
 ;;
 (defun helm-grep-guess-extensions (files)
   "Try to guess file extensions in FILES list when using grep recurse.
-These extensions will be added to command line with --include arg of grep."
+These extensions will be added to command line with --include arg
+of grep."
   (cl-loop with ext-list = (list helm-grep-preferred-ext "*")
         with lst = (if (file-directory-p (car files))
                        (directory-files
@@ -1015,10 +1023,10 @@ These extensions will be added to command line with --include arg of grep."
 ;;
 ;;
 (defvar helm-grep-before-init-hook nil
-  "Hook that runs before initialization of the helm buffer.")
+  "Hook that runs before initialization of the Helm buffer.")
 
 (defvar helm-grep-after-init-hook nil
-  "Hook that runs after initialization of the helm buffer.")
+  "Hook that runs after initialization of the Helm buffer.")
 
 (defclass helm-grep-class (helm-source-async)
   ((candidates-process :initform 'helm-grep-collect-candidates)
@@ -1026,7 +1034,7 @@ These extensions will be added to command line with --include arg of grep."
    (keymap :initform helm-grep-map)
    (pcre :initarg :pcre :initform nil
          :documentation
-         "  Backend is using pcre regexp engine when non--nil.")
+         "  Backend is using pcre regexp engine when non-nil.")
    (nohighlight :initform t)
    (nomark :initform t)
    (backend :initarg :backend
@@ -1034,7 +1042,7 @@ These extensions will be added to command line with --include arg of grep."
             :documentation
             "  The grep backend that will be used.
   It is actually used only as an internal flag
-  and don't set the backend by itself.
+  and doesn't set the backend by itself.
   You probably don't want to modify this.")
    (candidate-number-limit :initform 9999)
    (help-message :initform 'helm-grep-help-message)
@@ -1063,24 +1071,26 @@ These extensions will be added to command line with --include arg of grep."
   "Launch helm using backend BACKEND on a list of TARGETS files.
 
 When RECURSE is given and BACKEND is 'grep' use -r option of
-BACKEND and prompt user for EXTS to set the --include args of BACKEND.
-Interactively you can give more than one arg separated by space at prompt.
-e.g
+BACKEND and prompt user for EXTS to set the --include args of
+BACKEND.
+Interactively you can give more than one arg separated by space
+at prompt.
+E.g.:
     $Pattern: *.el *.py *.tex
 
-From lisp use the EXTS argument as a list of extensions as above.
+From Lisp use the EXTS argument as a list of extensions as above.
 If you are using ack-grep, you will be prompted for --type
-instead and EXTS will be ignored.
-If prompt is empty `helm-grep-ignored-files' are added to --exclude.
+instead and EXTS will be ignored.  If prompt is empty
+`helm-grep-ignored-files' are added to --exclude.
 
-Argument DEFAULT-INPUT is use as `default' arg of `helm' and INPUT
-is used as `input' arg of `helm', See `helm' docstring.
+Argument DEFAULT-INPUT is use as `default' arg of `helm' and
+INPUT is used as `input' arg of `helm'.  See `helm' docstring.
 
-Arg BACKEND when non--nil specify which backend to use
+Arg BACKEND when non-nil specifies which backend to use.
 It is used actually to specify 'zgrep' or 'git'.
-When BACKEND 'zgrep' is used don't prompt for a choice
-in recurse, and ignore EXTS, search being made recursively on files matching
-`helm-zgrep-file-extension-regexp' only."
+When BACKEND 'zgrep' is used don't prompt for a choice in
+recurse, and ignore EXTS, search being made recursively on files
+matching `helm-zgrep-file-extension-regexp' only."
   (let* (non-essential
          (ack-rec-p (helm-grep-use-ack-p :where 'recursive))
          (exts (and recurse
@@ -1275,12 +1285,13 @@ in recurse, and ignore EXTS, search being made recursively on files matching
 ;;
 ;;
 (defun helm-grep-buffers-1 (candidate &optional zgrep)
-  "Run grep on all file--buffers or CANDIDATE if it is a file--buffer.
-If one of selected buffers is not a file--buffer,
-it is ignored and grep will run on all others file--buffers.
-If only one candidate is selected and it is not a file--buffer,
+  "Run grep on all file buffers or CANDIDATE if it is a file buffer.
+If one of selected buffers is not a file buffer, it is ignored
+and grep will run on all others file-buffers.
+If only one candidate is selected and it is not a file buffer,
 switch to this buffer and run `helm-occur'.
-If a prefix arg is given run grep on all buffers ignoring non--file-buffers."
+If a prefix arg is given run grep on all buffers ignoring
+non-file buffers."
   (let* ((prefarg (or current-prefix-arg helm-current-prefix-arg))
          (helm-ff-default-directory
           (if (and helm-ff-default-directory
@@ -1420,14 +1431,15 @@ If a prefix arg is given run grep on all buffers ignoring non--file-buffers."
   "ag --line-numbers -S --hidden --color --nogroup %s %s %s"
   "The default command for AG, PT or RG.
 
-Takes three format specs, the first for type(s), the second for pattern
-and the third for directory.
+Takes three format specs, the first for type(s), the second for
+pattern and the third for directory.
 
-You can use safely \"--color\" (used by default) with AG RG and PT.
+You can use safely \"--color\" (used by default) with AG RG and
+PT.
 
-NOTE: Usage of \"--color=never\" is discouraged as it uses elisp to colorize
-matched items which is slower than using the native colorization of
-backend, however it is still supported.
+NOTE: Usage of \"--color=never\" is discouraged as it uses Elisp
+to colorize matched items which is slower than using the native
+colorization of backend, however it is still supported.
 
 For ripgrep here is the command line to use:
 
@@ -1439,7 +1451,7 @@ And to customize colors (always for ripgrep) use something like this:
 \--smart-case --no-heading --line-number %s %s %s
 
 This will change color for matched items from foreground red (the
-default) to a yellow background with a black foreground. For more
+default) to a yellow background with a black foreground.  For more
 enhanced settings of ansi colors see
 https://github.com/emacs-helm/helm/issues/2313.
 
@@ -1448,14 +1460,16 @@ You must use an output format that fit with helm grep, that is:
     \"filename:line-number:string\"
 
 The option \"--nogroup\" allow this.
-The option \"--line-numbers\" is also mandatory except with PT (not supported).
-For RG the options \"--no-heading\" and \"--line-number\" are the ones to use.
+The option \"--line-numbers\" is also mandatory except with
+PT (not supported).
+For RG the options \"--no-heading\" and \"--line-number\" are the
+ones to use.
 
-When modifying the default colors of matches with
-e.g. \"--color-match\" option of AG or \"--colors\" option of
-ripgrep you may want to modify as well
-`helm-grep-ag-pipe-cmd-switches' to have all matches colorized
-with same color in multi match,."
+When modifying the default colors of matches with e.g.
+\"--color-match\" option of AG or \"--colors\" option of ripgrep
+you may want to modify as well `helm-grep-ag-pipe-cmd-switches'
+to have all matches colorized with the same color in multi
+match."
   :group 'helm-grep
   :type 'string)
 
@@ -1483,8 +1497,8 @@ Ripgrep (rg) types are also supported if this backend is used."
 
 (defun helm-grep-ag-prepare-cmd-line (pattern directory &optional type)
   "Prepare AG command line to search PATTERN in DIRECTORY.
-When TYPE is specified it is one of what returns `helm-grep-ag-get-types'
-if available with current AG version."
+When TYPE is specified it is one of what `helm-grep-ag-get-types'
+returns if available with current AG version."
   (let* ((patterns (helm-mm-split-pattern pattern t))
          (pipe-switches (mapconcat 'identity helm-grep-ag-pipe-cmd-switches " "))
          (pipe-cmd (helm-acase (helm-grep--ag-command)
@@ -1634,8 +1648,8 @@ The color of matched items can be customized in your .gitconfig
 See `helm-grep-default-command' for more infos.
 
 The \"--exclude-standard\" and \"--no-index\" switches allow
-skipping unwanted files specified in ~/.gitignore_global
-and searching files not already staged (not enabled by default).
+skipping unwanted files specified in ~/.gitignore_global and
+searching files not already staged (not enabled by default).
 
 You have also to enable this in global \".gitconfig\" with
     \"git config --global core.excludesfile ~/.gitignore_global\"."
@@ -1645,8 +1659,8 @@ You have also to enable this in global \".gitconfig\" with
 (defun helm-grep-git-1 (directory &optional all default input)
   "Run git-grep on DIRECTORY.
 If DIRECTORY is not inside or part of a git repo exit with error.
-If optional arg ALL is non-nil grep the whole repo otherwise start
-at DIRECTORY.
+If optional arg ALL is non-nil grep the whole repo otherwise
+start at DIRECTORY.
 Arg DEFAULT is what you will have with `next-history-element',
 arg INPUT is what you will have by default at prompt on startup."
   (require 'vc)
@@ -1663,15 +1677,16 @@ arg INPUT is what you will have by default at prompt on startup."
 
 ;;;###autoload
 (defun helm-do-grep-ag (arg)
-  "Preconfigured helm for grepping with AG in `default-directory'.
-With prefix-arg prompt for type if available with your AG version."
+  "Preconfigured `helm' for grepping with AG in `default-directory'.
+With prefix arg prompt for type if available with your AG
+version."
   (interactive "P")
   (require 'helm-files)
   (helm-grep-ag (expand-file-name default-directory) arg))
 
 ;;;###autoload
 (defun helm-grep-do-git-grep (arg)
-  "Preconfigured helm for git-grepping `default-directory'.
+  "Preconfigured `helm' for git-grepping `default-directory'.
 With a prefix arg ARG git-grep the whole repository."
   (interactive "P")
   (require 'helm-files)

--- a/helm-help.el
+++ b/helm-help.el
@@ -55,7 +55,7 @@
 
 ;;;###autoload
 (defun helm-documentation ()
-  "Preconfigured Helm for Helm documentation.
+  "Preconfigured `helm' for Helm documentation.
 With a prefix arg refresh the documentation.
 
 Find here the documentation of all documented sources."

--- a/helm-id-utils.el
+++ b/helm-id-utils.el
@@ -28,7 +28,7 @@
   "Name of gid command (usually `gid').
 For Mac OS X users, if you install GNU coreutils, the name `gid'
 might be occupied by `id' from GNU coreutils, and you should set
-it to correct name (or absolute path), for example, if using
+it to correct name (or absolute path).  For example, if using
 MacPorts to install id-utils, it should be `gid32'."
   :group 'helm-id-utils
   :type 'file)
@@ -101,10 +101,10 @@ MacPorts to install id-utils, it should be `gid32'."
 
 ;;;###autoload
 (defun helm-gid ()
-  "Preconfigured helm for `gid' command line of `ID-Utils'.
-Need A database created with the command `mkid'
-above `default-directory'.
-Need id-utils as dependency which provide `mkid', `gid' etc...
+  "Preconfigured `helm' for `gid' command line of `ID-Utils'.
+Need A database created with the command `mkid' above
+`default-directory'.
+Need id-utils as dependency which provide `mkid', `gid' etc..
 See <https://www.gnu.org/software/idutils/>."
   (interactive)
   (let* ((db (locate-dominating-file

--- a/helm-imenu.el
+++ b/helm-imenu.el
@@ -28,11 +28,11 @@
 
 
 (defgroup helm-imenu nil
-  "Imenu related libraries and applications for helm."
+  "Imenu related libraries and applications for Helm."
   :group 'helm)
 
 (defcustom helm-imenu-delimiter " / "
-  "Delimit types of candidates and his value in `helm-buffer'."
+  "Delimit types of candidates and their value in `helm-buffer'."
   :group 'helm-imenu
   :type 'string)
 
@@ -44,9 +44,9 @@
 
 (defcustom helm-imenu-all-buffer-assoc nil
   "Major mode association alist for `helm-imenu-in-all-buffers'.
-Allow `helm-imenu-in-all-buffers' searching in these associated buffers
-even if they are not derived from each other.
-The alist is bidirectional, i.e no need to add '((foo . bar) (bar . foo))
+Allow `helm-imenu-in-all-buffers' searching in these associated
+buffers even if they are not derived from each other.  The alist
+is bidirectional, i.e. no need to add '((foo . bar) (bar . foo)),
 only '((foo . bar)) is needed."
   :type '(alist :key-type symbol :value-type symbol)
   :group 'helm-imenu)
@@ -58,9 +58,10 @@ When nil all candidates are displayed in a single source.
 
 NOTE: Each source will have as name \"Imenu <buffer-name>\".
 `helm-source-imenu-all' will not be set, however it will continue
-to be used as a flag for using default as input, if you do not want
-this behavior, remove it from `helm-sources-using-default-as-input'
-even if not using a single source to display imenu in all buffers."
+to be used as a flag for using default as input.  If you do not
+want this behavior, remove it from
+`helm-sources-using-default-as-input' even if not using a single
+source to display imenu in all buffers."
   :type 'boolean
   :group 'helm-imenu)
 
@@ -69,9 +70,10 @@ even if not using a single source to display imenu in all buffers."
     ("^\\(Function\\|Functions\\|Defuns\\)$" . font-lock-function-name-face)
     ("^\\(Types\\|Provides\\|Requires\\|Classes\\|Class\\|Includes\\|Imports\\|Misc\\|Code\\)$" . font-lock-type-face))
   "Faces for showing type in helm-imenu.
-This is a list of cons cells.  The cdr of each cell is a face to be used,
-and it can also just be like \\='(:foreground \"yellow\").
-Each car is a regexp match pattern of the imenu type string."
+This is a list of cons cells.  The cdr of each cell is a face to
+be used, and it can also just be like \\='(:foreground
+\"yellow\").  Each car is a regexp match pattern of the imenu type
+string."
   :group 'helm-faces
   :type '(repeat
           (cons
@@ -79,7 +81,7 @@ Each car is a regexp match pattern of the imenu type string."
            (sexp :tag "Face"))))
 
 (defcustom helm-imenu-extra-modes nil
-  "Extra modes where helm-imenu-in-all-buffers should look into."
+  "Extra modes where `helm-imenu-in-all-buffers' should look into."
   :group 'helm-imenu
   :type '(repeat symbol))
 
@@ -331,9 +333,10 @@ Each car is a regexp match pattern of the imenu type string."
 
 ;;;###autoload
 (defun helm-imenu-in-all-buffers ()
-  "Preconfigured helm for fetching imenu entries in all buffers with similar mode as current.
-A mode is similar as current if it is the same, it is derived i.e `derived-mode-p'
-or it have an association in `helm-imenu-all-buffer-assoc'."
+  "Preconfigured `helm' for fetching imenu entries in all buffers with similar mode as current.
+A mode is similar as current if it is the same, it is derived
+i.e. `derived-mode-p' or it have an association in
+`helm-imenu-all-buffer-assoc'."
   (interactive)
   (require 'which-func)
   (unless helm-imenu-in-all-buffers-separate-sources

--- a/helm-info.el
+++ b/helm-info.el
@@ -106,7 +106,7 @@ files with `helm-info-at-point'."
      :info-file ,fname ,@args))
 
 (defun helm-build-info-index-command (name doc source buffer)
-  "Define a helm command NAME with documentation DOC.
+  "Define a Helm command NAME with documentation DOC.
 Arg SOURCE will be an existing helm source named
 `helm-source-info-<NAME>' and BUFFER a string buffer name."
   (defalias (intern (concat "helm-info-" name))
@@ -118,9 +118,11 @@ Arg SOURCE will be an existing helm source named
     doc))
 
 (defun helm-define-info-index-sources (var-value &optional commands)
-  "Define helm sources named helm-source-info-<NAME>.
-Sources are generated for all entries of `helm-default-info-index-list'.
-If COMMANDS arg is non-nil, also build commands named `helm-info-<NAME>'.
+  "Define Helm sources named helm-source-info-<NAME>.
+Sources are generated for all entries of
+`helm-default-info-index-list'.
+If COMMANDS arg is non-nil, also build commands named
+`helm-info-<NAME>'.
 Where NAME is an element of `helm-default-info-index-list'."
   (cl-loop for str in var-value
            for sym = (intern (concat "helm-source-info-" str))
@@ -146,7 +148,7 @@ Where NAME is an element of `helm-default-info-index-list'."
   "Return list of Info files to use for `helm-info'.
 
 Elements of the list are strings of Info file names without
-extensions (e.g. \"emacs\" for file \"emacs.info.gz\"). Info
+extensions (e.g., \"emacs\" for file \"emacs.info.gz\").  Info
 files are found by searching directories in
 `Info-directory-list'."
   (info-initialize) ; Build Info-directory-list from INFOPATH (Issue #2118)
@@ -176,7 +178,7 @@ helm-info-<CANDIDATE>."
       (ring-insert helm-info-searched candidate))))
 
 (defun helm-def-source--info-files ()
-  "Return a `helm' source for Info files."
+  "Return a Helm source for Info files."
   (helm-build-sync-source "Helm Info"
     :candidates
     (lambda () (copy-sequence helm-default-info-index-list))
@@ -191,12 +193,13 @@ helm-info-<CANDIDATE>."
 (defun helm-info (&optional refresh)
   "Preconfigured `helm' for searching Info files' indices.
 
-With a prefix argument \\[universal-argument], set REFRESH to non-nil.
+With a prefix argument \\[universal-argument], set REFRESH to
+non-nil.
 
-Optional parameter REFRESH, when non-nil, reevaluates
+Optional parameter REFRESH, when non-nil, re-evaluates
 `helm-default-info-index-list'.  If the variable has been
 customized, set it to its saved value.  If not, set it to its
-standard value.  See `custom-reevaluate-setting' for more.
+standard value. See `custom-reevaluate-setting' for more.
 
 REFRESH is useful when new Info files are installed.  If
 `helm-default-info-index-list' has not been customized, the new

--- a/helm-lib.el
+++ b/helm-lib.el
@@ -63,7 +63,8 @@
 ;;
 (defcustom helm-file-globstar t
   "Same as globstar bash shopt option.
-When non--nil a pattern beginning with two stars will expand recursively.
+When non-nil a pattern beginning with two stars will expand
+recursively.
 Directories expansion is not supported yet."
   :group 'helm
   :type 'boolean)
@@ -72,8 +73,8 @@ Directories expansion is not supported yet."
   "The function used to forward point with `helm-yank-text-at-point'.
 With a nil value, fallback to default `forward-word'.
 The function should take one arg, an integer like `forward-word'.
-NOTE: Using `forward-symbol' here is not very useful as it is already
-provided by \\<helm-map>\\[next-history-element]."
+NOTE: Using `forward-symbol' here is not very useful as it is
+already provided by \\<helm-map>\\[next-history-element]."
   :type  'function
   :group 'helm)
 
@@ -89,9 +90,9 @@ If you prefer scrolling line by line, set this value to 1."
 (defcustom helm-help-full-frame t
   "Display help window in full frame when non nil.
 
-Even when `nil' probably the same result (full frame)
-can be reach by tweaking `display-buffer-alist' but it is
-much more convenient to use a simple boolean value here."
+Even when nil probably the same result (full frame) can be
+reached by tweaking `display-buffer-alist', but it is much more
+convenient to use a simple boolean value here."
   :type 'boolean
   :group 'helm-help)
 
@@ -120,15 +121,16 @@ much more convenient to use a simple boolean value here."
   "A list of regexps matching boring files.
 
 This list is build by default on `completion-ignored-extensions'.
-The directory names should end with \"/?\" e.g. \"\\.git/?\" and the
-file names should end with \"$\" e.g. \"\\.o$\".
+The directory names should end with \"/?\" e.g. \"\\.git/?\" and
+the file names should end with \"$\" e.g. \"\\.o$\".
 
-These regexps may be used to match the entire path, not just the file
-name, so for example to ignore files with a prefix \".bak.\", use
-\"\\.bak\\..*$\" as the regexp.
+These regexps may be used to match the entire path, not just the
+file name, so for example to ignore files with a prefix
+\".bak.\", use \"\\.bak\\..*$\" as the regexp.
 
-NOTE: When modifying this, be sure to use customize interface or the
-customize functions e.g. `customize-set-variable' and NOT `setq'."
+NOTE: When modifying this, be sure to use customize interface or
+the customize functions e.g. `customize-set-variable' and NOT
+`setq'."
   :group 'helm-files
   :type  '(repeat (choice regexp))
   :set 'helm-ff--setup-boring-regex)
@@ -162,9 +164,10 @@ customize functions e.g. `customize-set-variable' and NOT `setq'."
 ;;
 (defun helm-add-face-text-properties (beg end face &optional append object)
   "Add the face property to the text from START to END.
-It is a compatibility function which behave exactly like
-`add-face-text-property' if available otherwise like `add-text-properties'.
-When only `add-text-properties' is available APPEND is ignored."
+It is a compatibility function which behaves exactly like
+`add-face-text-property' if available, otherwise like
+`add-text-properties'.  When only `add-text-properties' is
+available APPEND is ignored."
   (if (fboundp 'add-face-text-property)
       (add-face-text-property beg end face append object)
       (add-text-properties beg end `(face ,face) object)))
@@ -331,7 +334,7 @@ When only `add-text-properties' is available APPEND is ignored."
   nil)
 
 (defcustom helm-advice-push-mark t
-  "Override `push-mark' with a version avoiding duplicates when non nil."
+  "Override `push-mark' with a version avoiding duplicates when non-nil."
   :group 'helm
   :type 'boolean
   :set (lambda (var val)
@@ -368,9 +371,9 @@ When only `add-text-properties' is available APPEND is ignored."
 ;;; Command loop helper
 ;;
 (defun helm-this-command ()
-  "Returns the actual command in action.
-Like `this-command' but return the real command,
-and not `exit-minibuffer' or other unwanted functions."
+  "Return the actual command in action.
+Like `this-command' but return the real command, and not
+`exit-minibuffer' or other unwanted functions."
   (cl-loop with bl = '(helm-maybe-exit-minibuffer
                        helm-confirm-and-exit-minibuffer
                        helm-exit-minibuffer
@@ -400,7 +403,7 @@ and not `exit-minibuffer' or other unwanted functions."
 Returns ITEM first occurence position found in SEQ.
 When SEQ is a string, ITEM have to be specified as a char.
 Argument TEST when unspecified default to `eq'.
-When argument ALL is non--nil return a list of all ITEM positions
+When argument ALL is non-nil return a list of all ITEM positions
 found in SEQ."
   (let ((key (if (stringp seq) 'across 'in)))
     `(cl-loop with deftest = 'eq
@@ -444,18 +447,19 @@ found in SEQ."
 ;;
 (defmacro helm-aif (test-form then-form &rest else-forms)
   "Anaphoric version of `if'.
-Like `if' but set the result of TEST-FORM in a temporary variable called `it'.
-THEN-FORM and ELSE-FORMS are then excuted just like in `if'."
+Like `if' but set the result of TEST-FORM in a temporary variable
+called `it'.  THEN-FORM and ELSE-FORMS are then excuted just like
+in `if'."
   (declare (indent 2) (debug t))
   `(let ((it ,test-form))
      (if it ,then-form ,@else-forms)))
 
 (defmacro helm-awhile (sexp &rest body)
   "Anaphoric version of `while'.
-Same usage as `while' except that SEXP is bound to
-a temporary variable called `it' at each turn.
-An implicit nil block is bound to the loop so usage
-of `cl-return' is possible to exit the loop."
+Same usage as `while' except that SEXP is bound to a temporary
+variable called `it' at each turn.
+An implicit nil block is bound to the loop so usage of
+`cl-return' is possible to exit the loop."
   (declare (indent 1) (debug t))
   (helm-with-gensyms (flag)
     `(let ((,flag t))
@@ -467,10 +471,10 @@ of `cl-return' is possible to exit the loop."
 
 (defmacro helm-acond (&rest clauses)
   "Anaphoric version of `cond'.
-In each clause of CLAUSES, the result of the car of clause
-is stored in a temporary variable called `it' and usable in the cdr
-of this same clause.  Each `it' variable is independent of its clause.
-The usage is the same as `cond'."
+In each clause of CLAUSES, the result of the car of clause is
+stored in a temporary variable called `it' and usable in the cdr
+of this same clause.  Each `it' variable is independent of its
+clause.  The usage is the same as `cond'."
   (declare (debug cond))
   (unless (null clauses)
     (helm-with-gensyms (sym)
@@ -484,8 +488,8 @@ The usage is the same as `cond'."
 
 (defmacro helm-aand (&rest conditions)
   "Anaphoric version of `and'.
-Each condition is bound to a temporary variable called `it' which is
-usable in next condition."
+Each condition is bound to a temporary variable called `it' which
+is usable in next condition."
   (declare (debug (&rest form)))
   (cond ((null conditions) t)
         ((null (cdr conditions)) (car conditions))
@@ -494,8 +498,8 @@ usable in next condition."
 
 (defmacro helm-acase (expr &rest clauses)
   "A simple anaphoric `cl-case' implementation handling strings.
-EXPR is bound to a temporary variable called `it' which is usable in
-CLAUSES to refer to EXPR.
+EXPR is bound to a temporary variable called `it' which is usable
+in CLAUSES to refer to EXPR.
 NOTE: Duplicate keys in CLAUSES are deliberately not handled.
 
 \(fn EXPR (KEYLIST BODY...)...)"
@@ -514,10 +518,10 @@ NOTE: Duplicate keys in CLAUSES are deliberately not handled.
 ;;
 (defsubst helm--mapconcat-pattern (pattern)
   "Transform string PATTERN in regexp for further fuzzy matching.
-e.g helm.el$
-    => \"[^h]*h[^e]*e[^l]*l[^m]*m[^.]*[.][^e]*e[^l]*l$\"
-    ^helm.el$
-    => \"helm[.]el$\"."
+E.g.: helm.el$
+     => \"[^h]*h[^e]*e[^l]*l[^m]*m[^.]*[.][^e]*e[^l]*l$\"
+     ^helm.el$
+     => \"helm[.]el$\"."
   (let ((ls (split-string-and-unquote pattern "")))
     (if (string= "^" (car ls))
         ;; Exact match.
@@ -541,13 +545,13 @@ e.g helm.el$
 ;;; Help routines.
 ;;
 (defvar helm-help-mode-before-hook nil
-  "A hook that run before helm-help starts.")
+  "A hook that runs before helm-help starts.")
 (defvar helm-help-mode-after-hook nil
-  "A hook that run when helm-help exits.")
+  "A hook that runs when helm-help exits.")
 (defun helm-help-internal (bufname insert-content-fn)
-  "Show long message during `helm' session in BUFNAME.
-INSERT-CONTENT-FN is the function that insert
-text to be displayed in BUFNAME."
+  "Show long message during Helm session in BUFNAME.
+INSERT-CONTENT-FN is the function that inserts text to be
+displayed in BUFNAME."
   (let ((winconf (current-frame-configuration))
         (hframe (selected-frame)))
     (helm-log-run-hook 'helm-help-mode-before-hook)
@@ -704,12 +708,13 @@ This is same as `remove-duplicates' but with memoisation.
 It is much faster, especially in large lists.
 A test function can be provided with TEST argument key.
 Default is `eq'.
-NOTE: Comparison of special elisp objects (e.g. markers etc...) fails
-because their printed representations which are stored in hash-table
-can't be compared with with the real object in SEQ.
-This is a bug in `puthash' which store the printable representation of
-object instead of storing the object itself, this to provide at the
-end a printable representation of hashtable itself."
+NOTE: Comparison of special Elisp objects (e.g., markers etc.)
+fails because their printed representations which are stored in
+hash-table can't be compared with with the real object in SEQ.
+This is a bug in `puthash' which store the printable
+representation of object instead of storing the object itself,
+this to provide at the end a printable representation of
+hashtable itself."
   (cl-loop with cont = (make-hash-table :test test)
            for elm in seq
            unless (gethash elm cont)
@@ -726,7 +731,7 @@ end a printable representation of hashtable itself."
     "\\`\\'"))                          ; Match nothing
 
 (defun helm-skip-entries (seq black-regexp-list &optional white-regexp-list)
-  "Remove entries which matches one of REGEXP-LIST from SEQ."
+  "Remove entries which match one of REGEXP-LIST from SEQ."
   (let ((black-regexp (helm--concat-regexps black-regexp-list))
         (white-regexp (helm--concat-regexps white-regexp-list)))
     (cl-loop for i in seq
@@ -737,7 +742,7 @@ end a printable representation of hashtable itself."
              collect i)))
 
 (defun helm-boring-directory-p (directory black-list)
-  "Check if one regexp in BLACK-LIST match DIRECTORY."
+  "Check if one regexp in BLACK-LIST matches DIRECTORY."
   (helm-awhile (helm-basedir (directory-file-name
                               (expand-file-name directory)))
     ;; Break at root to avoid infloop, root is / or on Windows
@@ -819,8 +824,8 @@ It is used for narrowing list of candidates to the
 (defun helm-source-by-name (name &optional sources)
   "Get a Helm source in SOURCES by NAME.
 
-Optional argument SOURCES is a list of Helm sources which default to
-`helm-sources'."
+Optional argument SOURCES is a list of Helm sources which default
+to `helm-sources'."
   (cl-loop with src-list = (if sources
                                (cl-loop for src in sources
                                         collect (if (listp src)
@@ -832,8 +837,8 @@ Optional argument SOURCES is a list of Helm sources which default to
 
 (defun helm-make-actions (&rest args)
   "Build an alist with (NAME . ACTION) elements with each pairs in ARGS.
-Where NAME is a string or a function returning a string or nil and ACTION
-a function.
+Where NAME is a string or a function returning a string or nil
+and ACTION a function.
 If NAME returns nil the pair is skipped.
 
 \(fn NAME ACTION ...)"
@@ -866,7 +871,8 @@ Handle multibyte characters by moving by columns."
   "Truncate string STR to end at column WIDTH.
 Similar to `truncate-string-to-width'.
 Add ENDSTR at end of truncated STR.
-Add spaces at end if needed to reach WIDTH when STR is shorter than WIDTH."
+Add spaces at end if needed to reach WIDTH when STR is shorter
+than WIDTH."
   (cl-loop for ini-str = str
         then (substring ini-str 0 (1- (length ini-str)))
         for sw = (string-width ini-str)
@@ -914,7 +920,7 @@ Add spaces at end if needed to reach WIDTH when STR is shorter than WIDTH."
 Same as `replace-regexp-in-string' but handle properly REP as
 function with SUBEXP specified.
 
-e.g
+E.g.:
 
     (helm--replace-regexp-in-buffer-string \"e\\\\(m\\\\)acs\" 'upcase \"emacs\" t nil 1)
     => \"eMacs\"
@@ -922,10 +928,10 @@ e.g
     (replace-regexp-in-string \"e\\\\(m\\\\)acs\" 'upcase \"emacs\" t nil 1)
     => \"eEMACSacs\"
 
-Also START argument behave as expected unlike
+Also START argument behaves as expected unlike
 `replace-regexp-in-string'.
 
-e.g
+E.g.:
 
     (helm--replace-regexp-in-buffer-string \"f\" \"r\" \"foofoo\" t nil nil 3)
     => \"fooroo\"
@@ -934,14 +940,14 @@ e.g
     => \"roo\"
 
 Unlike `replace-regexp-in-string' this function is buffer-based
-implemented i.e replacement is computed inside a temp buffer, so
+implemented i.e. replacement is computed inside a temp buffer, so
 REGEXP should be used differently than with
 `replace-regexp-in-string'.
 
 NOTE: This function is used internally for
 `helm-ff-query-replace-on-filenames' and builded for this.
-You should use `replace-regexp-in-string' instead unless the behavior
-of this function is really needed."
+You should use `replace-regexp-in-string' instead unless the
+behaviour of this function is really needed."
   (with-temp-buffer
     (insert str)
     (goto-char (or start (point-min)))
@@ -972,7 +978,7 @@ of this function is really needed."
   "Prompt user for an answer.
 Arg PROMPT is the prompt to present user the different possible
 answers, ANSWER-LIST is a list of strings.
-If user enter an answer which is one of ANSWER-LIST return this
+If user enters an answer which is one of ANSWER-LIST return this
 answer, otherwise keep prompting for a valid answer.
 Note that answer should be a single char, only short answer are
 accepted.
@@ -1039,8 +1045,9 @@ Example:
 
 (defun helm-elisp--persistent-help (candidate fun &optional name)
   "Used to build persistent actions describing CANDIDATE with FUN.
-Argument NAME is used internally to know which command to use when
-symbol CANDIDATE refers at the same time to variable and a function.
+Argument NAME is used internally to know which command to use
+when symbol CANDIDATE refers at the same time to a variable and a
+function.
 See `helm-elisp-show-help'."
   (let ((hbuf (get-buffer (help-buffer))))
     (cond  ((helm-follow-mode-p)
@@ -1145,12 +1152,12 @@ Argument ALIST is an alist of associated major modes."
           it)))
 
 (defun helm-basename (fname &optional ext)
-  "Print FNAME  with any  leading directory  components removed.
+  "Print FNAME with any leading directory components removed.
 If specified, also remove filename extension EXT.
-Arg EXT can be specified as a string with or without dot,
-in this case it should match file-name-extension.
-It can also be non-nil (`t') in this case no checking
-of file-name-extension is done and the extension is removed
+Arg EXT can be specified as a string with or without dot, in this
+case it should match `file-name-extension'.
+It can also be non-nil (t) in this case no checking of
+`file-name-extension' is done and the extension is removed
 unconditionally."
   (let ((non-essential t))
     (if (and ext (or (string= (file-name-extension fname) ext)
@@ -1230,20 +1237,22 @@ other candidate transformers."
                                            noerror)
   "Walk through DIRECTORY tree.
 
-Argument PATH can be one of basename, relative, full, or a function
-called on file name, default to basename.
+Argument PATH can be one of basename, relative, full, or a
+function called on file name, default to basename.
 
-Argument DIRECTORIES when `t' return also directories names,
+Argument DIRECTORIES when t return also directories names,
 otherwise skip directories names, with a value of `only' returns
-only subdirectories, i.e files are skipped.
+only subdirectories, i.e. files are skipped.
 
 Argument MATCH is a regexp matching files or directories.
 
-Argument SKIP-SUBDIRS when `t' will skip `helm-walk-ignore-directories'
-otherwise if it is given as a list of directories, this list will be used
-instead of `helm-walk-ignore-directories'.
+Argument SKIP-SUBDIRS when t will skip
+`helm-walk-ignore-directories', otherwise if it is given as a
+list of directories, this list will be used instead of
+`helm-walk-ignore-directories'.
 
-Argument NOERROR when `t' will skip directories which are not accessible."
+Argument NOERROR when t will skip directories which are not
+accessible."
   (let ((fn (cl-case path
                (basename 'file-name-nondirectory)
                (relative 'file-relative-name)
@@ -1281,7 +1290,7 @@ Argument NOERROR when `t' will skip directories which are not accessible."
 
 (defun helm-file-expand-wildcards (pattern &optional full)
   "Same as `file-expand-wildcards' but allow recursion.
-Recursion happen when PATTERN starts with two stars.
+Recursion happens when PATTERN starts with two stars.
 Directories expansion is not supported."
   (let ((bn (helm-basename pattern))
         (case-fold-search nil))
@@ -1302,7 +1311,7 @@ Directories expansion is not supported."
 ;;
 (defun helm-set-pattern (pattern &optional noupdate)
   "Set minibuffer contents to PATTERN.
-if optional NOUPDATE is non-nil, helm buffer is not changed."
+If optional NOUPDATE is non-nil, the Helm buffer is not changed."
   (with-selected-window (or (active-minibuffer-window) (minibuffer-window))
     (delete-minibuffer-contents)
     (insert pattern))
@@ -1378,16 +1387,17 @@ I.e. when using `helm-next-line' and friends in BODY."
 (defun helm--prepare-completion-styles (&optional nomode styles)
   "Return a suitable list of styles for `completion-styles'.
 
-When `helm-completion-style' is not `emacs' the Emacs vanilla default
-`completion-styles' is used except for `helm-dynamic-completion' which
-use inconditionally `emacs' as value for `helm-completion-style'.
+When `helm-completion-style' is not `emacs' the Emacs vanilla
+default `completion-styles' is used except for
+`helm-dynamic-completion' which uses inconditionally `emacs' as
+value for `helm-completion-style'.
  
 If styles are specified in `helm-completion-styles-alist' for a
 particular mode, use these styles unless NOMODE is non nil.
 If STYLES is specified as a list of styles suitable for
 `completion-styles' these styles are used in the given order.
-Otherwise helm style is added to `completion-styles' always after flex
-or helm-flex completion style if present."
+Otherwise helm style is added to `completion-styles' always after
+flex or helm-flex completion style if present."
   ;; For `helm-completion-style' and `helm-completion-styles-alist'.
   (require 'helm-mode)
   (if (memq helm-completion-style '(helm helm-fuzzy))
@@ -1421,15 +1431,19 @@ or helm-flex completion style if present."
   "Build a function listing the possible completions of `helm-pattern' in COLLECTION.
 
 Only the elements of COLLECTION that satisfy PREDICATE are considered.
-Argument POINT is same as in `completion-all-completions' and is
-meaningful only when using some kind of `completion-at-point'.
-The return value is a list of completions that may be sorted by the
-sort function provided by the completion-style in use (emacs-27 only),
-otherwise (emacs-26) the sort function have to be provided if needed
-either with a FCT function in source or by passing the sort function
-with METADATA e.g. (metadata (display-sort-function . foo)).
-If you don't want the sort fn provided by style to kick in (emacs-27)
-you can use as metadata value the symbol `nosort'.
+
+Argument POINT is the same as in `completion-all-completions' and
+is meaningful only when using some kind of `completion-at-point'.
+
+The return value is a list of completions that may be sorted by
+the sort function provided by the completion-style in
+use (emacs-27 only), otherwise (emacs-26) the sort function has
+to be provided if needed either with an FCT function in source or
+by passing the sort function with METADATA
+E.g.: (metadata (display-sort-function . foo)).
+
+If you don't want the sort fn provided by style to kick
+in (emacs-27) you can use as metadata value the symbol `nosort'.
 
 Example:
 
@@ -1442,10 +1456,12 @@ Example:
 
 When argument NOMODE is non nil don't use `completion-styles' as
 specified in `helm-completion-styles-alist' for specific modes.
+
 When STYLES is specified use these `completion-styles', see
 `helm--prepare-completion-styles'.
-Also `helm-completion-style' settings have no effect here, `emacs'
-being used inconditionally as value."
+
+Also `helm-completion-style' settings have no effect here,
+`emacs' being used inconditionally as value."
   (lambda ()
     (let* (;; Force usage of emacs style otherwise
            ;; helm--prepare-completion-styles will reset
@@ -1538,14 +1554,15 @@ being used inconditionally as value."
 (defun helm--ansi-color-apply (string)
   "A version of `ansi-color-apply' immune to upstream changes.
 
-Similar to the emacs-24.5 version without support to `ansi-color-context'
-which is buggy in emacs.
+Similar to the emacs-24.5 version without support to
+`ansi-color-context' which is buggy in Emacs.
 
-Modify also `ansi-color-regexp' by using own variable `helm--ansi-color-regexp'
-that match whole STRING.
+Modify also `ansi-color-regexp' by using own variable
+`helm--ansi-color-regexp' that matches whole STRING.
 
-This is needed to provide compatibility for both emacs-25 and emacs-24.5
-as emacs-25 version of `ansi-color-apply' is partially broken."
+This is needed to provide compatibility for both emacs-25 and
+emacs-24.5 as emacs-25 version of `ansi-color-apply' is partially
+broken."
   (require 'ansi-color)
   (let ((start 0)
         codes end escape-sequence

--- a/helm-locate.el
+++ b/helm-locate.el
@@ -39,19 +39,21 @@ If nil Search in all files."
 
 (defcustom helm-ff-locate-db-filename "locate.db"
   "The basename of the locatedb file you use locally in your directories.
-When this is set and `helm' find such a file in the directory from
-where you launch locate, it will use this file and will not prompt you
-for a db file.
-Note that this happen only when locate is launched with a prefix arg."
+When this is set and Helm finds such a file in the directory from
+where you launch locate, it will use this file and will not
+prompt you for a db file.
+Note that this happen only when locate is launched with a prefix
+arg."
   :group 'helm-locate
   :type 'string)
 
 (defcustom helm-locate-command nil
   "A list of arguments for locate program.
 
-Helm will calculate a default value for your system on startup unless
-`helm-locate-command' is non-nil, here the default values it will use
-according to your system:
+Helm will calculate a default value for your system on startup
+unless `helm-locate-command' is non-nil.
+
+Here are the default values it will use according to your system:
 
 Gnu/linux:     \"locate %s -e -A --regex %s\"
 berkeley-unix: \"locate %s %s\"
@@ -60,19 +62,20 @@ Others:        \"locate %s %s\"
 
 This string will be passed to format so it should end with `%s'.
 The first format spec is used for the \"-i\" value of locate/es,
-So don't set it directly but use `helm-locate-case-fold-search'
+so don't set it directly but use `helm-locate-case-fold-search'
 for this.
 
-The last option must be the one preceding pattern i.e \"-r\" or \"--regex\".
+The last option must be the one preceding pattern i.e \"-r\" or
+\"--regex\".
 
 You will be able to pass other options such as \"-b\" or \"l\"
-during helm invocation after entering pattern only when multi matching,
-not when fuzzy matching.
+during Helm invocation after entering pattern only when multi
+matching, not when fuzzy matching.
 
-Note that the \"-b\" option is added automatically by helm when
+Note that the \"-b\" option is added automatically by Helm when
 var `helm-locate-fuzzy-match' is non-nil and switching back from
-multimatch to fuzzy matching (this is done automatically when a space
-is detected in pattern)."
+multimatch to fuzzy matching (this is done automatically when a
+space is detected in pattern)."
   :type 'string
   :group 'helm-locate)
 
@@ -86,8 +89,8 @@ is detected in pattern)."
   "It have the same meaning as `helm-case-fold-search'.
 The -i option of locate will be used depending of value of
 `helm-pattern' when this is set to 'smart.
-When nil \"-i\" will not be used at all.
-and when non--nil it will always be used.
+When nil \"-i\" will not be used at all and when non-nil it will
+always be used.
 NOTE: the -i option of the \"es\" command used on windows does
 the opposite of \"locate\" command."
   :group 'helm-locate
@@ -107,8 +110,8 @@ Note that when this is enabled searching is done on basename."
 
 (defcustom helm-locate-project-list nil
   "A list of directories, your projects.
-When set, allow browsing recursively files in all
-directories of this list with `helm-projects-find-files'."
+When set, allow browsing recursively files in all directories of
+this list with `helm-projects-find-files'."
   :group 'helm-locate
   :type '(repeat string))
 
@@ -120,9 +123,9 @@ For Windows and `es' use something like \"es -r ^%s.*%s.*$\"
 The two format specs are mandatory.
 
 If for some reasons you can't use locate because your filesystem
-doesn't have a data base, you can use find command from findutils but
-be aware that it will be much slower, see `helm-find-files' embebded
-help for more infos."
+doesn't have a database, you can use find command from findutils
+but be aware that it will be much slower.  See `helm-find-files'
+embedded help for more infos."
   :type 'string
   :group 'helm-files)
 
@@ -141,8 +144,8 @@ help for more infos."
 
 (defun helm-ff-find-locatedb (&optional from-ff)
   "Try to find if a local locatedb file is available.
-The search is done in `helm-ff-default-directory' or
-fall back to `default-directory' if FROM-FF is nil."
+The search is done in `helm-ff-default-directory' or falls back to
+`default-directory' if FROM-FF is nil."
   (helm-aif (and helm-ff-locate-db-filename
                  (locate-dominating-file
                   (or (and from-ff
@@ -166,11 +169,11 @@ It should receive the same arguments as
 
 (defun helm-locate-1 (&optional localdb init from-ff default)
   "Generic function to run Locate.
-Prefix arg LOCALDB when (4) search and use a local locate db file when it
-exists or create it, when (16) force update of existing db file
-even if exists.
-It have no effect when locate command is 'es'.
-INIT is a string to use as initial input in prompt.
+Prefix arg LOCALDB when (4) search and use a local locate db file
+when it exists or create it, when (16) force update of existing
+db file even if exists.
+It has no effect when locate command is 'es'.  INIT is a string
+to use as initial input in prompt.
 See `helm-locate-with-db' and `helm-locate'."
   (require 'helm-mode)
   (helm-locate-set-command)
@@ -443,8 +446,8 @@ Note: you can add locate options after entering pattern.
 See 'man locate' for valid options and also `helm-locate-command'.
 
 You can specify a local database with prefix argument ARG.
-With two prefix arg, refresh the current local db or create it
-if it doesn't exists.
+With two prefix arg, refresh the current local db or create it if
+it doesn't exists.
 
 To create a user specific db, use
 \"updatedb -l 0 -o db_path -U directory\".

--- a/helm-man.el
+++ b/helm-man.el
@@ -33,7 +33,7 @@
 (declare-function helm-generic-sort-fn "helm-utils.el" (S1 S2))
 
 (defgroup helm-man nil
-  "Man and Woman applications for helm."
+  "Man and Woman applications for Helm."
   :group 'helm)
 
 (defcustom helm-man-or-woman-function 'Man-getpage-in-background
@@ -54,11 +54,11 @@ Arguments are passed to `manual-entry' with `format.'"
 ;; Internal
 (defvar helm-man--pages nil
   "All man pages on system.
-Will be calculated the first time you invoke helm with this
+Will be calculated the first time you invoke Helm with this
 source.")
 
 (defun helm-man-default-action (candidate)
-  "Default action for jumping to a woman or man page from helm."
+  "Default action for jumping to a woman or man page from Helm."
   (let ((wfiles (mapcar #'car (woman-file-name-all-completions candidate))))
     (condition-case nil
         (let ((file (if (cdr wfiles)

--- a/helm-misc.el
+++ b/helm-misc.el
@@ -33,7 +33,7 @@
   :group 'helm)
 
 (defcustom helm-time-zone-home-location "Paris"
-  "The time zone of your home"
+  "The time zone of your home."
   :group 'helm-misc
   :type 'string)
 

--- a/helm-mode.el
+++ b/helm-mode.el
@@ -53,7 +53,7 @@
 By default `helm-mode' use `helm-completing-read-default-handler' to
 provide helm completion in each `completing-read' or `read-file-name'
 found, but other functions can be specified here for specific
-commands. This also allow disabling helm completion for some commands
+commands. This also allows disabling helm completion for some commands
 when needed.
 
 Each entry is a cons cell like (EMACS_COMMAND . COMPLETING-READ_HANDLER)
@@ -65,7 +65,7 @@ Each value maybe a helm function that takes same arguments as
 `completing-read' plus NAME and BUFFER, where NAME is the name of the new
 helm source and BUFFER the name of the buffer we will use, but it can
 be also a function not using helm, in this case the function should
-take same args as `completing-read' and not be prefixed by \"helm-\".
+take the same args as `completing-read' and not be prefixed by \"helm-\".
 
 `helm' will use the name of the command calling `completing-read' as
 NAME and BUFFER will be computed as well with NAME but prefixed with
@@ -73,7 +73,7 @@ NAME and BUFFER will be computed as well with NAME but prefixed with
 
 This function prefix name must start by \"helm-\" when it uses helm,
 otherwise `helm' assumes the function is not a helm function and
-expects same args as `completing-read', this allow you to define a
+expects the same args as `completing-read', this allows you to define a
 handler not using helm completion.
 
 Example:
@@ -96,16 +96,16 @@ Example:
 
 
 We want here to make the regular `completing-read' in `foo/test'
-returns a list of candidate(s) instead of a single candidate.
+return a list of candidate(s) instead of a single candidate.
 
 Note that this function will be reused for ALL the `completing-read'
-of this command, so it should handle all cases, e.g
-If first `completing-read' complete against symbols and
+of this command, so it should handle all cases. E.g.,
+if first `completing-read' completes against symbols and
 second `completing-read' should handle only buffer,
-your specialized function should handle the both.
+your specialized function should handle both.
 
 If the value of an entry is nil completion will fall back to
-emacs vanilla behavior.
+Emacs vanilla behaviour.
 Example:
 
 If you want to disable helm completion for `describe-function', use:
@@ -136,7 +136,7 @@ See `helm-case-fold-search' for more info."
 
 (defcustom helm-mode-handle-completion-in-region t
   "Whether to replace or not `completion-in-region-function'.
-This enable support for `completing-read-multiple' and `completion-at-point'
+This enables support for `completing-read-multiple' and `completion-at-point'
 when non--nil."
   :group 'helm-mode
   :type 'boolean)
@@ -160,7 +160,7 @@ Apply only in `helm-mode' handled commands."
 When nil no sorting is done.
 The function is a `filtered-candidate-transformer' function which takes
 two args CANDIDATES and SOURCE.
-It will be used only when `helm-completion-style' is either emacs or
+It will be used only when `helm-completion-style' is either Emacs or
 helm, otherwise when helm-fuzzy style is used, the fuzzy sort function
 will be used."
   :group 'helm-mode
@@ -184,7 +184,7 @@ in `completion-styles-alist' (emacs-26)."
 
 (defvar helm-mode-minibuffer-setup-hook-black-list '(minibuffer-completion-help)
   "Incompatible `minibuffer-setup-hook' functions go here.
-A list of symbols.  Helm-mode is rejecting all lambda's, byte-code fns
+A list of symbols.  `helm-mode' is rejecting all lambda's, byte-code fns
 and all functions belonging in this list from `minibuffer-setup-hook'.
 This is mainly needed to prevent \"*Completions*\" buffers to popup.")
 
@@ -227,35 +227,35 @@ This is mainly needed to prevent \"*Completions*\" buffers to popup.")
 
 (helm-multi-key-defun helm-mode-delete-char-backward-maybe
     "Delete char backward when text is not the prefix helm is completing against.
-First call warn user about deleting prefix completion.
-Second call delete backward char in current-buffer and quit helm completion,
-letting user starting a new completion with a new prefix."
+First call warns user about deleting prefix completion.
+Second call deletes backward char in current-buffer and quits helm completion,
+letting the user start a new completion with a new prefix."
   '(helm-mode-delete-char-backward-1 helm-mode-delete-char-backward-2) 1)
 
 (defcustom helm-completion-style 'emacs
   "Style of completion to use in `completion-in-region'.
 
-This affect only `completion-at-point' and friends, and
+This affects only `completion-at-point' and friends, and
 the `completing-read' using the default handler
 i.e. `helm-completing-read-default-handler'.
 
-NB: This have nothing to do with `completion-styles', it is independent to
-helm, but when using emacs as helm-completion-style helm
+NB: This has nothing to do with `completion-styles', it is independent from
+helm, but when using 'emacs as helm-completion-style helm
 will use the `completion-styles' for its completions.
 Up to the user to configure `completion-styles'.
 
-There is three possible value to use:
+There are three possible values to use:
 
 - helm, use multi match regular helm completion.
 
-- helm-fuzzy, use fuzzy matching, note that as usual when
+- helm-fuzzy, use fuzzy matching.  Note that as usual when
   entering a space helm switch to multi matching mode.
 
-- emacs, use regular emacs completion according to
-  `completion-styles', note that even in this style, helm allows using
-  multi match.  Emacs-27 provide a style called `flex' that can be used
+- emacs, use regular Emacs completion according to
+  `completion-styles'.  Note that even in this style, helm allows using
+  multi match.  Emacs-27 provides a style called `flex' that can be used
   aside `helm' style (see `completion-styles-alist').  When `flex' style
-  is not available (Emacs<27) helm provide `helm-flex' style which is similar to
+  is not available (Emacs<27) helm provides `helm-flex' style which is similar to
   `flex' and helm fuzzy matching.
 
 For a better experience, if you don't know what to use, set
@@ -296,7 +296,7 @@ suitable value for `helm-completion-style'.
 When specifying emacs as style for a mode, `completion-styles' can be
 specified by using a cons cell specifying completion-styles to use
 with helm emacs style, e.g. (foo-mode . (emacs helm flex)) will set
-`completion-styles' to '(helm flex) for foo-mode, this affect only
+`completion-styles' to '(helm flex) for foo-mode.  This affects only
 completions happening in buffers and not minibuffer completions,
 i.e. completing-read's."
   :group 'helm-mode
@@ -365,7 +365,7 @@ INPUT is the string you want to complete against, defaulting to
 `helm-pattern' which is the value of what you enter in minibuffer.
 Note that when using a function as COLLECTION this value will be
 available with the input argument of the function only when using a
-sync source from `helm-comp-read', i.e not using
+sync source from `helm-comp-read', i.e. not using
 `:candidates-in-buffer', otherwise the function is called only once
 with an empty string as value for `helm-pattern' because
 `helm-pattern' is not yet computed, which is what we want otherwise
@@ -573,7 +573,7 @@ Keys description:
   When it is non--nil, all elements of HISTORY are displayed in
   a special source before COLLECTION.
 
-- INPUT-HISTORY: A symbol. the minibuffer input history will be
+- INPUT-HISTORY: A symbol. The minibuffer input history will be
   stored there, if nil or not provided, `minibuffer-history'
   will be used instead.
 
@@ -602,7 +602,7 @@ Keys description:
 - VOLATILE: Use volatile attribute.
 
 - SORT: A predicate to give to `sort' e.g `string-lessp'
-  Use this only on small data as it is ineficient.
+  Use this only on small data as it is inefficient.
   If you want to sort faster add a sort function to
   FC-TRANSFORMER.
   Note that FUZZY when enabled is already providing a sort function.
@@ -627,7 +627,7 @@ Keys description:
   See match-part documentation in `helm-source'.
 
 - MATCH-DYNAMIC: See match-dynamic in `helm-source-sync'
-  It have no effect when used with CANDIDATES-IN-BUFFER.
+  It has no effect when used with CANDIDATES-IN-BUFFER.
 
 - ALLOW-NEST: Allow nesting this `helm-comp-read' in a helm session.
   See `helm'.
@@ -641,8 +641,8 @@ Keys description:
 Any prefix args passed during `helm-comp-read' invocation will be recorded
 in `helm-current-prefix-arg', otherwise if prefix args were given before
 `helm-comp-read' invocation, the value of `current-prefix-arg' will be used.
-That's mean you can pass prefix args before or after calling a command
-that use `helm-comp-read' See `helm-M-x' for example."
+That means you can pass prefix args before or after calling a command
+that use `helm-comp-read'.  See `helm-M-x' for example."
 
   (when (get-buffer helm-action-buffer)
     (kill-buffer helm-action-buffer))
@@ -841,9 +841,9 @@ that use `helm-comp-read' See `helm-M-x' for example."
      init hist default _inherit-input-method
      name buffer &optional cands-in-buffer exec-when-only-one)
   "Call `helm-comp-read' with same args as `completing-read'.
-Extra optional arg CANDS-IN-BUFFER mean use `candidates-in-buffer'
+Extra optional arg CANDS-IN-BUFFER means use `candidates-in-buffer'
 method which is faster.
-It should be used when candidate list don't need to rebuild dynamically."
+It should be used when candidate list doesn't need to be rebuilt dynamically."
   (let ((history (or (car-safe hist) hist))
         (initial-input (helm-aif (pcase init
                                    ((pred (stringp)) init)
@@ -886,7 +886,7 @@ It should be used when candidate list don't need to rebuild dynamically."
      name buffer &optional _cands-in-buffer exec-when-only-one)
   "Call `helm-comp-read' with same args as `completing-read'.
 
-This handler use dynamic matching which allow honouring `completion-styles'."
+This handler uses dynamic matching which allows honouring `completion-styles'."
   (let* ((history (or (car-safe hist) hist))
          (input (pcase init
                   ((pred (stringp)) init)
@@ -1168,9 +1168,9 @@ Keys description:
 
 - NAME: Source name, default to \"Read File Name\".
 
-- INITIAL-INPUT: Where to start read file name, default to `default-directory'.
+- INITIAL-INPUT: Where to start reading file name, default to `default-directory'.
 
-- BUFFER: `helm-buffer' name default to \"*Helm Completions*\".
+- BUFFER: `helm-buffer' name, defaults to \"*Helm Completions*\".
 
 - TEST: A predicate called with one arg 'candidate'.
 
@@ -1457,7 +1457,7 @@ The `helm-find-files' history `helm-ff-history' is used here."
     (apply old--fn args)))
 
 (defvar helm-completion--sorting-done nil
-  "Flag that notify the FCT if sorting have been done in completion function.")
+  "Flag that notifies the FCT if sorting has been done in completion function.")
 (defun helm-completion-in-region-sort-fn (candidates _source)
   "Default sort function for completion-in-region."
   (if helm-completion--sorting-done
@@ -1501,7 +1501,7 @@ The `helm-find-files' history `helm-ff-history' is used here."
 
 (defun helm-completion-try-completion (string table pred point)
   "The try completion function for `completing-styles-alist'.
-Actually do nothing."
+Actually does nothing."
   ;; AFAIU the try-completions style functions
   ;; are here to check if what is at point is suitable for TABLE but
   ;; there is no way to pass a multiple pattern from what is at point
@@ -1642,9 +1642,9 @@ Actually do nothing."
 (defun helm-completion--flex-all-completions
     (string table pred point &optional transform-pattern-fn)
   "Match the presumed substring STRING to the entries in TABLE.
-Respect PRED and POINT.  The pattern used is a PCM-style
-substring pattern, but it be massaged by TRANSFORM-PATTERN-FN, if
-that is non-nil."
+Respect PRED and POINT.  The pattern used is a PCM-style substring
+pattern, but it will be massaged by TRANSFORM-PATTERN-FN, if that
+is non-nil."
   (let* ((beforepoint (substring string 0 point))
          (afterpoint (substring string point))
          (bounds (completion-boundaries beforepoint table pred afterpoint))
@@ -1909,7 +1909,7 @@ negative arg turn off.
 You can toggle it with M-x `helm-mode'.
 
 About `ido-mode':
-DO NOT enable `ido-everywhere' when using `helm-mode' and instead of
+DO NOT enable `ido-everywhere' when using `helm-mode'.  Instead of
 using `ido-mode', add the commands where you want to use ido to
 `helm-completing-read-handlers-alist' with `ido' as value.
 

--- a/helm-multi-match.el
+++ b/helm-multi-match.el
@@ -67,7 +67,7 @@ when these options are used."
   "Regexp to represent space itself in multiple regexp match.")
 
 (defun helm-mm-split-pattern (pattern &optional grep-space)
-  "Split PATTERN if it contain spaces and return resulting list.
+  "Split PATTERN if it contains spaces and return resulting list.
 If spaces in PATTERN are escaped, don't split at this place.
 i.e \"foo bar baz\"=> (\"foo\" \"bar\" \"baz\")
 but \"foo\\ bar baz\"=> (\"foo\\s-bar\" \"baz\").
@@ -187,9 +187,9 @@ If GREP-SPACE is used translate escaped space to \"\\s\" instead of \"\\s-\"."
 (defvar helm-mm--3-pattern-list nil)
 
 (defun helm-mm-3-get-patterns (pattern)
-  "Returns a list of predicate/regexp cons cells.
-e.g. ((identity . \"foo\") (not . \"bar\")).
-If PATTERN is inchanged, don't recompute PATTERN and return the
+  "Return a list of predicate/regexp cons cells.
+E.g., ((identity . \"foo\") (not . \"bar\")).
+If PATTERN is unchanged, don't recompute PATTERN and return the
 previous value stored in `helm-mm--3-pattern-list'."
   (unless (equal pattern helm-mm--3-pattern-str)
     (setq helm-mm--3-pattern-str pattern
@@ -199,7 +199,7 @@ previous value stored in `helm-mm--3-pattern-list'."
 
 (defun helm-mm-3-get-patterns-internal (pattern)
   "Return a list of predicate/regexp cons cells.
-e.g. ((identity . \"foo\") (not . \"bar\"))."
+E.g., ((identity . \"foo\") (not . \"bar\"))."
   (unless (string= pattern "")
     (cl-loop for pat in (helm-mm-split-pattern pattern)
           collect (if (string= "!" (substring pat 0 1))
@@ -208,15 +208,15 @@ e.g. ((identity . \"foo\") (not . \"bar\"))."
 
 (cl-defun helm-mm-3-match (candidate &optional (pattern helm-pattern))
   "Check if PATTERN match CANDIDATE.
-When PATTERN contain a space, it is splitted and matching is done
-with the several resulting regexps against CANDIDATE.
-e.g \"bar foo\" will match \"foobar\" and \"barfoo\".
-Argument PATTERN, a string, is transformed in a list of
-cons cell with `helm-mm-3-get-patterns' if it contain a space.
-e.g \"foo bar\"=>((identity . \"foo\") (identity . \"bar\")).
-Then each predicate of cons cell(s) is called with regexp of same
-cons cell against CANDIDATE.
-i.e (identity (string-match \"foo\" \"foo bar\")) => t."
+When PATTERN contains a space, it is splitted and matching is
+done with the several resulting regexps against CANDIDATE.
+E.g., \"bar foo\" will match \"foobar\" and \"barfoo\".
+Argument PATTERN, a string, is transformed in a list of cons cell
+with `helm-mm-3-get-patterns' if it contains a space.
+E.g., \"foo bar\"=>((identity . \"foo\") (identity . \"bar\")).
+Then each predicate of cons cell(s) is called with the regexp of
+the same cons cell against CANDIDATE.
+I.e. (identity (string-match \"foo\" \"foo bar\")) => t."
   (let ((pat (helm-mm-3-get-patterns pattern)))
     (cl-loop for (predicate . regexp) in pat
              always (funcall predicate
@@ -273,7 +273,7 @@ i.e (identity (re-search-forward \"foo\" (point-at-eol) t)) => t."
 (define-minor-mode helm-migemo-mode
     "Enable migemo in helm.
 It will be available in the sources handling it,
-i.e the sources which have the slot :migemo with non--nil value."
+i.e. the sources which have the slot :migemo with non--nil value."
   :lighter " Hmio"
   :group 'helm
   :global t
@@ -328,7 +328,7 @@ i.e the sources which have the slot :migemo with non--nil value."
   "Check if PATTERN match CANDIDATE.
 Same as `helm-mm-3-match' but only for the cdr of patterns, the car of
 patterns must always match CANDIDATE prefix.
-e.g \"bar foo baz\" will match \"barfoobaz\" or \"barbazfoo\" but not
+E.g. \"bar foo baz\" will match \"barfoobaz\" or \"barbazfoo\" but not
 \"foobarbaz\" whereas `helm-mm-3-match' would match all."
   (let* ((pat (helm-mm-3-get-patterns (or pattern helm-pattern)))
          (first (car pat)))

--- a/helm-net.el
+++ b/helm-net.el
@@ -30,7 +30,7 @@
   :group 'helm)
 
 (defcustom helm-google-suggest-default-browser-function nil
-  "The browse url function you prefer to use with google suggest.
+  "The browse url function you prefer to use with Google suggest.
 When nil, use the first browser function available
 See `helm-browse-url-default-browser-alist'."
   :group 'helm-net
@@ -72,7 +72,7 @@ Otherwise `url-retrieve-synchronously' is used."
 
 (defcustom helm-surfraw-duckduckgo-url
   "https://duckduckgo.com/lite/?q=%s&kp=1"
-  "The duckduckgo url.
+  "The Duckduckgo url.
 This is a format string, don't forget the `%s'.
 If you have personal settings saved on duckduckgo you should have
 a personal url, see your settings on duckduckgo."
@@ -192,7 +192,7 @@ Can be \"-new-tab\" (default) or \"-new-window\"."
      request #'helm-google-suggest-parser)))
 
 (defun helm-google-suggest-set-candidates (&optional request-prefix)
-  "Set candidates with result and number of google results found."
+  "Set candidates with result and number of Google results found."
   (let ((suggestions (helm-google-suggest-fetch
                       (or (and request-prefix
                                (concat request-prefix
@@ -223,7 +223,7 @@ Can be \"-new-tab\" (default) or \"-new-window\"."
     "?"))
 
 (defun helm-google-suggest-action (candidate)
-  "Default action to jump to a google suggested candidate."
+  "Default action to jump to a Google suggested candidate."
   (let ((arg (format helm-google-suggest-search-url
                      (url-hexify-string candidate))))
     (helm-aif helm-google-suggest-default-browser-function
@@ -232,7 +232,7 @@ Can be \"-new-tab\" (default) or \"-new-window\"."
 
 (defvar helm-google-suggest-default-function
   'helm-google-suggest-set-candidates
-  "Default function to use in helm google suggest.")
+  "Default function to use in `helm-google-suggest'.")
 
 (defvar helm-source-google-suggest
   (helm-build-sync-source "Google Suggest"
@@ -244,7 +244,7 @@ Can be \"-new-tab\" (default) or \"-new-window\"."
     :requires-pattern 3))
 
 (defun helm-google-suggest-emacs-lisp ()
-  "Try to emacs lisp complete with google suggestions."
+  "Try to emacs lisp complete with Google suggestions."
   (helm-google-suggest-set-candidates "emacs lisp"))
 
 
@@ -291,12 +291,12 @@ Can be \"-new-tab\" (default) or \"-new-window\"."
 
 ;;;###autoload
 (defun helm-browse-url-firefox (url &optional _ignore)
-  "Same as `browse-url-firefox' but detach from emacs.
+  "Same as `browse-url-firefox' but detach from Emacs.
 
-So when you quit emacs you can keep your firefox session open
-and not be prompted to kill firefox process.
+So when you quit Emacs you can keep your Firefox session open and
+not be prompted to kill the Firefox process.
 
-NOTE: Probably not supported on some systems (e.g Windows)."
+NOTE: Probably not supported on some systems (e.g., Windows)."
   (interactive (list (read-string "URL: " (browse-url-url-at-point))
                      nil))
   (setq url (browse-url-encode-url url))
@@ -309,12 +309,12 @@ NOTE: Probably not supported on some systems (e.g Windows)."
 
 ;;;###autoload
 (defun helm-browse-url-opera (url &optional _ignore)
-  "Browse URL with opera browser and detach from emacs.
+  "Browse URL with Opera browser and detach from Emacs.
 
-So when you quit emacs you can keep your opera session open
-and not be prompted to kill opera process.
+So when you quit Emacs you can keep your Opera session open and
+not be prompted to kill the Opera process.
 
-NOTE: Probably not supported on some systems (e.g Windows)."
+NOTE: Probably not supported on some systems (e.g., Windows)."
   (interactive (list (read-string "URL: " (browse-url-url-at-point))
                      nil))
   (setq url (browse-url-encode-url url))
@@ -325,7 +325,7 @@ NOTE: Probably not supported on some systems (e.g Windows)."
 
 ;;;###autoload
 (defun helm-browse-url-chromium (url &optional _ignore)
-  "Browse URL with google chrome browser."
+  "Browse URL with Google Chrome browser."
   (interactive "sURL: ")
   (helm-generic-browser
    url helm-browse-url-chromium-program))
@@ -416,7 +416,7 @@ NOTE: Probably not supported on some systems (e.g Windows)."
 
 ;;;###autoload
 (defun helm-google-suggest ()
-  "Preconfigured `helm' for google search with google suggest."
+  "Preconfigured `helm' for Google search with Google suggest."
   (interactive)
   (helm-other-buffer 'helm-source-google-suggest "*helm google*"))
 

--- a/helm-occur.el
+++ b/helm-occur.el
@@ -145,7 +145,7 @@ buffers (i.e. a helm command using `helm-source-buffers-list' like
 `helm-mini') and use the multi occur buffers action.
 
 This is the helm implementation that collect lines matching pattern
-like vanilla emacs `occur' but have nothing to do with it, the search
+like vanilla Emacs `occur' but have nothing to do with it, the search
 engine beeing completely different and also much faster."
   (interactive)
   (setq helm-source-occur
@@ -191,7 +191,7 @@ engine beeing completely different and also much faster."
       (helm-multi-occur-1 (mapcar 'get-buffer buffers)))))
 
 (defun helm-occur-transformer (candidates source)
-  "Returns CANDIDATES prefixed with line number."
+  "Return CANDIDATES prefixed with line number."
   (cl-loop with buf = (helm-attr 'buffer-name source)
            for c in candidates collect
            (when (string-match helm-occur--search-buffer-regexp c)
@@ -212,7 +212,7 @@ engine beeing completely different and also much faster."
                    :initform nil)))
 
 (defun helm-occur-build-sources (buffers &optional source-name)
-  "Build sources for helm-occur for each buffer in BUFFERS list."
+  "Build sources for `helm-occur' for each buffer in BUFFERS list."
   (cl-loop for buf in buffers
            collect
            (helm-make-source (or source-name
@@ -266,7 +266,7 @@ engine beeing completely different and also much faster."
              :moccur-buffers buffers)))
 
 (defun helm-multi-occur-1 (buffers &optional input)
-  "Runs helm-occur on a list of buffers.
+  "Run `helm-occur' on a list of buffers.
 Each buffer's result is displayed in a separated source."
   (let* ((curbuf (current-buffer))
          (bufs (if helm-occur-always-search-in-current
@@ -299,7 +299,7 @@ Each buffer's result is displayed in a separated source."
 (cl-defun helm-occur-action (lineno
                                   &optional (method (quote buffer)))
   "Jump to line number LINENO with METHOD.
-arg METHOD can be one of buffer, buffer-other-window, buffer-other-frame."
+METHOD can be one of buffer, buffer-other-window, buffer-other-frame."
   (require 'helm-grep)
   (let ((buf (if (eq major-mode 'helm-occur-mode)
                  (get-text-property (point) 'buffer-name)
@@ -367,7 +367,7 @@ Same as `helm-occur-goto-line' but go in new frame."
 (put 'helm-moccur-run-save-buffer 'helm-only t)
 
 (defun helm-occur-right ()
-  "helm-occur action for right arrow.
+  "`helm-occur' action for right arrow.
 This is used when `helm-occur-use-ioccur-style-keys' is enabled.
 If follow is enabled (default) go to next source, otherwise execute
 persistent action."
@@ -506,7 +506,7 @@ persistent action."
   (helm-multi-occur-1 helm-occur--buffer-list helm-occur-mode--last-pattern))
 
 (defun helm-occur-buffer-substring-with-linums ()
-  "Returns current-buffer contents as a string with all lines
+  "Return current-buffer contents as a string with all lines
 numbered.  The property 'buffer-name is added to the whole string."
   (let ((bufstr (buffer-substring-no-properties (point-min) (point-max)))
         (bufname (buffer-name)))

--- a/helm-regexp.el
+++ b/helm-regexp.el
@@ -37,7 +37,7 @@
 (defun helm-query-replace-regexp (_candidate)
   "Query replace regexp from `helm-regexp'.
 With a prefix arg replace only matches surrounded by word boundaries,
-i.e Don't replace inside a word, regexp is surrounded with \\bregexp\\b."
+i.e. don't replace inside a word, regexp is surrounded with \\bregexp\\b."
   (let ((regexp helm-input))
     (apply 'query-replace-regexp
            (helm-query-replace-args regexp))))
@@ -52,7 +52,7 @@ i.e Don't replace inside a word, regexp is surrounded with \\bregexp\\b."
   (helm-regexp-kill-new helm-input))
 
 (defun helm-query-replace-args (regexp)
-  "create arguments of `query-replace-regexp' action in `helm-regexp'."
+  "Create arguments of `query-replace-regexp' action in `helm-regexp'."
   (let ((region-only (helm-region-active-p)))
     (list
      regexp

--- a/helm-ring.el
+++ b/helm-ring.el
@@ -39,9 +39,9 @@
   "Max number of chars displayed per candidate in kill-ring browser.
 When `t', don't truncate candidate, show all.
 By default it is approximatively the number of bits contained in five lines
-of 80 chars each i.e 80*5.
-Note that if you set this to nil multiline will be disabled, i.e you
-will not have anymore separators between candidates."
+of 80 chars each, i.e. 80*5.
+Note that if you set this to nil multiline will be disabled, i.e. you
+will not have separators between candidates any more."
   :type '(choice (const :tag "Disabled" t)
           (integer :tag "Max candidate offset"))
   :group 'helm-ring)
@@ -163,10 +163,10 @@ use `helm-kill-ring-separator' as default."
 (defun helm-kill-ring-action-yank-1 (str)
   "Insert STR in `kill-ring' and set STR to the head.
 
-When called with a prefix arg, point and mark are exchanged without
-activating region.
-If this action is executed just after `yank',
-replace with STR as yanked string."
+When called with a prefix arg, point and mark are exchanged
+without activating region.
+If this action is executed just after `yank', replace with STR as
+yanked string."
   (let ((yank-fn (lambda (&optional before yank-pop)
                    (insert-for-yank str)
                    ;; Set the window start back where it was in

--- a/helm-semantic.el
+++ b/helm-semantic.el
@@ -165,7 +165,7 @@ you have completion on these functions with `C-M i' in the customize interface."
 ;;;###autoload
 (defun helm-semantic (arg)
   "Preconfigured `helm' for `semantic'.
-If ARG is supplied, pre-select symbol at point instead of current"
+If ARG is supplied, pre-select symbol at point instead of current."
   (interactive "P")
   (let ((tag (helm-aif (car (semantic-current-tag-parent))
                  (let ((curtag (car (semantic-current-tag))))

--- a/helm-sys.el
+++ b/helm-sys.el
@@ -40,20 +40,22 @@
   "Top command used to display output of top.
 A format string where %s will be replaced with `frame-width'.
 
-To use 'top' command, a version supporting batch mode (-b option) is needed.
-On Mac OSX 'top' command doesn't support this, so ps command
-is used instead by default.
-Normally 'top' command output have 12 columns, but in some versions you may
-have less than this, so you can either customize top to use 12 columns with the
-interactives 'f' and 'W' commands of top, or modify
-`helm-top-sort-columns-alist' to fit with the number of columns
-your 'top' command is using.
+To use 'top' command, a version supporting batch mode (-b option)
+is needed. On Mac OSX 'top' command doesn't support this, so the
+'ps' command is used instead by default.
 
-If you modify 'ps' command be sure that 'pid' comes in first
-and \"env COLUMNS=%s\" is specified at beginning of command.
-Ensure also that no elements contain spaces (e.g use start_time and not start).
-Same as for 'top' you can customize `helm-top-sort-columns-alist' to make sort commands
-working properly according to your settings."
+Normally 'top' command output have 12 columns, but in some
+versions you may have less than this, so you can either customize
+top to use 12 columns with the interactives 'f' and 'W' commands
+of top, or modify `helm-top-sort-columns-alist' to fit with the
+number of columns your 'top' command is using.
+
+If you modify 'ps' command be sure that 'pid' comes in first and
+\"env COLUMNS=%s\" is specified at beginning of command. Ensure
+also that no elements contain spaces (e.g., use start_time and
+not start). Same as for 'top': you can customize
+`helm-top-sort-columns-alist' to make sort commands working
+properly according to your settings."
   :group 'helm-sys
   :type 'string)
 
@@ -64,7 +66,7 @@ working properly according to your settings."
   "Allow defining which column to use when sorting output of top/ps command.
 Only com, mem, cpu and user are sorted, so no need to put something else there,
 it will have no effect.
-Note that column numbers are counted from zero, i.e column 1 is the nth 0 column."
+Note that column numbers are counted from zero, i.e. column 1 is the nth 0 column."
   :group 'helm-sys
   :type '(alist :key-type symbol :value-type (integer :tag "Column number")))
 
@@ -76,15 +78,15 @@ The minimal delay allowed is 1.5, if less than this helm-top will use 1.5."
 
 (defcustom helm-top-poll-delay-post-command 1.0
   "Helm top stop polling during this delay.
-This delay is additioned to `helm-top-poll-delay' after emacs stop
+This delay is added to `helm-top-poll-delay' after Emacs stops
 being idle."
   :group 'helm-sys
   :type 'float)
 
 (defcustom helm-top-poll-preselection 'linum
-  "Stay on same line or follow candidate when `helm-top-poll' update display.
+  "Stay on same line or follow candidate when `helm-top-poll' updates display.
 Possible values are 'candidate or 'linum.
-This affect also sorting functions in the same way."
+This affects also sorting functions in the same way."
   :group'helm-sys
   :type '(radio :tag "Preferred preselection action for helm-top"
           (const :tag "Follow candidate" candidate)
@@ -143,9 +145,9 @@ This affect also sorting functions in the same way."
                       helm-top-poll-delay-post-command)))
 
 (defun helm-top-initialize-poll-hooks ()
-  ;; When emacs is idle during say 20s
+  ;; When Emacs is idle during say 20s
   ;; the idle timer will run in 20+1.5 s.
-  ;; This is fine when emacs stays idle, because the next timer
+  ;; This is fine when Emacs stays idle, because the next timer
   ;; will run at 21.5+1.5 etc... so the display will be updated
   ;; at every 1.5 seconds.
   ;; But as soon as emacs looses its idleness, the next update
@@ -437,7 +439,7 @@ Show actions only on line starting by a PID."
 
 ;;;###autoload
 (defun helm-list-emacs-process ()
-  "Preconfigured `helm' for emacs process."
+  "Preconfigured `helm' for Emacs process."
   (interactive)
   (helm-other-buffer 'helm-source-emacs-process "*helm process*"))
 

--- a/helm-tags.el
+++ b/helm-tags.el
@@ -107,8 +107,8 @@ one match."
   "Cache content of etags files used here for faster access.")
 
 (defun helm-etags-get-tag-file (&optional directory)
-  "Return the path of etags file if found.
-Lookes recursively in parents directorys for a
+  "Return the path of etags file if found in DIRECTORY.
+Look recursively in parents directorys for a
 `helm-etags-tag-file-name' file."
   ;; Get tag file from `default-directory' or upper directory.
   (let ((current-dir (helm-etags-find-tag-file-directory
@@ -118,7 +118,7 @@ Lookes recursively in parents directorys for a
       (expand-file-name helm-etags-tag-file-name current-dir))))
 
 (defun helm-etags-all-tag-files ()
-  "Return files from the following sources;
+  "Return files from the following sources:
   1) An automatically located file in the parent directories, by `helm-etags-get-tag-file'.
   2) `tags-file-name', which is commonly set by `find-tag' command.
   3) `tags-table-list' which is commonly set by `visit-tags-table' command."
@@ -186,7 +186,7 @@ If not found in CURRENT-DIR search in upper directory."
 
 (defun helm-etags-init ()
   "Feed `helm-buffer' using `helm-etags-cache' or tag file.
-If no entry in cache, create one."
+If there is no entry in cache, create one."
   (let ((tagfiles (helm-etags-all-tag-files)))
     (when tagfiles
       (with-current-buffer (helm-candidate-buffer 'global)

--- a/helm-utils.el
+++ b/helm-utils.el
@@ -76,11 +76,11 @@ It is a float, usually 1024.0 but could be 1000.0 on some systems."
   :type '(repeat (choice string)))
 
 (defcustom helm-html-decode-entities-function #'helm-html-decode-entities-string
-  "Function used to decode html entities in html bookmarks.
+  "Function used to decode HTML entities in HTML bookmarks.
 Helm comes by default with `helm-html-decode-entities-string', if you need something
 more sophisticated you can use `w3m-decode-entities-string' if available.
 
-In emacs itself org-entities seems broken and `xml-substitute-numeric-entities'
+In Emacs itself org-entities seem broken and `xml-substitute-numeric-entities'
 supports only numeric entities."
   :group 'helm-utils
   :type 'function)
@@ -88,17 +88,17 @@ supports only numeric entities."
 
 (defvar helm-goto-line-before-hook '(helm-save-current-pos-to-mark-ring)
   "Run before jumping to line.
-This hook run when jumping from `helm-goto-line', `helm-etags-default-action',
+This hook runs when jumping from `helm-goto-line', `helm-etags-default-action',
 and `helm-imenu-default-action'.
-This allow you to retrieve a previous position after using the different helm
+This allows you to retrieve a previous position after using the different helm
 tools for searching (etags, grep, gid, (m)occur etc...).
-By default positions are added to `mark-ring' you can also add to register
-by using instead (or adding) `helm-save-pos-to-register-before-jump'.
-In this case last position is added to the register
-`helm-save-pos-before-jump-register'.")
+By default positions are added to `mark-ring'.
+You can also add to register by using (or adding)
+`helm-save-pos-to-register-before-jump' instead. In this case
+last position is added to the register `helm-save-pos-before-jump-register'.")
 
 (defvar helm-save-pos-before-jump-register ?_
-  "The register where `helm-save-pos-to-register-before-jump' save position.")
+  "The register where `helm-save-pos-to-register-before-jump' saves position.")
 
 (defconst helm-html-entities-alist
   '(("&quot;"   . 34)   ;; "
@@ -206,18 +206,18 @@ In this case last position is added to the register
   "Table of html character entities and values.")
 
 (defvar helm-find-many-files-after-hook nil
-  "Hook that run at end of `helm-find-many-files'.")
+  "Hook that runs at end of `helm-find-many-files'.")
 
 ;;; Faces.
 ;;
 (defface helm-selection-line
     '((t (:inherit highlight :distant-foreground "black")))
-  "Face used in the `helm-current-buffer' when jumping to candidate."
+  "Face used in the `helm-current-buffer' when jumping to a candidate."
   :group 'helm-faces)
 
 (defface helm-match-item
     '((t (:inherit isearch)))
-  "Face used to highlight item matched in a selected line."
+  "Face used to highlight the item matched in a selected line."
   :group 'helm-faces)
 
 
@@ -236,7 +236,7 @@ according to the setting of `split-width-threshold' and the size of
 the window from where splitting is done.
 
 Note that when using `decide' and `split-width-threshold' is nil, the
-behavior is the same that with a nil value."
+behavior is the same as with a nil value."
   :group 'helm-utils
   :type '(choice
            (const :tag "Split window vertically" t)
@@ -258,8 +258,8 @@ It is typically used to rearrange windows."
 (defun helm-window-show-buffers (buffers &optional other-window)
   "Show BUFFERS.
 
-If more than one buffer marked switch to these buffers in separate windows.
-If OTHER-WINDOW is non-nil, keep current buffer and switch to others buffers
+With more than one buffer marked switch to these buffers in separate windows.
+If OTHER-WINDOW is non-nil, keep current buffer and switch to other buffers
 in separate windows.
 If a prefix arg is given split windows vertically."
   (let ((initial-ow-fn (if (cdr (window-list))
@@ -494,7 +494,7 @@ To use this add it to `helm-goto-line-before-hook'."
 (defun helm-show-all-candidates-in-source (arg)
   "Toggle all or only candidate-number-limit cands in current source.
 With a numeric prefix arg show only the ARG number of candidates.
-The prefix arg have no effect when toggling to only
+The prefix arg has no effect when toggling to only
 candidate-number-limit."
   (interactive "p")
   (with-helm-alive-p
@@ -661,7 +661,7 @@ that is sorting is done against real value of candidate."
 
 (cl-defun helm-file-human-size (size &optional (kbsize helm-default-kbsize))
   "Return a string showing SIZE of a file in human readable form.
-SIZE can be an integer or a float depending it's value.
+SIZE can be an integer or a float depending on it's value.
 `file-attributes' will take care of that to avoid overflow error.
 KBSIZE is a floating point number, defaulting to `helm-default-kbsize'."
   (cl-loop with result = (cons "B" size)
@@ -983,8 +983,8 @@ Assume regexp is a pcre based regexp."
                      file))))
 
 (defun helm-open-dired (file)
-  "Opens a dired buffer in FILE's directory.  If FILE is a
-directory, open this directory."
+  "Open a dired buffer in FILE's directory.
+If FILE is a directory, open this directory."
   (if (file-directory-p file)
       (dired file)
     (dired (file-name-directory file))
@@ -1013,7 +1013,7 @@ directory, open this directory."
 
 (defun helm-find-many-files (_ignore)
   "Simple action that run `find-file' on marked candidates.
-Run `helm-find-many-files-after-hook' at end"
+Run `helm-find-many-files-after-hook' at end."
   (let ((helm--reading-passwd-or-string t))
     (mapc 'find-file (helm-marked-candidates))
     (helm-log-run-hook 'helm-find-many-files-after-hook)))
@@ -1030,7 +1030,7 @@ If COUNT is non--nil add a number after each prompt."
         finally return (remove "" lis)))
 
 (defun helm-html-bookmarks-to-alist (file url-regexp bmk-regexp)
-  "Parse html bookmark FILE and return an alist with (title . url) as elements."
+  "Parse HTML bookmark FILE and return an alist with (title . url) as elements."
   (let (bookmarks-alist url title)
     (with-temp-buffer
       (insert-file-contents file)
@@ -1048,7 +1048,7 @@ If COUNT is non--nil add a number after each prompt."
     (nreverse bookmarks-alist)))
 
 (defun helm-html-entity-to-string (entity)
-  "Replace an html ENTITY by its string value.
+  "Replace an HTML ENTITY with its string value.
 When unable to decode ENTITY returns nil."
   (helm-aif (assoc entity helm-html-entities-alist)
       (string (cdr it))

--- a/helm.el
+++ b/helm.el
@@ -53,7 +53,7 @@ Each function runs sequentially for each KEY press.
 If DELAY is specified, switch back to initial function of FUNCTIONS list
 after DELAY seconds.
 The functions in FUNCTIONS list take no args.
-e.g
+E.g.
     (defun foo ()
       (interactive)
       (message \"Run foo\"))
@@ -66,9 +66,9 @@ e.g
 
 \(helm-define-multi-key global-map (kbd \"<f5> q\") '(foo bar baz) 2)
 
-Each time \"<f5> q\" is pressed, the next function is executed. Waiting
-more than 2 seconds between key presses switches back to executing the first
-function on the next hit."
+Each time \"<f5> q\" is pressed, the next function is executed.
+Waiting more than 2 seconds between key presses switches back to
+executing the first function on the next hit."
   (define-key keymap key (helm-make-multi-command functions delay)))
 
 ;;;###autoload
@@ -113,7 +113,7 @@ Run each function in the FUNCTIONS list in turn when called within DELAY seconds
                              (set iterator nil))))))
 
 (helm-multi-key-defun helm-toggle-resplit-and-swap-windows
-    "Multi key command to re-split and swap helm window.
+    "Multi key command to re-split and swap Helm window.
 First call runs `helm-toggle-resplit-window',
 and second call within 1s runs `helm-swap-windows'."
   '(helm-toggle-resplit-window helm-swap-windows) 1)
@@ -122,35 +122,34 @@ and second call within 1s runs `helm-swap-windows'."
 ;;;###autoload
 (defun helm-define-key-with-subkeys (map key subkey command
                                          &optional other-subkeys prompt exit-fn)
-  "Defines in MAP a KEY and SUBKEY to COMMAND.
+  "Define in MAP a KEY and SUBKEY to COMMAND.
 
 This allows typing KEY to call COMMAND the first time and
 type only SUBKEY on subsequent calls.
 
-Arg MAP is the keymap to use, SUBKEY is the initial short key-binding to
-call COMMAND.
+Arg MAP is the keymap to use, SUBKEY is the initial short
+key binding to call COMMAND.
 
-Arg OTHER-SUBKEYS is an alist specifying other short key-bindings
-to use once started e.g:
+Arg OTHER-SUBKEYS is an alist specifying other short key bindings
+to use once started, e.g.:
 
     (helm-define-key-with-subkeys global-map
        (kbd \"C-x v n\") ?n 'git-gutter:next-hunk
        '((?p . git-gutter:previous-hunk))\)
 
-
 In this example, `C-x v n' will run `git-gutter:next-hunk'
-subsequent \"n\"'s run this command again
-and subsequent \"p\"'s run `git-gutter:previous-hunk'.
+subsequent \"n\" will run this command again and subsequent \"p\"
+will run `git-gutter:previous-hunk'.
 
-If specified PROMPT can be displayed in minibuffer to
-describe SUBKEY and OTHER-SUBKEYS.
-Arg EXIT-FN specifies a function to run on exit.
+If specified PROMPT can be displayed in minibuffer to describe
+SUBKEY and OTHER-SUBKEYS.  Arg EXIT-FN specifies a function to run
+on exit.
 
-For any other keys pressed, run their assigned command as defined
+For any other key pressed, run their assigned command as defined
 in MAP and then exit the loop running EXIT-FN, if specified.
 
-NOTE: SUBKEY and OTHER-SUBKEYS bindings support only char syntax and
-vectors, so don't use strings to define them."
+NOTE: SUBKEY and OTHER-SUBKEYS bindings support only char syntax
+and vectors, so don't use strings to define them."
   (declare (indent 1))
   (define-key map key
     (lambda ()
@@ -288,7 +287,7 @@ vectors, so don't use strings to define them."
 (defun helm-customize-group ()
   "Jump to customization group of current source.
 
-Default to `helm' when group is not defined in source."
+Default to Helm group when group is not defined in source."
   (interactive)
   (helm-run-after-exit 'helm-customize-group-1 (helm-attr 'group)))
 (put 'helm-customize-group 'helm-only t)
@@ -318,8 +317,8 @@ Default to `helm' when group is not defined in source."
 This is a format spec where %d will be replaced by the candidate
 number.
 
-NOTE: `setq' have no effect until you restart emacs, use customize for
-immediate effect."
+NOTE: `setq' have no effect until you restart Emacs, use
+customize for immediate effect."
   :group 'helm
   :type 'string
   :set #'helm--action-at-nth-set-fn-)
@@ -330,22 +329,22 @@ immediate effect."
 This is a format spec where %d will be replaced by the candidate
 number.
 
-NOTE: `setq' have no effect until you restart emacs, use customize for
-immediate effect."
+NOTE: `setq' have no effect until you restart Emacs, use
+customize for immediate effect."
   :group 'helm
   :type 'string
   :set #'helm--action-at-nth-set-fn+)
 
 
 (defgroup helm nil
-  "Open helm."
+  "Open Helm."
   :prefix "helm-" :group 'convenience)
 
 (defcustom helm-completion-window-scroll-margin 5
-  " `scroll-margin' to use for helm completion window.
+  "`scroll-margin' to use for Helm completion window.
 Set to 0 to disable.
 NOTE: This has no effect when `helm-display-source-at-screen-top'
-id is non-`nil'."
+id is non-nil."
   :group 'helm
   :type  'integer)
 
@@ -357,7 +356,8 @@ id is non-`nil'."
 (defcustom helm-display-source-at-screen-top t
   "Display candidates at the top of screen.
 This happens with `helm-next-source' and `helm-previous-source'.
-NOTE: When non-`nil' (default), disable `helm-completion-window-scroll-margin'."
+NOTE: When non-nil (default), disable
+`helm-completion-window-scroll-margin'."
   :group 'helm
   :type 'boolean)
 
@@ -365,7 +365,7 @@ NOTE: When non-`nil' (default), disable `helm-completion-window-scroll-margin'."
   "Global limit for number of candidates displayed.
 When the pattern is empty, the number of candidates shown will be
 as set here instead of the entire list, which may be hundreds or
-thousands. Since narrowing and filtering rapidly reduces
+thousands.  Since narrowing and filtering rapidly reduces
 available candidates, having a small list will keep the interface
 responsive.
 
@@ -379,8 +379,8 @@ Set this value to nil for no limit."
   :type 'float)
 
 (defcustom helm-exit-idle-delay 0
-  "Idle time before exiting minibuffer while helm is updating.
-Has no affect when helm-buffer is up to date \(i.e exit without
+  "Idle time before exiting minibuffer while Helm is updating.
+Has no affect when helm-buffer is up to date \(i.e. exit without
 delay in this condition\)."
   :group 'helm
   :type 'float)
@@ -389,7 +389,7 @@ delay in this condition\)."
 (make-obsolete-variable 'helm-samewindow 'helm-full-frame "1.4.8.1")
 (defcustom helm-full-frame nil
   "Use current window for showing candidates.
-If t, then Helm does not pop-up new window."
+If t, then Helm does not pop-up a new window."
   :group 'helm
   :type 'boolean)
 
@@ -404,14 +404,14 @@ If t, then Helm does not pop-up new window."
 (defcustom helm-save-configuration-functions
   '(set-window-configuration . current-window-configuration)
   "Functions used to restore or save configurations for frames and windows.
-Specified as a pair of functions, where car is the restore function and cdr
-is the save function.
+Specified as a pair of functions, where car is the restore
+function and cdr is the save function.
 
 To save and restore frame configuration, set this variable to
 '\(set-frame-configuration . current-frame-configuration\)
 
 NOTE: This may not work properly with own-frame minibuffer
-settings. Older versions saves/restores frame configuration, but
+settings.  Older versions saves/restores frame configuration, but
 the default has changed now to avoid flickering."
   :group 'helm
   :type 'sexp)
@@ -420,15 +420,15 @@ the default has changed now to avoid flickering."
   "Function used to display `helm-buffer'.
 
 Local value in `helm-buffer' will take precedence on this default
-value. Commands that are in `helm-commands-using-frame' will have
+value.  Commands that are in `helm-commands-using-frame' will have
 `helm-buffer' displayed in frame, `helm-display-function' being
 ignored.
-If no local value found and current command is not one of
+If no local value is found and current command is not one of
 `helm-commands-using-frame' use this default value.
-Function in charge of deciding which value use is
+The function in charge of deciding which value use is
 `helm-resolve-display-function'.
 
-To set it locally to `helm-buffer' in helm sources use
+To set it locally to `helm-buffer' in Helm sources use
 `helm-set-local-variable' in init function or use
 :display-function slot in `helm' call."
   :group 'helm
@@ -445,7 +445,7 @@ Use nil or t to turn off smart behavior and use
 Default is smart.
 
 NOTE: Case fold search has no effect when searching asynchronous
-sources, which rely on customized features implemented directly
+sources, which relies on customized features implemented directly
 into their execution process. See helm-grep.el for an example."
   :group 'helm
   :type '(choice (const :tag "Ignore case" t)
@@ -481,19 +481,21 @@ the same window scheme as the previous session unless
 Must be one acceptable arg for `split-window' SIDE,
 that is `below', `above', `left' or `right'.
 
-Other acceptable values are `same' which always display
-`helm-buffer' in current window and `other' that display
+Other acceptable values are `same' which always displays
+`helm-buffer' in current window and `other' that displays
 `helm-buffer' below if only one window or in
 `other-window-for-scrolling' when available.
 
-A nil value has same effect as `below'.
-If `helm-full-frame' is non-`nil', it take precedence over this setting.
+A nil value has same effect as `below'. If `helm-full-frame' is
+non-nil, it take precedence over this setting.
 
-See also `helm-split-window-inside-p' and `helm-always-two-windows' that
-take precedence over this.
+See also `helm-split-window-inside-p' and
+`helm-always-two-windows' that take precedence over this.
 
-NOTE: this has no effect if `helm-split-window-preferred-function' is not
-`helm-split-window-default-fn' unless this new function can handle this."
+NOTE: this has no effect if
+`helm-split-window-preferred-function' is not
+`helm-split-window-default-fn' unless this new function can
+handle this."
   :group 'helm
   :type 'symbol)
 
@@ -504,40 +506,43 @@ the current frame only has one window. Possible values
 are acceptable args for `split-window' SIDE, that is `below', 
 `above', `left' or `right'.
 
-If `helm-full-frame' is non-`nil', it take precedence over this setting.
+If `helm-full-frame' is non-nil, it takes precedence over this
+setting.
 
 See also `helm-split-window-inside-p' and `helm-always-two-windows' that
-take precedence over this.
+takes precedence over this.
 
-NOTE: this has no effect if `helm-split-window-preferred-function' is not
-`helm-split-window-default-fn' unless this new function can handle this."
+NOTE: this has no effect if
+`helm-split-window-preferred-function' is not
+`helm-split-window-default-fn' unless this new function can
+handle this."
   :group 'helm
   :type 'symbol)
 
 (defcustom helm-display-buffer-default-height nil
   "Initial height of `helm-buffer', specified as an integer or a function.
 
-The function should take one arg and the responsibility for
-re-sizing the window; function's return value is ignored.
-Note that this have no effect when the split is vertical.
-See `display-buffer' for more info."
+The function should take one arg and be responsible for re-sizing
+the window; function's return value is ignored.  Note that this
+has no effect when the split is vertical.  See `display-buffer'
+for more info."
   :group 'helm
   :type '(choice integer function))
 
 (defcustom helm-display-buffer-default-width nil
   "Initial width of `helm-buffer', specified as an integer or a function.
 
-The function should take one arg and the responsibility for
-re-sizing the window; function's return value is ignored.
-Note that this have no effect when the split is horizontal.
-See `display-buffer' for more info."
+The function should take one arg and be responsible for re-sizing
+the window; function's return value is ignored.  Note that this
+have no effect when the split is horizontal.  See `display-buffer'
+for more info."
   :group 'helm
   :type '(choice integer function))
 
 (defvaralias 'helm-split-window-in-side-p 'helm-split-window-inside-p)
 (make-obsolete-variable 'helm-split-window-in-side-p 'helm-split-window-inside-p "2.8.6")
 (defcustom helm-split-window-inside-p nil
-  "Forces split inside selected window when non-`nil'.
+  "Force split inside selected window when non-nil.
 See also `helm-split-window-default-side'.
 
 NOTE: this has no effect if
@@ -548,19 +553,20 @@ handle this."
   :type 'boolean)
 
 (defcustom helm-always-two-windows nil
-  "When non-`nil' helm uses two windows in this frame.
+  "When non-nil Helm uses two windows in this frame.
 
 I.e. `helm-buffer' in one window and `helm-current-buffer'
 in the other.
 
-Note: this has no effect when `helm-split-window-inside-p' is non-`nil',
-or when `helm-split-window-default-side' is set to 'same.
+Note: this has no effect when `helm-split-window-inside-p' is
+non-nil, or when `helm-split-window-default-side' is set to
+'same.
 
 When `helm-autoresize-mode' is enabled, setting this to nil
 will have no effect.
 
-Also when non-`nil' it overrides the effect of `helm-split-window-default-side'
-set to `other'."
+Also when non-nil it overrides the effect of
+`helm-split-window-default-side' set to `other'."
   :group 'helm
   :type 'boolean)
 
@@ -578,8 +584,8 @@ set to `other'."
   "Action functions to pass to `display-buffer'.
 See (info \"(elisp) Action Functions for Buffer Display\").
 
-Have no effect when `helm-always-two-windows' is non-nil and may
-override other settings like `helm-split-window-inside-p'."
+It has no effect when `helm-always-two-windows' is non-nil and
+may override other settings like `helm-split-window-inside-p'."
   :group 'helm
   :type '(repeat symbol))
 
@@ -587,8 +593,8 @@ override other settings like `helm-split-window-inside-p'."
   "Additional alist to pass to `display-buffer' action.
 See (info \"(elisp) Action Alists for Buffer Display\").
 
-Have no effect when `helm-always-two-windows' is non-nil and may
-override other settings like `helm-split-window-inside-p'.
+It has no effect when `helm-always-two-windows' is non-nil and
+may override other settings like `helm-split-window-inside-p'.
 Note that window-height and window-width have to be configured in
 `helm-display-buffer-height' and `helm-display-buffer-width'."
   :group 'helm
@@ -604,27 +610,29 @@ Note that window-height and window-width have to be configured in
                                                  helm-source-grep-ag
                                                  helm-source-grep-git
                                                  helm-source-grep)
-  "List of helm sources that need to use `helm--maybe-use-default-as-input'.
+  "List of Helm sources that need to use `helm--maybe-use-default-as-input'.
 When a source is a member of this list, default `thing-at-point'
 will be used as input."
   :group 'helm
   :type '(repeat (choice symbol)))
 
 (defcustom helm-delete-minibuffer-contents-from-point t
-  "When non-`nil', `helm-delete-minibuffer-contents' delete region from `point'.
-Otherwise delete `minibuffer-contents'.
-See documentation for  `helm-delete-minibuffer-contents'."
+  "When non-nil, `helm-delete-minibuffer-contents' deletes region from `point'.
+Otherwise it deletes `minibuffer-contents'.
+See documentation for `helm-delete-minibuffer-contents'."
   :group 'helm
   :type 'boolean)
 
 (defcustom helm-follow-mode-persistent nil
-  "When non-`nil', save last state of `helm-follow-mode' for the next emacs sessions.
+  "When non-nil, save last state of `helm-follow-mode' for the next Emacs sessions.
 
-Each time you turn on or off `helm-follow-mode', the current source name will be stored
-or removed from `helm-source-names-using-follow'.
+Each time you turn on or off `helm-follow-mode', the current
+source name will be stored or removed from
+`helm-source-names-using-follow'.
 
-Note that this may be disabled in some places where it is unsafe to use
-because persistent action is changing according to context."
+Note that this may be disabled in some places where it is unsafe
+to use because persistent action is changing according to
+context."
   :group 'helm
   :type 'boolean)
 
@@ -633,25 +641,25 @@ because persistent action is changing according to context."
 This list of source names will be used only
 when `helm-follow-mode-persistent' is non-nil.
 
-You don't have to customize this yourself unless you really want and
-know what you are doing, instead just set
-`helm-follow-mode-persistent' to non-nil and as soon you turn on or
-off `helm-follow-mode' (C-c C-f) in a source, helm will save or remove
-source name in this variable."
+You don't have to customize this yourself unless you really want
+and know what you are doing, instead just set
+`helm-follow-mode-persistent' to non-nil and as soon as you turn
+on or off `helm-follow-mode' (C-c C-f) in a source, Helm will
+save or remove source name in this variable."
   :group 'helm
   :type '(repeat (choice string)))
 
 (defcustom helm-prevent-escaping-from-minibuffer t
-  "Prevent escaping from minibuffer with `other-window' during the helm session."
+  "Prevent escaping from minibuffer with `other-window' during the Helm session."
   :group 'helm
   :type 'boolean)
 
 (defcustom helm-allow-mouse nil
-  "Allow mouse usage during the helm session when non-nil.
+  "Allow mouse usage during the Helm session when non-nil.
 
-Note that this also allow moving out of minibuffer when clicking
-outside of `helm-buffer', up to you to get back to helm by clicking
-back in `helm-buffer' or minibuffer."
+Note that this also allows moving out of minibuffer when clicking
+outside of `helm-buffer', so it is up to you to get back to Helm
+by clicking back in `helm-buffer' or minibuffer."
   :group 'helm
   :type 'boolean)
 
@@ -684,14 +692,14 @@ When nil, no highlighting is done."
   :type 'function)
 
 (defcustom helm-autoresize-max-height 40
-  "Specifies maximum height and defaults to percent of helm window's frame height.
+  "Specify maximum height and defaults to percent of Helm window's frame height.
 
 See `fit-window-to-buffer' for more infos."
   :group 'helm
   :type 'integer)
 
 (defcustom helm-autoresize-min-height 10
-  "Specifies minimum height and defaults to percent of helm window's frame height.
+  "Specify minimum height and defaults to percent of Helm window's frame height.
 
 If nil, `window-min-height' is used.
 See `fit-window-to-buffer' for details."
@@ -699,12 +707,14 @@ See `fit-window-to-buffer' for details."
   :type 'integer)
 
 (defcustom helm-input-method-verbose-flag nil
-  "The default value for `input-method-verbose-flag' used in helm minibuffer.
+  "The default value for `input-method-verbose-flag' used in Helm minibuffer.
 It is nil by default, which does not turn off input method. Helm
-updates and exits without interruption -- necessary for complex methods.
+updates and exits without interruption -- necessary for complex
+methods.
 
 If set to any other value as per `input-method-verbose-flag',
-then use `C-\\' to disable the `current-input-method' to exit or update helm"
+then use `C-\\' to disable the `current-input-method' to exit or
+update Helm."
   :group 'helm
   :type '(radio :tag "A flag to control extra guidance for input methods in helm."
                 (const :tag "Never provide guidance" nil)
@@ -717,26 +727,28 @@ then use `C-\\' to disable the `current-input-method' to exit or update helm"
   :type 'boolean)
 
 (defcustom helm-inherit-input-method t
-  "Inherit `current-input-method' from `current-buffer' when non-`nil'.
+  "Inherit `current-input-method' from `current-buffer' when non-nil.
 The default is to enable this by default and then toggle
 `toggle-input-method'."
   :group 'helm
   :type 'boolean)
 
 (defcustom helm-echo-input-in-header-line nil
-  "Send current input in header-line when non-nil."
+  "Send current input to header-line when non-nil."
   :group 'helm
   :type 'boolean)
 
 (defcustom helm-header-line-space-before-prompt 'left-fringe
   "Specify the space before prompt in header-line.
 
-This will be used when `helm-echo-input-in-header-line' is non-nil.
+This will be used when `helm-echo-input-in-header-line' is
+non-nil.
 
-Value can be one of the symbols 'left-fringe or 'left-margin or an
-integer specifying the number of spaces before prompt.
-Note that on input longer that `window-width' the continuation string
-will be shown on left side of window without taking care of this."
+Value can be one of the symbols 'left-fringe or 'left-margin or
+an integer specifying the number of spaces before prompt.  Note
+that on input longer that `window-width' the continuation string
+will be shown on left side of window without taking care of
+this."
   :group 'helm
   :type '(choice
           (symbol
@@ -745,22 +757,25 @@ will be shown on left side of window without taking care of this."
           integer))
 
 (defcustom helm-tramp-connection-min-time-diff 5
-  "Value of `tramp-connection-min-time-diff' for helm remote processes.
-If set to zero helm remote processes are not delayed.
-Setting this to a value less than 5 or disabling it with a zero value
-is risky, however on emacs versions starting at 24.5 it seems
-it is now possible to disable it.
-Anyway at any time in helm you can suspend your processes while typing
-by hitting \\<helm-map> `\\[helm-toggle-suspend-update]'.
+  "Value of `tramp-connection-min-time-diff' for Helm remote processes.
+If set to zero Helm remote processes are not delayed.
+
+Setting this to a value less than 5 or disabling it with a zero
+value is risky, however on Emacs versions starting at 24.5 it
+seems it is now possible to disable it.
+
+Anyway at any time in Helm you can suspend your processes while
+typing by hitting \\<helm-map> `\\[helm-toggle-suspend-update]'.
+
 Only async sources than use a sentinel calling
 `helm-process-deferred-sentinel-hook' are affected by this."
   :type 'integer
   :group 'helm)
 
 (defcustom helm-debug-root-directory nil
-  "When non-`nil', saves helm log messages to a file in this directory.
-When `nil' log messages are saved to a buffer instead.
-Log message are saved only when `helm-debug' is non-nil, so setting this
+  "When non-nil, save Helm log messages to a file in this directory.
+When nil log messages are saved to a buffer instead.  Log message
+are saved only when `helm-debug' is non-nil, so setting this
 doesn't enable debugging by itself.
 
 See `helm-log-save-maybe' for more info."
@@ -775,8 +790,9 @@ in same window.
 If left display the action buffer at the left of helm-buffer.
 If right or any other value, split at right.
 
-Note that this may not fit well with some helm window configurations,
-so it have only effect when `helm-always-two-windows' is non-nil."
+Note that this may not fit well with some Helm window
+configurations, so it have only effect when
+`helm-always-two-windows' is non-nil."
   :group 'helm
   :type '(choice
           (const :tag "Split at left" left)
@@ -789,13 +805,13 @@ so it have only effect when `helm-always-two-windows' is non-nil."
   :group 'helm)
 
 (defcustom helm-display-buffer-reuse-frame nil
-  "When non nil helm frame is not deleted and reused in next sessions.
+  "When non nil Helm frame is not deleted and reused in next sessions.
 
-This was used to workaround a bug in emacs where frames where
+This was used to workaround a bug in Emacs where frames where
 popping up slowly, now that the bug have been fixed upstream
-\(emacs-27) probably you don't want to use this anymore.
-On emacs-26 set `x-wait-for-event-timeout' to nil to have your frames
-popping up fast."
+\(emacs-27) probably you don't want to use this any more.  On
+emacs-26 set `x-wait-for-event-timeout' to nil to have your
+frames popping up fast."
   :group 'helm
   :type 'boolean)
 
@@ -805,42 +821,42 @@ popping up fast."
   :type '(repeat symbol))
 
 (defcustom helm-actions-inherit-frame-settings t
-  "Actions inherit helm frame settings of initial command when non nil."
+  "Actions inherit Helm frame settings of initial command when non nil."
   :group 'helm
   :type 'boolean)
 
 (defcustom helm-use-undecorated-frame-option t
-  "Display helm frame undecorated when non nil.
+  "Display Helm frame undecorated when non nil.
 
-This option have no effect with emacs versions lower than 26."
+This option has no effect with Emacs versions lower than 26."
   :group 'helm
   :type 'boolean)
 
 (defcustom helm-frame-background-color nil
-  "Background color for helm frames, a string.
+  "Background color for Helm frames, a string.
 Fallback to default face background when nil."
   :group 'helm
   :type 'string)
 
 (defcustom helm-frame-foreground-color nil
-  "Foreground color for helm frames, a string.
+  "Foreground color for Helm frames, a string.
 Fallback to default face foreground when nil"
   :group 'helm
   :type 'string)
 
 (defcustom helm-frame-alpha nil
-  "Alpha parameter for helm frames, an integer.
+  "Alpha parameter for Helm frames, an integer.
 Fallback to 100 when nil."
   :group 'helm
   :type 'integer)
 
 (defcustom helm-use-frame-when-more-than-two-windows nil
-  "Display helm buffer in frame when more than two windows."
+  "Display Helm buffer in frame when more than two windows."
   :group 'helm
   :type 'boolean)
 
 (defcustom helm-use-frame-when-dedicated-window nil
-  "Display helm buffer in frame when helm is started from a dedicated window."
+  "Display Helm buffer in frame when Helm is started from a dedicated window."
   :group 'helm
   :type 'boolean)
 
@@ -851,8 +867,9 @@ Fallback to 100 when nil."
   :type 'function)
 
 (defcustom helm-truncate-lines nil
-  "The value of `truncate-lines' when helm startup.
-You can toggle later `truncate-lines' with \\<helm-map>\\[helm-toggle-truncate-line]."
+  "The value of `truncate-lines' when Helm starts.
+You can toggle later `truncate-lines' with
+\\<helm-map>\\[helm-toggle-truncate-line]."
   :group 'helm
   :type 'boolean)
 
@@ -860,7 +877,7 @@ You can toggle later `truncate-lines' with \\<helm-map>\\[helm-toggle-truncate-l
 ;;
 ;;
 (defgroup helm-faces nil
-  "Customize the appearance of helm."
+  "Customize the appearance of Helm."
   :prefix "helm-"
   :group 'faces
   :group 'helm)
@@ -874,7 +891,7 @@ You can toggle later `truncate-lines' with \\<helm-map>\\[helm-toggle-truncate-l
      :background "#abd7f0"
      :foreground "black"
      :weight bold :height 1.3 :family "Sans Serif"))
-  "Face for source header in the helm buffer."
+  "Face for source header in the Helm buffer."
   :group 'helm-faces)
 
 (defface helm-visible-mark
@@ -891,7 +908,7 @@ You can toggle later `truncate-lines' with \\<helm-map>\\[helm-toggle-truncate-l
 
 (defface helm-header
   '((t (:inherit header-line)))
-  "Face for header lines in the helm buffer."
+  "Face for header lines in the Helm buffer."
   :group 'helm-faces)
 
 (defface helm-candidate-number
@@ -902,7 +919,7 @@ You can toggle later `truncate-lines' with \\<helm-map>\\[helm-toggle-truncate-l
 
 (defface helm-candidate-number-suspended
   '((t (:inherit helm-candidate-number :inverse-video t)))
-  "Face for candidate number in mode-line when helm is suspended."
+  "Face for candidate number in mode-line when Helm is suspended."
   :group 'helm-faces)
 
 (defface helm-selection
@@ -910,7 +927,7 @@ You can toggle later `truncate-lines' with \\<helm-map>\\[helm-toggle-truncate-l
      :distant-foreground "black")
     (((background light)) :background "#b5ffd1"
      :distant-foreground "black"))
-  "Face for currently selected item in the helm buffer."
+  "Face for currently selected item in the Helm buffer."
   :group 'helm-faces)
 
 (defface helm-separator
@@ -921,7 +938,7 @@ You can toggle later `truncate-lines' with \\<helm-map>\\[helm-toggle-truncate-l
 
 (defface helm-action
   '((t (:underline t)))
-  "Face for action lines in the helm action buffer."
+  "Face for action lines in the Helm action buffer."
   :group 'helm-faces)
 
 (defface helm-prefarg
@@ -943,12 +960,12 @@ You can toggle later `truncate-lines' with \\<helm-map>\\[helm-toggle-truncate-l
 
 (defface helm-minibuffer-prompt
   '((t (:inherit minibuffer-prompt)))
-  "Face used for the minibuffer/headline prompt (such as Pattern:) in helm."
+  "Face used for the minibuffer/headline prompt (such as Pattern:) in Helm."
   :group 'helm-faces)
 
 (defface helm-eob-line
   '((t (:inherit default)))
-  "Face for empty line at end of sources in the helm buffer.
+  "Face for empty line at end of sources in the Helm buffer.
 Allow specifying the height of this line."
   :group 'helm-faces)
 
@@ -959,34 +976,35 @@ Allow specifying the height of this line."
   "Overlay used to highlight the currently selected item.")
 
 (defvar helm-async-processes nil
-  "List of information about asynchronous processes managed by helm.")
+  "List of information about asynchronous processes managed by Helm.")
 
 (defvar helm-before-initialize-hook nil
-  "Runs before helm initialization.
+  "Runs before Helm initialization.
 This hook runs before init functions in `helm-sources', which is
-before creation of `helm-buffer'. Set local variables for
+before creation of `helm-buffer'.  Set local variables for
 `helm-buffer' that need a value from `current-buffer' with
 `helm-set-local-variable'.")
 
 (defvar helm-after-initialize-hook nil
-  "Runs after helm initialization.
+  "Runs after Helm initialization.
 This hook runs after `helm-buffer' is created but not from
-`helm-buffer'. The hook needs to specify in which buffer to run.")
+`helm-buffer'.  The hook needs to specify in which buffer to
+run.")
 
 (defvaralias 'helm-update-hook 'helm-after-update-hook)
 (make-obsolete-variable 'helm-update-hook 'helm-after-update-hook "1.9.9")
 
 (defvar helm-after-update-hook nil
-  "Runs after updating the helm buffer with the new input pattern.")
+  "Runs after updating the Helm buffer with the new input pattern.")
 
 (defvar helm-before-update-hook nil
-  "Runs before updating the helm buffer with the new input pattern.")
+  "Runs before updating the Helm buffer with the new input pattern.")
 
 (defvar helm-cleanup-hook nil
   "Runs after exiting the minibuffer and before performing an
 action.
 
-This hook runs even if helm exits the minibuffer abnormally (e.g.
+This hook runs even if Helm exits the minibuffer abnormally (e.g.
 via `helm-keyboard-quit').")
 
 (defvar helm-select-action-hook nil
@@ -994,7 +1012,7 @@ via `helm-keyboard-quit').")
 
 (defvar helm-before-action-hook nil
   "Runs before executing action.
-Unlike `helm-cleanup-hook', this hook runs before helm closes the
+Unlike `helm-cleanup-hook', this hook runs before Helm closes the
 minibuffer and also before performing an action.")
 
 (defvar helm-after-action-hook nil
@@ -1003,8 +1021,8 @@ minibuffer and also before performing an action.")
 (defvar helm-exit-minibuffer-hook nil
   "Runs just before exiting the minibuffer.
 
-This hook runs when helm exits the minibuffer normally (e.g. via
-candidate selection), but does NOT run if helm exits the
+This hook runs when Helm exits the minibuffer normally (e.g., via
+candidate selection), but does NOT run if Helm exits the
 minibuffer abnormally (e.g. via `helm-keyboard-quit').")
 
 (defvar helm-after-persistent-action-hook nil
@@ -1023,26 +1041,26 @@ minibuffer abnormally (e.g. via `helm-keyboard-quit').")
   "Runs when switching to and from the action buffer.")
 
 (defvar helm-execute-action-at-once-if-one nil
-  "When non--nil executes the default action and then exits if only one candidate.
-If symbol 'current-source is given as value exit if only one candidate
-in current source.
-This variable accepts a function with no args that should returns a boolean
-value or 'current-source.")
+  "When non-nil execute the default action and then exit if only one candidate.
+If symbol 'current-source is given as value exit if only one
+candidate in current source.  This variable accepts a function
+with no args that should returns a boolean value or
+'current-source.")
 
 (defvar helm-quit-if-no-candidate nil
-  "When non-`nil', quits if there are no candidates.
+  "When non-nil, quit if there are no candidates.
 This variable accepts a function.")
 
 (defvar helm-debug-variables nil
-  "A list of helm variables that `helm-debug-output' displays.
-If `nil', `helm-debug-output' includes only variables with
-`helm-' prefixes.")
+  "A list of Helm variables that `helm-debug-output' displays.
+If nil, `helm-debug-output' includes only variables with `helm-'
+prefixes.")
 
 (defvar helm-debug-buffer "*Debug Helm Log*")
 
 (defvar helm-debug nil
-  "If non-`nil', write log message to `helm-debug-buffer'.
-Default is `nil', which disables writing log messages because the
+  "If non-nil, write log message to `helm-debug-buffer'.
+Default is nil, which disables writing log messages because the
 size of `helm-debug-buffer' grows quickly.")
 
 (defvar helm-mode-line-string "\
@@ -1053,14 +1071,14 @@ size of `helm-debug-buffer' grows quickly.")
 f1/f2/f-n:NthAct \
 \\[helm-toggle-suspend-update]:Tog.suspend \
 \\[helm-customize-group]:Conf"
-  "Help string displayed by helm in the mode-line.
+  "Help string displayed by Helm in the mode-line.
 It is either a string or a list of two string arguments where the
 first string is the name and the second string is displayed in
-the mode-line. When `nil', uses default `mode-line-format'.")
+the mode-line. When nil, it defaults to `mode-line-format'.")
 
 (defvar helm-minibuffer-set-up-hook nil
   "Hook that runs at minibuffer initialization.
-A hook useful for modifying minibuffer settings in helm.
+A hook useful for modifying minibuffer settings in Helm.
 
 An example that hides the minibuffer when using
 `helm-echo-input-in-header-line':
@@ -1068,7 +1086,7 @@ An example that hides the minibuffer when using
       (add-hook 'helm-minibuffer-set-up-hook #'helm-hide-minibuffer-maybe)
 
 Note that we check `helm-echo-input-in-header-line' value
-from `helm-buffer' which allow detecting possible local
+from `helm-buffer' which allows detecting possible local
 value of this var.")
 
 (defvar helm-help-message
@@ -1077,54 +1095,65 @@ value of this var.")
 
 To navigate in this Help buffer see [[Helm help][here]].
 
-Helm narrows down the list of candidates as you type a filter pattern see [[Matching in Helm][Matching in Helm]].
+Helm narrows down the list of candidates as you type a filter
+pattern.  See [[Matching in Helm][Matching in Helm]].
 
-Helm accepts multiple space-separated patterns, each pattern can be negated with \"!\".
+Helm accepts multiple space-separated patterns, each pattern can
+be negated with \"!\".
 
-Helm also supports fuzzy matching in some places when specified, you will find
-several variables to enable fuzzy matching in diverse [[Helm sources][sources]],
-see [[https://github.com/emacs-helm/helm/wiki/Fuzzy-matching][fuzzy-matching]] in helm-wiki for more infos.
+Helm also supports fuzzy matching in some places when specified,
+you will find several variables to enable fuzzy matching in
+diverse [[Helm sources][sources]], see
+[[https://github.com/emacs-helm/helm/wiki/Fuzzy-matching][fuzzy-matching]]
+in helm-wiki for more infos.
 
 Helm generally uses familiar Emacs keys to navigate the list.
 Here follow some of the less obvious bindings:
 
-- `\\<helm-map>\\[helm-maybe-exit-minibuffer]' selects the candidate from the list, executes the default action
-upon exiting the Helm session.
+- `\\<helm-map>\\[helm-maybe-exit-minibuffer]' selects the
+candidate from the list, executes the default action upon exiting
+the Helm session.
 
-- `\\<helm-map>\\[helm-execute-persistent-action]' executes the default action but without exiting the Helm session.
-Not all sources support this.
+- `\\<helm-map>\\[helm-execute-persistent-action]' executes the
+default action but without exiting the Helm session.  Not all
+sources support this.
 
-- `\\<helm-map>\\[helm-select-action]' displays a list of actions available on current candidate or all marked candidates.
-The default binding <tab> is ordinarily used for completion, but that would be
-redundant since Helm completes upon every character entered in the prompt.
-See [[https://github.com/emacs-helm/helm/wiki#helm-completion-vs-emacs-completion][Helm wiki]].
+- `\\<helm-map>\\[helm-select-action]' displays a list of actions
+available on current candidate or all marked candidates.  The
+default binding <tab> is ordinarily used for completion, but that
+would be redundant since Helm completes upon every character
+entered in the prompt.  See
+[[https://github.com/emacs-helm/helm/wiki#helm-completion-vs-emacs-completion][Helm
+wiki]].
 
-Note: In addition to the default actions list, additional actions appear
-depending of the type of the selected candidate(s).  They are called filtered
-actions.
+Note: In addition to the default actions list, additional actions
+appear depending on the type of the selected candidate(s).  They
+are called filtered actions.
 
 ** Helm sources
 
-Helm uses what's called sources to provide different kinds of completions, each helm session
-can handle one or more source.
-A source is an alist object which is build from various classes, see [[Writing your own Helm sources][here]]
-and [[https://github.com/emacs-helm/helm/wiki/Developing#creating-a-source][Helm wiki]] for more infos.
+Helm uses what's called sources to provide different kinds of
+completions.  Each Helm session can handle one or more source.  A
+source is an alist object which is build from various classes,
+see [[Writing your own Helm sources][here]] and
+[[https://github.com/emacs-helm/helm/wiki/Developing#creating-a-source][Helm
+wiki]] for more infos.
 
 *** Configure sources
 
-You will find in helm sources already built and bound to a
-variable called generally `helm-source-<something>', in this case
+You will find in Helm sources already built and bound to a
+variable called generally `helm-source-<something>'.  In this case
 it is an alist and you can change the attributes (keys) values
-using `helm-attrset' function in your config, of course you have
-to ensure before calling `helm-attrset' that the file containing
-source is loaded with e.g. `with-eval-after-load'.  Of course you
-can also completely redefine the source but this is generally not
-elegant as it duplicate for its most part code already defined in
-Helm.
+using `helm-attrset' function in your configuration.  Of course
+you have to ensure before calling `helm-attrset' that the file
+containing source is loaded, e.g. with `with-eval-after-load'.  Of
+course you can also completely redefine the source but this is
+generally not elegant as it duplicate for its most part code
+already defined in Helm.
 
 You will find also sources that are not built and even not bound
-to any variables because they are rebuilded at each start of helm
-session.  In this case you can add a defmethod called
+to any variables because they are rebuilded at each start of a
+Helm session.  In this case you can add a defmethod called
 `helm-setup-user-source' to your config:
 
 #+begin_src elisp
@@ -1134,46 +1163,53 @@ session.  In this case you can add a defmethod called
 
 #+end_src
 
-See [[https://github.com/emacs-helm/helm/wiki/FAQ#why-is-a-customizable-helm-source-nil][here]] for more infos,
-and for more complex examples of configuration [[https://github.com/thierryvolpiatto/emacs-tv-config/blob/master/init-helm.el#L340][here]].
+See
+[[https://github.com/emacs-helm/helm/wiki/FAQ#why-is-a-customizable-helm-source-nil][here]]
+for more infos, and for more complex examples of configuration
+[[https://github.com/thierryvolpiatto/emacs-tv-config/blob/master/init-helm.el#L340][here]].
 
 ** Modify keybindings in Helm
 
 Helm main keymap is `helm-map', all keys bound in this map apply
-to all helm sources.  However, most sources have their own
-keymap, with each binding overriding its counterpart in
-`helm-map', you can see all bindings in effect in the [[Commands][Commands]]
-section (available only if the source have its own keymap and documentation of course).
+to all Helm sources.  However, most sources have their own keymap,
+with each binding overriding its counterpart in `helm-map', you
+can see all bindings in effect in the [[Commands][Commands]]
+section (available only if the source has its own keymap and
+documentation of course).
 
 ** Matching in Helm
 
-All what you write in minibuffer is interpreted as a regexp or
+All that you write in minibuffer is interpreted as a regexp or
 multiple regexps if separated by a space.  This is true for most
-sources unless developer of source have disabled it or have choosen to
-use fuzzy matching.  Even if a source have fuzzy matching enabled,
-helm will switch to multi match as soon as it detect a space in
-pattern, it may also switch to multi match as well if pattern starts
-with a \"^\" beginning of line sign, in those cases each pattern
-separated with space should be a regexp and not a fuzzy pattern.  When
-using multi match patterns, each pattern starting with \"!\" is
-interpreted as a negation i.e. match everything but this.
+sources unless the developer of the source has disabled it or
+have choosen to use fuzzy matching.  Even if a source has fuzzy
+matching enabled, Helm will switch to multi match as soon as it
+detects a space in the pattern.  It may also switch to multi match
+as well if pattern starts with a \"^\" beginning of line sign.  In
+those cases each pattern separated with space should be a regexp
+and not a fuzzy pattern.  When using multi match patterns, each
+pattern starting with \"!\" is interpreted as a negation i.e.
+match everything but this.
 
 *** Completion-styles
 
-Helm generally fetch its candidates with the :candidates function
-up to `helm-candidate-number-limit' and then apply match functions
-to these candidates according to `helm-pattern'.
+Helm generally fetches its candidates with the :candidates
+function up to `helm-candidate-number-limit' and then applies
+match functions to these candidates according to `helm-pattern'.
 But Helm allows matching candidates directly from the :candidates
 function using its own `completion-styles'.
-Helm provides 'helm completion style but also 'helm-flex completion style
-for Emacs<27 that don't have 'flex completion style, otherwise (emacs-27)
-'flex completion style is used to provide fuzzy aka flex completion.
-By default, like in Emacs vanilla, all completion commands
-\(e.g. `completion-at-point') using `completion-in-region' or
+Helm provides 'helm completion style but also 'helm-flex
+completion style for Emacs<27 that don't have 'flex completion
+style, otherwise (emacs-27) 'flex completion style is used to
+provide fuzzy aka flex completion.
+By default, like in Emacs vanilla, all completion commands \(e.g.,
+`completion-at-point') using `completion-in-region' or
 `completing-read' use `completion-styles'.
-Some Helm native commands like `helm-M-x' do use `completion-styles'.
-Any helm sources can use `completion-styles' by using :match-dynamic slot
-and building their :candidates function with `helm-dynamic-completion'.
+Some Helm native commands like `helm-M-x' do use
+`completion-styles'.  Any Helm sources can use `completion-styles'
+by using :match-dynamic slot and building their :candidates
+function with `helm-dynamic-completion'.
+
 Example:
 
 #+begin_src elisp
@@ -1187,95 +1223,106 @@ Example:
 
 #+end_src
 
-By default Helm setup `completion-styles' and always add 'helm to it, however
-the flex completion styles are not added, this is up to the user if she want to
-have such completion to enable this.
-As specified above use 'flex for emacs-27 and 'helm-flex for emacs-26.
-Anyway, 'helm-flex is not provided in `completion-styles-alist' if 'flex is present.
+By default Helm sets up `completion-styles' and always adds 'helm
+to it.  However the flex completion styles are not added.  This is
+up to the user if she wants to have such completion to enable
+this.
+As specified above use 'flex for emacs-27 and 'helm-flex for
+emacs-26. Anyway, 'helm-flex is not provided in
+`completion-styles-alist' if 'flex is present.
 
-Finally Helm provide two user variables to control `completion-styles' usage:
-`helm-completion-style' and `helm-completion-syles-alist'.
-Both variables are customizable.
-The former allows retrieving previous Helm behavior if needed, by setting it to
-`helm' or `helm-fuzzy', default being `emacs' which allows dynamic completion
-and usage of `completion-styles', the second allows setting `helm-completion-style'
-per mode and also specify `completion-styles' per mode (see its docstring).
-Note that these two variables take effect only in helm-mode i.e. in all what use
-`completion-read' or `completion-in-region', IOW all helmized commands.
-File completion in `read-file-name' family doesn't obey completion-styles and have their
-own file completion implementation.
-Native helm commands using `completion-styles' doesn't obey `helm-completion-style' and
-`helm-completion-syles-alist' (e.g. helm-M-x).
+Finally Helm provides two user variables to control
+`completion-styles' usage: `helm-completion-style' and
+`helm-completion-syles-alist'.  Both variables are customizable.
+The former allows retrieving previous Helm behavior if needed, by
+setting it to `helm' or `helm-fuzzy', default being `emacs' which
+allows dynamic completion and usage of `completion-styles'.  The
+second allows setting `helm-completion-style' per mode and also
+specifying `completion-styles' per mode (see its docstring).  Note
+that these two variables take effect only in helm-mode i.e. in
+all that uses `completion-read' or `completion-in-region', IOW all
+helmized commands.  File completion in `read-file-name' family
+doesn't obey completion-styles and has its own file completion
+implementation. Native Helm commands using `completion-styles'
+doesn't obey `helm-completion-style' and
+`helm-completion-syles-alist' (e.g., helm-M-x).
 
-Also for a better control of styles in native helm sources (not helmized by helm-mode)
-using :match-dynamic, `helm-dynamic-completion' provides a STYLES argument that allows
+Also for a better control of styles in native Helm sources (not
+helmized by helm-mode) using :match-dynamic,
+`helm-dynamic-completion' provides a STYLES argument that allows
 specifying explicitely styles for this source.
 
-NOTE: Some old completion styles are not working fine with helm
+NOTE: Some old completion styles are not working fine with Helm
 and are disabled by default in
-`helm-blacklist-completion-styles', they are anyway not useful in
-helm because 'helm style supersed these styles.
+`helm-blacklist-completion-styles'.  They are anyway not useful in
+Helm because 'helm style supersedes these styles.
 
 ** Helm mode
 
-`helm-mode' toggles Helm completion in native Emacs functions,
-so when you turn `helm-mode' on, commands like `switch-to-buffer' will use
-Helm completion instead of the usual Emacs completion buffer.
+`helm-mode' toggles Helm completion in native Emacs functions, so
+when you turn `helm-mode' on, commands like `switch-to-buffer'
+will use Helm completion instead of the usual Emacs completion
+buffer.
 
 *** What gets or does not get \"helmized\" when `helm-mode' is enabled?
 
-Helm provides generic completion on all Emacs functions using `completing-read',
-`completion-in-region' and their derivatives, e.g. `read-file-name'.  Helm
-exposes a user variable to control which function to use for a specific Emacs
-command: `helm-completing-read-handlers-alist'.  If the function for a specific
-command is nil, it turns off Helm completion.  See the variable documentation
-for more infos.
+Helm provides generic completion on all Emacs functions using
+`completing-read', `completion-in-region' and their derivatives,
+e.g. `read-file-name'.  Helm exposes a user variable to control
+which function to use for a specific Emacs command:
+`helm-completing-read-handlers-alist'.  If the function for a
+specific command is nil, it turns off Helm completion.  See the
+variable documentation for more infos.
 
 *** Helm functions vs helmized Emacs functions
 
-While there are Helm functions that perform the same completion as other
-helmized Emacs functions, e.g. `switch-to-buffer' and `helm-buffers-list', the
-native Helm functions like `helm-buffers-list' can receive new features, the
-allow marking candidates, they have several actions, etc.  Whereas the helmized
-Emacs functions only have Helm completion, one action and no more then Emacs can
-provide for this function.  This is the intended behavior.
+While there are Helm functions that perform the same completion
+as other helmized Emacs functions, e.g. `switch-to-buffer' and
+`helm-buffers-list', the native Helm functions like
+`helm-buffers-list' can receive new features that allow marking
+candidates, have several actions, etc.  Whereas the helmized Emacs
+functions only have Helm completion, Emacs can provide no more
+than one action for this function.  This is the intended behavior.
 
-Generally you are better off using the native Helm command
-than the helmized Emacs equivalent.
+Generally you are better off using the native Helm command than
+the helmized Emacs equivalent.
 
 *** Completion behavior with Helm and completion-at-point
 
-Helm is NOT completing dynamically, that's mean that when you are
+Helm is NOT completing dynamically.  That means that when you are
 completing some text at point, completion is done against this
-text and subsequent characters you add AFTER this text, this
-allow you to use matching methods provided by Helm, that is multi
-matching or fuzzy matching (see [[Matching in Helm][Matching in Helm]]).
+text and subsequent characters you add AFTER this text.  This
+allows you to use matching methods provided by Helm, that is multi
+matching or fuzzy matching (see [[Matching in Helm][Matching in
+Helm]]).
 
 Completion is not done dynamically (against `helm-pattern')
 because backend functions (i.e. `competion-at-point-functions')
-are not aware of the Helm matching methods.
+are not aware of Helm matching methods.
 
 By behaving like this, the benefit is that you can fully use Helm
 matching methods but you can't start a full completion against a
-prefix different than the initial text you have at point, Helm
-warn you against this by colorizing the initial input and send an
-user-error message when trying to delete backward text beyond
-this limit at first hit on DEL and on second hit on DEL within a
-short delay (1s) quit Helm and delete-backward char in
+prefix different than the initial text you have at point.  Helm
+warns you against this by colorizing the initial input and sends
+a user-error message when trying to delete backward text beyond
+this limit at first hit on DEL.  A second hit on DEL within a
+short delay (1s) quits Helm and delete-backward char in
 current-buffer.
 
 ** Helm help
 
-\\[helm-documentation]: Show all helm documentations concatenated in one org file.
+\\[helm-documentation]: Show all Helm documentations concatenated
+in one org file.
 
-From a Helm session, just hit \\<helm-map>\\[helm-help] to have the
-documentation for the current source followed by the global Helm documentation.
+From a Helm session, just hit \\<helm-map>\\[helm-help] to have
+the documentation for the current source followed by the global
+Helm documentation.
 
-While in the help buffer, most of the Emacs regular keybindings
+While in the help buffer, most of the Emacs regular key bindings
 are available; the most important ones are shown in minibuffer.
-However due to the implementation restrictions, no regular Emacs
-keymap is used (it runs in a loop when reading the help buffer)
-they are hardcoded and not modifiable.
+However, due to implementation restrictions, no regular Emacs
+keymap is used (it runs in a loop when reading the help buffer).
+They are hardcoded and not modifiable.
 
 The hard-coded documentation bindings are:
 
@@ -1309,20 +1356,25 @@ The hard-coded documentation bindings are:
 ** Customize Helm
 
 Helm provides a lot of user variables for extensive customization.
-From any Helm session, type \\<helm-map>\\[helm-customize-group] to jump to the current source `custom' group.
-Helm also has a special group for faces you can access via `M-x customize-group RET helm-faces'.
+From any Helm session, type \\<helm-map>\\[helm-customize-group]
+to jump to the current source `custom' group.  Helm also has a
+special group for faces you can access via `M-x customize-group
+RET helm-faces'.
 
-Note: Some sources may not have their group set and default to the `helm' group.
+Note: Some sources may not have their group set and default to
+the `helm' group.
 
 ** Display Helm in windows and frames
 
-You can display the helm completion buffer in many differents
+You can display the Helm completion buffer in many different
 window configurations, see the custom interface to discover the
-different windows configurations available (See [[Customize Helm][Customize Helm]] to jump to custom interface).
-When using Emacs in a graphic display (i.e. not in a terminal) you can as
-well display your helm buffers in separated frames globally for
-all helm commands or separately for specific helm commands.
-See [[https://github.com/emacs-helm/helm/wiki/frame][helm wiki]] for more infos.
+different windows configurations available (See [[Customize
+Helm][Customize Helm]] to jump to custom interface).  When using
+Emacs in a graphic display (i.e. not in a terminal) you can as
+well display your Helm buffers in separated frames globally for
+all Helm commands or separately for specific Helm commands.  See
+[[https://github.com/emacs-helm/helm/wiki/frame][helm wiki]] for
+more infos.
 
 ** Helm's basic operations and default key bindings
 
@@ -1354,9 +1406,10 @@ source can have its own keymap).
 
 ** Action transformers
 
-You may be surprized to see you actions list changing depending of context, this
-happen when a source have an action transformer function which check the current
-candidate selectioned and add specific actions for this candidate.
+You may be surprized to see your actions list changing depending
+on the context.  This happen when a source has an action
+transformer function which checks the current selected candidate
+and adds specific actions for this candidate.
 
 ** Shortcuts for n-th first actions
 
@@ -1364,80 +1417,97 @@ f1-f12: Execute n-th action where n is 1 to 12.
 
 ** Shortcuts for executing the default action on the n-th candidate
 
-Helm does not display line numbers by default, with Emacs-26+
-you can enable it permanently in all helm buffers with:
+Helm does not display line numbers by default, with Emacs-26+ you
+can enable it permanently in all helm buffers with:
 
     (add-hook 'helm-after-initialize-hook 'helm-init-relative-display-line-numbers)
 
-You can also toggle line numbers with \\<helm-map>\\[helm-display-line-numbers-mode] in current helm buffer.
+You can also toggle line numbers with
+\\<helm-map>\\[helm-display-line-numbers-mode] in current Helm
+buffer.
 
-Of course when enabling `global-display-line-numbers-mode' helm buffers will have line numbers as well.
-\(don't forget to customize `display-line-numbers-type' to relative).
+Of course when enabling `global-display-line-numbers-mode' Helm
+buffers will have line numbers as well. \(Don't forget to
+customize `display-line-numbers-type' to relative).
 
-In Emacs versions < to 26 you will have to use [[https://github.com/coldnew/linum-relative][linum-relative]] package
-and `helm-linum-relative-mode'.
+In Emacs versions < to 26 you will have to use
+[[https://github.com/coldnew/linum-relative][linum-relative]]
+package and `helm-linum-relative-mode'.
 
 Then when line numbers are enabled with one of the methods above
 the following keys are available([1]):
 
-C-x <n>: Execute default action on the n-th candidate before currently selected candidate.
+C-x <n>: Execute default action on the n-th candidate before
+currently selected candidate.
 
-C-c <n>: Execute default action on the n-th candidate after current selected candidate.
+C-c <n>: Execute default action on the n-th candidate after
+current selected candidate.
 
-\"n\" is limited to 1-9.  For larger jumps use other navigation keys.
+\"n\" is limited to 1-9.  For larger jumps use other navigation
+keys.
 
-\[1] Note that the keybindings are always available even if line numbers are not displayed,
-they are just useless in this case.
+\[1] Note that the key bindings are always available even if line
+numbers are not displayed.  They are just useless in this case.
 
 ** Mouse control in Helm
 
-A basic support for the mouse is provided when the user sets `helm-allow-mouse' to non-nil.
+A basic support for the mouse is provided when the user sets
+`helm-allow-mouse' to non-nil.
 
 - mouse-1 selects the candidate.
 - mouse-2 executes the default action on selected candidate.
 - mouse-3 pops up the action menu.
 
-Note: When mouse control is enabled in Helm, it also lets you click around and lose
-the minibuffer focus: you'll have to click on the Helm buffer or the minibuffer
-to retrieve control of your Helm session.
+Note: When mouse control is enabled in Helm, it also lets you
+click around and lose the minibuffer focus: you'll have to click
+on the Helm buffer or the minibuffer to retrieve control of your
+Helm session.
 
 ** Marked candidates
 
-You can mark candidates to execute an action on all of them instead of the
-current selected candidate only.  (See bindings below.)  Most Helm actions
-operate on marked candidates unless candidate-marking is explicitely forbidden
-for a specific source.
+You can mark candidates to execute an action on all of them
+instead of the current selected candidate only.  (See bindings
+below.) Most Helm actions operate on marked candidates unless
+candidate-marking is explicitely forbidden for a specific source.
 
-- To mark/unmark a candidate, use \\[helm-toggle-visible-mark].  (See bindings below.)
-With a numeric prefix arg mark ARG candidates forward, if ARG is negative
-mark ARG candidates backward.
+- To mark/unmark a candidate, use
+\\[helm-toggle-visible-mark].  (See bindings below.) With a
+numeric prefix arg mark ARG candidates forward, if ARG is
+negative mark ARG candidates backward.
 
-- To mark all visible unmarked candidates at once in current source use \\[helm-mark-all].
-With a prefix argument, mark all candidates in all sources.
+- To mark all visible unmarked candidates at once in current
+source use \\[helm-mark-all].  With a prefix argument, mark all
+candidates in all sources.
 
-- To unmark all visible marked candidates at once use \\[helm-unmark-all].
+- To unmark all visible marked candidates at once use
+  \\[helm-unmark-all].
 
-- To mark/unmark all candidates at once use \\[helm-toggle-all-marks].
-With a prefix argument, mark/unmark all candidates in all sources.
+- To mark/unmark all candidates at once use
+\\[helm-toggle-all-marks].  With a prefix argument, mark/unmark
+all candidates in all sources.
 
-Note: When multiple candidates are selected across different sources, only the
-candidates of the current source will be used when executing most actions (as
-different sources can have different actions).  Some actions support
-multi-source marking however.
+Note: When multiple candidates are selected across different
+sources, only the candidates of the current source will be used
+when executing most actions (as different sources can have
+different actions).  Some actions support multi-source marking
+however.
 
 ** Follow candidates
 
-When `helm-follow-mode' is on (\\<helm-map>\\[helm-follow-mode] to toggle it),
-moving up and down the Helm session or updating the list of candidates will
-automatically execute the persistent-action as specified for the current source.
+When `helm-follow-mode' is on (\\<helm-map>\\[helm-follow-mode]
+to toggle it), moving up and down Helm session or updating the
+list of candidates will automatically execute the
+persistent-action as specified for the current source.
 
-If `helm-follow-mode-persistent' is non-nil, the state of the mode will be
-restored for the following Helm sessions.
+If `helm-follow-mode-persistent' is non-nil, the state of the
+mode will be restored for the following Helm sessions.
 
-If you just want to follow candidates occasionally without enabling
-`helm-follow-mode', you can use \\<helm-map>\\[helm-follow-action-forward] or \\[helm-follow-action-backward] instead.
-Conversely, when `helm-follow-mode' is enabled, those commands
-go to previous/next line without executing the persistent action.
+If you just want to follow candidates occasionally without
+enabling `helm-follow-mode', you can use
+\\<helm-map>\\[helm-follow-action-forward] or
+\\[helm-follow-action-backward] instead.  Conversely, when
+`helm-follow-mode' is enabled, those commands go to previous/next
+line without executing the persistent action.
 
 ** Frequently Used Commands
 
@@ -1455,86 +1525,103 @@ go to previous/next line without executing the persistent action.
 
 ** Special yes, no or yes for all answers
 
-You may be prompted in the minibuffer to answer by [y,n,!,q] in some places
-for confirmation.
+You may be prompted in the minibuffer to answer by [y,n,!,q] in
+some places for confirmation.
 
 - y  mean yes
 - no mean no
 - !  mean yes for all
 - q  mean quit or abort current operation.
 
-When using ! you will not be prompted anymore for the same thing in current operation
-e.g. file deletion, file copy etc...
+When using ! you will not be prompted for the same thing in
+current operation any more, e.g. file deletion, file copy etc...
 
 ** Moving in `helm-buffer'
 
-You can move in `helm-buffer' with the usual commands used in Emacs:
-\(\\<helm-map>\\[helm-next-line], \\<helm-map>\\[helm-previous-line], etc.  See above basic commands.
-When `helm-buffer' contains more than one source, change source with \\<helm-map>\\[helm-next-source] and \\[helm-previous-source].
+You can move in `helm-buffer' with the usual commands used in
+Emacs: \(\\<helm-map>\\[helm-next-line],
+\\<helm-map>\\[helm-previous-line], etc.  See above basic
+commands.  When `helm-buffer' contains more than one source,
+change source with \\<helm-map>\\[helm-next-source] and
+\\[helm-previous-source].
 
-Note: When reaching the end of a source, \\<helm-map>\\[helm-next-line] will *not* go to the next source when
-variable `helm-move-to-line-cycle-in-source' is non-nil, so you will have to use \\<helm-map>\\[helm-next-source]
-and \\[helm-previous-source].
+Note: When reaching the end of a source,
+\\<helm-map>\\[helm-next-line] will *not* go to the next source
+when variable `helm-move-to-line-cycle-in-source' is non-nil, so
+you will have to use \\<helm-map>\\[helm-next-source] and
+\\[helm-previous-source].
 
 ** Resume previous session from current Helm session
 
-You can use `C-c n' (`helm-run-cycle-resume') to cycle in resumables sources.
-`C-c n' is a special key set with `helm-define-key-with-subkeys' which, after pressing it, allows you
-to keep cycling with further `n'.
+You can use `C-c n' (`helm-run-cycle-resume') to cycle in
+resumables sources.  `C-c n' is a special key set with
+`helm-define-key-with-subkeys' which, after pressing it, allows
+you to keep cycling with further `n'.
 
-Tip: You can bound the same key in `global-map' to `helm-cycle-resume'
-     with `helm-define-key-with-subkeys' to let you transparently cycle
-     sessions, Helm fired up or not.
-     You can also bind the cycling commands to single key presses (e.g. `S-<f1>') this time
-     with a simple `define-key'.  (Note that `S-<f1>' is not available in terminals.)
+Tip: You can bound the same key in `global-map' to
+     `helm-cycle-resume' with `helm-define-key-with-subkeys' to
+     let you transparently cycle sessions, Helm fired up or not.
+     You can also bind the cycling commands to single key
+     presses (e.g., `S-<f1>') this time with a simple
+     `define-key'.  (Note that `S-<f1>' is not available in
+     terminals.)
 
-Note: `helm-define-key-with-subkeys' is available only once Helm is loaded.
+Note: `helm-define-key-with-subkeys' is available only once Helm
+is loaded.
 
-You can also use \\<helm-map>\\[helm-resume-previous-session-after-quit] to resume
-the previous session, or \\<helm-map>\\[helm-resume-list-buffers-after-quit]
-to have completion on all resumable buffers.
+You can also use
+\\<helm-map>\\[helm-resume-previous-session-after-quit] to resume
+the previous session, or
+\\<helm-map>\\[helm-resume-list-buffers-after-quit] to have
+completion on all resumable buffers.
 
 ** Global commands
 
 *** Resume Helm session from outside Helm
 
-\\<global-map>\\[helm-resume] revives the last `helm' session.  Binding a key to
-this command will greatly improve `helm' interactivity, e.g. when quitting Helm
-accidentally.
+\\<global-map>\\[helm-resume] revives the last Helm session.
+Binding a key to this command will greatly improve Helm
+interactivity, e.g. when quitting Helm accidentally.
 
-You can call \\<global-map>\\[helm-resume] with a prefix argument to choose
-\(with completion!) which session you'd like to resume.  You can also cycle in
-these sources with `helm-cycle-resume' (see above).
+You can call \\<global-map>\\[helm-resume] with a prefix argument
+to choose \(with completion!) which session you'd like to resume.
+You can also cycle in these sources with `helm-cycle-resume' (see
+above).
 
 ** Debugging Helm
 
-Helm exposes the special variable `helm-debug': setting it to non-nil
-will enable Helm logging in a special outline-mode buffer.
-Helm resets the variable to nil at the end of each session.
+Helm exposes the special variable `helm-debug': setting it to
+non-nil will enable Helm logging in a special outline-mode
+buffer.  Helm resets the variable to nil at the end of each
+session.
 
 For convenience, \\<helm-map>\\[helm-enable-or-switch-to-debug]
-allows you to turn on debugging for this session only.
-To avoid accumulating log entries while you are typing patterns, you can use
-\\<helm-map>\\[helm-toggle-suspend-update] to turn off updating.  When you
-are ready turn it on again to resume logging.
+allows you to turn on debugging for this session only.  To avoid
+accumulating log entries while you are typing patterns, you can
+use \\<helm-map>\\[helm-toggle-suspend-update] to turn off
+updating.  When you are ready turn it on again to resume logging.
 
-Once you exit your Helm session you can access the debug buffer with
-`helm-debug-open-last-log'.  It is possible to save logs to dated files when
-`helm-debug-root-directory' is set to a valid directory.
+Once you exit your Helm session you can access the debug buffer
+with `helm-debug-open-last-log'.  It is possible to save logs to
+dated files when `helm-debug-root-directory' is set to a valid
+directory.
 
-Note: Be aware that Helm log buffers grow really fast, so use `helm-debug' only
-when needed.
+Note: Be aware that Helm log buffers grow really fast, so use
+`helm-debug' only when needed.
 
 ** Writing your own Helm sources
 
-Writing simple sources for your own usage is easy.  When calling the `helm'
-function, the sources are added the :sources slot which can be a symbol or a
-list of sources.  Sources can be built with different EIEIO classes depending
-what you want to do.  To simplify this, several `helm-build-*' macros are
-provided.  Below, simple examples to start with.
+Writing simple sources for your own usage is easy.  When calling
+the `helm' function, the sources are added the :sources slot
+which can be a symbol or a list of sources.  Sources can be built
+with different EIEIO classes depending on what you want to do.  To
+simplify this, several `helm-build-*' macros are provided.  Below
+there are simple examples to start with.
 
-We will not go further here, see [[https://github.com/emacs-helm/helm/wiki/Developing][Helm wiki]] and the source
-code for more information and more complex examples.
+We will not go further here, see
+[[https://github.com/emacs-helm/helm/wiki/Developing][Helm wiki]]
+and the source code for more information and more complex
+examples.
 
 #+begin_src elisp
 
@@ -1562,15 +1649,15 @@ It also accepts function or variable symbol.")
 (defvar helm-autoresize-mode) ;; Undefined in `helm-default-display-buffer'.
 
 (defvar helm-async-outer-limit-hook nil
-  "A hook that run in async sources when process output comes out of `candidate-number-limit'.
+  "A hook that runs in async sources when process output comes out of `candidate-number-limit'.
 Should be set locally to `helm-buffer' with `helm-set-local-variable'.")
 
 (defvar helm-quit-hook nil
-  "A hook that run when quitting helm.")
+  "A hook that runs when quitting Helm.")
 
 (defvar helm-resume-after-hook nil
-  "A hook that run after resuming a helm session.
-The hook should take one arg SOURCES.")
+  "A hook that runs after resuming a Helm session.
+The hook should takes one arg SOURCES.")
 
 ;;; Internal Variables
 ;;
@@ -1579,8 +1666,8 @@ The hook should take one arg SOURCES.")
   "A list of source names to be displayed.
 Other sources won't appear in the search results.
 If nil, no filtering is done.
-Don't set this directly, use `helm-set-source-filter' during helm session
-to modify it.")
+Don't set this directly, use `helm-set-source-filter' during a
+Helm session to modify it.")
 (defvar helm-current-prefix-arg nil
   "Record `current-prefix-arg' when exiting minibuffer.")
 (defvar helm-saved-action nil
@@ -1590,17 +1677,17 @@ to modify it.")
 (defvar helm-in-persistent-action nil
   "Flag whether in persistent-action or not.")
 (defvar helm-last-buffer nil
-  "`helm-buffer' of previously `helm' session.")
+  "`helm-buffer' of a previous Helm session.")
 (defvar helm-saved-selection nil
   "Value of the currently selected object when the action list is shown.")
 (defvar helm-sources nil
   "[INTERNAL] Value of current sources in use, a list of alists.
-The list of sources (symbols or alists) is normalized to alists in
-`helm-initialize'.")
+The list of sources (symbols or alists) is normalized to alists
+in `helm-initialize'.")
 (defvar helm-buffer-file-name nil
-  "Variable `buffer-file-name' when `helm' is invoked.")
+  "Variable `buffer-file-name' when Helm is invoked.")
 (defvar helm-candidate-cache (make-hash-table :test 'equal)
-  "Holds the available candidate within a single helm invocation.")
+  "Holds the available candidate within a single Helm invocation.")
 (defvar helm--candidate-buffer-alist nil)
 (defvar helm-input ""
   "The input typed in the candidates panel.")
@@ -1611,7 +1698,7 @@ The list of sources (symbols or alists) is normalized to alists in
 (defvar helm-tick-hash (make-hash-table :test 'equal))
 (defvar helm-issued-errors nil)
 (defvar helm--last-log-file nil
-  "The name of the log file of the last helm session.")
+  "The name of the log file of the last Helm session.")
 (defvar helm--local-variables nil)
 (defvar helm-split-window-state nil)
 (defvar helm--window-side-state nil)
@@ -1625,22 +1712,22 @@ The list of sources (symbols or alists) is normalized to alists in
 (defvar helm--force-updating-p nil
   "[INTERNAL] Don't use this in your programs.")
 (defvar helm-exit-status 0
-  "Flag to inform if helm did exit or quit.
-0 means helm did exit when executing an action.
-1 means helm did quit with \\[keyboard-quit]
-Knowing this exit-status could help restore a window config when helm aborts
-in some special circumstances.
-See `helm-exit-minibuffer' and `helm-keyboard-quit'.")
+  "Flag to inform if Helm did exit or quit.
+0 means Helm did exit when executing an action.
+1 means Helm did quit with \\[keyboard-quit]
+Knowing this exit-status could help restore a window config when
+Helm aborts in some special circumstances.  See
+`helm-exit-minibuffer' and `helm-keyboard-quit'.")
 (defvar helm-minibuffer-confirm-state nil)
 (defvar helm-quit nil)
 (defvar helm-buffers nil
   "Helm buffers listed in order of most recently used.")
 (defvar helm-current-position nil
-  "Cons of \(point . window-start\)  when `helm' is invoked.
+  "Cons of \(point . window-start\)  when Helm is invoked.
 `helm-current-buffer' uses this to restore position after
 `helm-keyboard-quit'")
 (defvar helm-last-frame-or-window-configuration nil
-  "Used to store window or frame configuration at helm start.")
+  "Used to store window or frame configuration at Helm start.")
 (defvar helm-onewindow-p nil)
 (defvar helm-types nil)
 (defvar helm--mode-line-string-real nil) ; The string to display in mode-line.
@@ -1668,27 +1755,28 @@ precedence on :default.")
 Sources generated by `helm-mode' don't need to be added here
 because they are automatically added.
 
-You should not modify this yourself unless you know what you are doing.")
+You should not modify this yourself unless you know what you are
+doing.")
 (defvar helm--completing-file-name nil
   "Non nil when `helm-read-file-name' is running.
 Used for `helm-file-completion-source-p'.")
 ;; Same as `ffap-url-regexp' but keep it here to ensure `ffap-url-regexp' is not nil.
 (defvar helm--url-regexp "\\`\\(news\\(post\\)?:\\|mailto:\\|file:\\|\\(ftp\\|https?\\|telnet\\|gopher\\|www\\|wais\\)://\\)")
 (defvar helm--ignore-errors nil
-  "Flag to prevent helm popping up errors in candidates functions.
-Should be set in candidates functions if needed, will be restored
-at end of session.")
+  "Flag to prevent Helm popping up errors in candidates functions.
+Should be set in candidates functions if needed, and will be
+restored at end of session.")
 (defvar helm--action-prompt "Select action: ")
 (defvar helm--cycle-resume-iterator nil)
 (defvar helm--buffer-in-new-frame-p nil)
 (defvar helm-initial-frame nil
-  "[INTERNAL] The selected frame before starting helm.
+  "[INTERNAL] The selected frame before starting Helm.
 Helm use this internally to know in which frame it started, don't
 modify this yourself.")
 (defvar helm-popup-frame nil
-  "The frame where helm is displayed.
+  "The frame where Helm is displayed.
 
-This is only used when helm is using
+This is only used when Helm is using
 `helm-display-buffer-in-own-frame' as `helm-display-function' and
 `helm-display-buffer-reuse-frame' is non nil.")
 (defvar helm--nested nil)
@@ -1703,9 +1791,9 @@ This is only used when helm is using
 Local to `helm-buffer'.")
 (defvar helm--executing-helm-action nil
   "Non nil when action is triggering a new helm-session.
-This may be let bounded in other places to notify the display function
-to reuse the same frame parameters as the previous helm session just
-like resume would do.")
+This may be let bounded in other places to notify the display
+function to reuse the same frame parameters as the previous Helm
+session just like resume would do.")
 (defvar helm--current-buffer-narrowed nil)
 (defvar helm--suspend-update-interactive-flag nil)
 (defvar helm-persistent-action-window-buffer nil
@@ -1716,7 +1804,7 @@ window handling a buffer, it is this one we store.")
 
 ;; Utility: logging
 (defun helm-log (format-string &rest args)
-  "Log message `helm-debug' is non-`nil'.
+  "Log message `helm-debug' is non-nil.
 Messages are written to the `helm-debug-buffer' buffer.
 
 Argument FORMAT-STRING is a string to use with `format'.
@@ -1737,7 +1825,7 @@ Use optional arguments ARGS like in `format'."
                           (apply #'format (cons format-string args)))))))))
 
 (defun helm-log-run-hook (hook)
-  "Run HOOK like `run-hooks' but write these actions to helm log buffer."
+  "Run HOOK like `run-hooks' but write these actions to Helm log buffer."
   (helm-log "Executing %s with value = %S" hook (symbol-value hook))
   (helm-log "Executing %s with global value = %S" hook (default-value hook))
   (run-hooks hook)
@@ -1764,7 +1852,7 @@ Use optional arguments ARGS like in `format'."
 (defun helm-log-error (&rest args)
   "Accumulate error messages into `helm-issued-errors'.
 ARGS are args given to `format'.
-e.g (helm-log-error \"Error %s: %s\" (car err) (cdr err))."
+E.g. (helm-log-error \"Error %s: %s\" (car err) (cdr err))."
   (apply 'helm-log (concat "ERROR: " (car args)) (cdr args))
   (let ((msg (apply 'format args)))
     (unless (member msg helm-issued-errors)
@@ -1773,7 +1861,8 @@ e.g (helm-log-error \"Error %s: %s\" (car err) (cdr err))."
 (defun helm-log-save-maybe ()
   "Save log buffer when `helm-debug-root-directory' is non nil.
 Create `helm-debug-root-directory' directory if necessary.
-Messages are logged to a file named with todays date and time in this directory."
+Messages are logged to a file named with today's date and time in
+this directory."
   (when (and (stringp helm-debug-root-directory)
              (not (file-directory-p helm-debug-root-directory)))
     (make-directory helm-debug-root-directory t))
@@ -1801,7 +1890,7 @@ End:")
 
 ;;;###autoload
 (defun helm-debug-open-last-log ()
-  "Open helm log file or buffer of last helm session."
+  "Open Helm log file or buffer of last Helm session."
   (interactive)
   (if helm--last-log-file
       (progn
@@ -1864,7 +1953,7 @@ End:")
   `(with-helm-temp-hook 'helm-after-update-hook ,@body))
 
 (defmacro with-helm-alive-p (&rest body)
-  "Return error when BODY run outside helm context."
+  "Return error when BODY run outside Helm context."
   (declare (indent 0) (debug t))
   `(progn
      (if helm-alive-p
@@ -1872,7 +1961,7 @@ End:")
        (error "Running helm command outside of context"))))
 
 (defmacro with-helm-in-frame (&rest body)
-  "Execute helm function in BODY displaying `helm-buffer' in separate frame."
+  "Execute Helm function in BODY displaying `helm-buffer' in separate frame."
   (declare (debug t) (indent 0))
   `(progn
      (helm-set-local-variable
@@ -1887,14 +1976,15 @@ End:")
 If SRC is omitted, use current source.
 
 If COMPUTE is non-`nil' compute value of ATTRIBUTE-NAME with
-`helm-interpret-value'.  COMPUTE can have also 'ignorefn as value, in
-this case `helm-interpret-value' will return a function as value
-unchanged, but will eval a symbol which is bound.
+`helm-interpret-value'.  COMPUTE can have also 'ignorefn as value,
+in this case `helm-interpret-value' will return a function as
+value unchanged, but will eval a symbol which is bound.
 
-You can use `setf' to modify value of ATTRIBUTE-NAME unless COMPUTE is
-specified, if attribute ATTRIBUTE-NAME is not found in SOURCE `setf'
-will create new attribute ATTRIBUTE-NAME with specified value.
-You can also use `helm-attrset' to modify ATTRIBUTE-NAME."
+You can use `setf' to modify value of ATTRIBUTE-NAME unless
+COMPUTE is specified, if attribute ATTRIBUTE-NAME is not found in
+SOURCE `setf' will create new attribute ATTRIBUTE-NAME with
+specified value.  You can also use `helm-attrset' to modify
+ATTRIBUTE-NAME."
   (declare (gv-setter
             (lambda (val)
               `(let* ((src (or ,source (helm-get-current-source)))
@@ -1928,18 +2018,19 @@ You can also use `helm-attrset' to modify ATTRIBUTE-NAME."
                                        (src (helm-get-current-source)))
   "Set the value of ATTRIBUTE-NAME of source SRC to VALUE.
 
-If ATTRIBUTE-NAME doesn't exists in source it is created with value VALUE..
-If SRC is omitted, use current source.
-If operation succeed, return value, otherwise nil.
+If ATTRIBUTE-NAME doesn't exists in source it is created with
+value VALUE.  If SRC is omitted, use current source.  If operation
+succeed, return value, otherwise nil.
 
-Note that `setf' on `helm-attr' can be used instead of this function."
+Note that `setf' on `helm-attr' can be used instead of this
+function."
   (setf (helm-attr attribute-name src) value))
 
 (defun helm-add-action-to-source (name fn source &optional index)
   "Add new action NAME linked to function FN to SOURCE.
-Function FN should be a valid function that takes one arg i.e candidate,
-argument NAME is a string that will appear in action menu
-and SOURCE should be an existing helm source already loaded.
+Function FN should be a valid function that takes one arg i.e.
+candidate, argument NAME is a string that will appear in action
+menu and SOURCE should be an existing helm source already loaded.
 If INDEX is specified, action is added to the action list at INDEX,
 otherwise added at end.
 This allows users to add specific actions to an existing source
@@ -1956,8 +2047,8 @@ without modifying source code."
 
 (defun helm-delete-action-from-source (action-or-name source)
   "Delete ACTION-OR-NAME from SOURCE.
-ACTION-OR-NAME can either be the name of action or the symbol function
-associated to name."
+ACTION-OR-NAME can either be the name of action or the symbol
+function associated to name."
   (let* ((actions    (helm-attr 'action source 'ignorefn))
          (del-action (if (symbolp action-or-name)
                          (rassoc action-or-name actions)
@@ -1967,21 +2058,24 @@ associated to name."
 (cl-defun helm-add-action-to-source-if (name fn source predicate
                                              &optional (index 4) test-only)
   "Add new action NAME linked to function FN to SOURCE.
-Action NAME will be available when the current candidate matches PREDICATE.
+Action NAME will be available when the current candidate matches
+PREDICATE.
 This function adds an entry in the `action-transformer' attribute
 of SOURCE (or creates one if not found).
 Function PREDICATE must take one candidate as arg.
-Function FN should be a valid function that takes one arg i.e. candidate,
-argument NAME is a string that will appear in action menu
-and SOURCE should be an existing helm source already loaded.
+Function FN should be a valid function that takes one arg i.e.
+candidate, argument NAME is a string that will appear in action
+menu and SOURCE should be an existing Helm source already loaded.
 If INDEX is specified, action is added in action list at INDEX.
-Value of INDEX should be always >=1, default to 4.
-This allow user to add a specific `action-transformer'
-to an existing source without modifying source code.
-E.g
-Add the action \"Byte compile file async\" linked to
-function 'async-byte-compile-file to source `helm-source-find-files'
-only when predicate helm-ff-candidates-lisp-p return non-`nil':
+Value of INDEX should be always >=1, default to 4.  This allows
+user to add a specific `action-transformer' to an existing source
+without modifying source code.
+
+E.g.
+
+Add the action \"Byte compile file async\" linked to function
+'async-byte-compile-file to source `helm-source-find-files' only
+when predicate helm-ff-candidates-lisp-p returns non-nil:
 
 \(helm-add-action-to-source-if \"Byte compile file async\"
                               'async-byte-compile-file
@@ -2013,12 +2107,12 @@ only when predicate helm-ff-candidates-lisp-p return non-`nil':
 (defun helm-set-source-filter (sources)
   "Set the value of `helm-source-filter' to SOURCES and update.
 
-This function sets a filter for helm sources and it may be
-called while helm is running. It can be used to toggle
-displaying of sources dynamically. For example, additional keys
-can be bound into `helm-map' to display only the file-related
-results if there are too many matches from other sources and
-you're after files only:
+This function sets a filter for Helm sources and it may be called
+while Helm is running.  It can be used to toggle displaying of
+sources dynamically.  For example, additional keys can be bound
+into `helm-map' to display only the file-related results if there
+are too many matches from other sources and you're after files
+only:
 
 Shift+F shows only file results from some sources:
 
@@ -2057,8 +2151,8 @@ existing Helm function names."
 
 (defun helm-set-sources (sources &optional no-init no-update)
   "Set SOURCES during `helm' invocation.
-If NO-INIT is non-`nil', skip executing init functions of SOURCES.
-If NO-UPDATE is non-`nil', skip executing `helm-update'."
+If NO-INIT is non-nil, skip executing init functions of SOURCES.
+If NO-UPDATE is non-nil, skip executing `helm-update'."
   (with-current-buffer helm-buffer
     (setq helm-sources (helm-get-sources sources))
     (helm-log "helm-sources = %S" helm-sources))
@@ -2068,8 +2162,8 @@ If NO-UPDATE is non-`nil', skip executing `helm-update'."
 (defun helm-get-selection (&optional buffer force-display-part source)
   "Return the currently selected item or nil.
 
-if BUFFER is nil or unspecified, use helm-buffer as default value.
-If FORCE-DISPLAY-PART is non-`nil', return the display string.
+If BUFFER is nil or unspecified, use `helm-buffer' as default value.
+If FORCE-DISPLAY-PART is non-nil, return the display string.
 If FORCE-DISPLAY-PART value is `withprop' the display string is returned
 with its properties."
   (setq buffer (or buffer helm-buffer))
@@ -2151,7 +2245,7 @@ Return nil when `helm-buffer' is empty."
                                 source)))))))))
 
 (defun helm-buffer-is-modified (buffer)
-  "Return non-`nil' when BUFFER is modified since `helm' was invoked."
+  "Return non-nil when BUFFER is modified since Helm was invoked."
   (let* ((buf         (get-buffer buffer))
          (key         (concat (buffer-name buf) "/" (helm-attr 'name)))
          (source-tick (or (gethash key helm-tick-hash) 0))
@@ -2163,18 +2257,18 @@ Return nil when `helm-buffer' is empty."
     modifiedp))
 
 (defun helm-current-buffer-is-modified ()
-  "Check if `helm-current-buffer' is modified since `helm' was invoked."
+  "Check if `helm-current-buffer' is modified since Helm was invoked."
   (helm-buffer-is-modified helm-current-buffer))
 
 (defun helm-run-after-exit (function &rest args)
-  "Execute FUNCTION with ARGS after exiting `helm'.
+  "Execute FUNCTION with ARGS after exiting Helm.
 The action is to call FUNCTION with arguments ARGS.
 Unlike `helm-exit-and-execute-action', this can be used
-to call non--actions functions with any ARGS or no ARGS at all.
+to call non-actions functions with any ARGS or no ARGS at all.
 
-Use this on commands invoked from key-bindings, but not
-on action functions invoked as action from the action menu,
-i.e. functions called with RET."
+Use this on commands invoked from key bindings, but not on action
+functions invoked as action from the action menu, i.e. functions
+called with RET."
   (helm-kill-async-processes)
   (helm-log "function = %S" function)
   (helm-log "args = %S" args)
@@ -2183,13 +2277,13 @@ i.e. functions called with RET."
      (apply function args))))
 
 (defun helm-exit-and-execute-action (action)
-  "Exit current helm session and execute ACTION.
-Argument ACTION is a function called with one arg (candidate)
-and part of the actions of current source.
+  "Exit current Helm session and execute ACTION.
+Argument ACTION is a function called with one arg (candidate) and
+part of the actions of current source.
 
-Use this on commands invoked from key-bindings, but not
+Use this on commands invoked from key bindings, but not
 on action functions invoked as action from the action menu,
-i.e functions called with RET."
+i.e. functions called with RET."
   ;; If ACTION is not an action available in source 'action attribute,
   ;; return an error.  This allow to remove unneeded actions from
   ;; source that inherit actions from type, note that ACTION have to
@@ -2267,7 +2361,7 @@ Otherwise, return VALUE itself."
 Use this to set local vars before calling helm.
 
 When used from an init or update function
-(i.e when `helm-force-update' is running) the variables are set
+\(i.e. when `helm-force-update' is running) the variables are set
 using `make-local-variable' within the `helm-buffer'.
 
 Usage: helm-set-local-variable ([VAR VALUE]...)
@@ -2328,19 +2422,20 @@ was deleted and the candidates list not updated."
 (defun helm-apply-functions-from-source (source functions &rest args)
   "From SOURCE apply FUNCTIONS on ARGS.
 
-This function is used to process filter functions, when filter is a
-\`filtered-candidate-transformer', we pass to ARGS candidates+source
-whereas when the filter is `candidate-transformer' we pass to ARGS
-candidates only.
-This function is used also to process functions called with no args,
-e.g. init functions, in this case it is called without ARGS.
+This function is used to process filter functions.  When filter is
+a \`filtered-candidate-transformer', we pass to ARGS
+candidates+source whereas when the filter is
+`candidate-transformer' we pass to ARGS candidates only.
+This function is also used to process functions called with no
+args, e.g. init functions.  In this case it is called without
+ARGS.
 See `helm-process-filtered-candidate-transformer'
 \`helm-compute-attr-in-sources' and
 \`helm-process-candidate-transformer'.
 
-Arg FUNCTIONS is either a symbol or a list of functions, each function being
-applied on ARGS and called on the result of the precedent function.
-Return the result of last function call."
+Arg FUNCTIONS is either a symbol or a list of functions, each
+function being applied on ARGS and called on the result of the
+precedent function.  Return the result of last function call."
   (let ((helm--source-name (assoc-default 'name source))
         (helm-current-source source)
         (funs (if (functionp functions) (list functions) functions)))
@@ -2385,8 +2480,8 @@ Return the result of last function call."
 
 (defun helm-get-candidate-number (&optional in-current-source)
   "Return candidates number in `helm-buffer'.
-If IN-CURRENT-SOURCE is provided return number of candidates of current source
-only."
+If IN-CURRENT-SOURCE is provided return the number of candidates
+of current source only."
   (with-helm-buffer
     (if (or (helm-empty-buffer-p)
             (helm-empty-source-p))
@@ -2526,7 +2621,7 @@ the list items, starting with the first.
 
 If nil, `thing-at-point' is used.
 
-If `helm--maybe-use-default-as-input' is non-`nil', display is
+If `helm--maybe-use-default-as-input' is non-nil, display is
 updated using this value, unless :input is specified, in which
 case that value is used instead.
 
@@ -2550,7 +2645,7 @@ session. The `helm-' prefix can be omitted. For example,
        :buffer \"*helm buffers*\"
        :candidate-number-limit 10\)
 
-starts a Helm session with the variable
+Starts a Helm session with the variable
 `helm-candidate-number-limit' set to 10.
 
 ** Backward compatibility
@@ -2598,9 +2693,9 @@ However, the use of non-keyword args is deprecated.
         (apply fn plist))))) ; [1] fn == helm-internal.
 
 (defun helm--alive-p ()
-  "[Internal] Check if `helm' is alive.
-An `helm' session is considered alive if `helm-alive-p' value is
-non-`nil', the `helm-buffer' is visible, and cursor is in the
+  "[INTERNAL] Check if `helm' is alive.
+An Helm session is considered alive if `helm-alive-p' value is
+non-nil, the `helm-buffer' is visible, and cursor is in the
 minibuffer."
   (and helm-alive-p
        (get-buffer-window (helm-buffer-get) 'visible)
@@ -2610,11 +2705,11 @@ minibuffer."
 (defun helm-parse-keys (keys)
   "Parse the KEYS arguments of `helm'.
 Return only those keys not in `helm-argument-keys', prefix them
-with \"helm\", and then convert them to an alist. This allows
+with \"helm\", and then convert them to an alist.  This allows
 adding arguments that are not part of `helm-argument-keys', but
-are valid helm variables nevertheless. For
-example, :candidate-number-limit is bound to
-`helm-candidate-number-limit' in the source.
+are valid helm variables nevertheless.  For example,
+:candidate-number-limit is bound to `helm-candidate-number-limit'
+in the source.
 
   (helm-parse-keys '(:sources ((name . \"test\")
                                (candidates . (a b c)))
@@ -2636,9 +2731,9 @@ example, :candidate-number-limit is bound to
                       prompt resume
                       preselect buffer
                       keymap default history)
-  "The internal helm function called by `helm'.
+  "The internal Helm function called by `helm'.
 For SOURCES INPUT PROMPT RESUME PRESELECT BUFFER KEYMAP DEFAULT and
-HISTORY args See `helm'."
+HISTORY args see `helm'."
   (cl-assert (or (stringp input)
                  (null input))
              nil "Error in %S buffer: Initial input should be a string or nil"
@@ -2746,10 +2841,10 @@ HISTORY args See `helm'."
 ;;
 ;;
 (defun helm-resume (arg)
-  "Resume a previous `helm' session.
-Call with a prefix arg to choose among existing helm
-buffers (sessions). When calling from lisp, specify a buffer-name
-as a string with ARG."
+  "Resume a previous Helm session.
+Call with a prefix arg to choose among existing Helm
+buffers (sessions).  When calling from Lisp, specify a
+`buffer-name' as a string with ARG."
   (interactive "P")
   (let (buffer
         cur-dir
@@ -2800,7 +2895,7 @@ as a string with ARG."
           (run-hook-with-args 'helm-resume-after-hook sources))))))
 
 (defun helm-resume-previous-session-after-quit ()
-  "Resume previous helm session within a running helm."
+  "Resume previous Helm session within a running Helm."
   (interactive)
   (with-helm-alive-p
     (let ((arg (if (null (member helm-buffer helm-buffers)) 0 1))) 
@@ -2810,7 +2905,7 @@ as a string with ARG."
 (put 'helm-resume-previous-session-after-quit 'helm-only t)
 
 (defun helm-resume-list-buffers-after-quit ()
-  "List resumable helm buffers within running helm."
+  "List Helm buffers that can be resumed within a running Helm."
   (interactive)
   (with-helm-alive-p
     (if (> (length helm-buffers) 0)
@@ -2819,7 +2914,7 @@ as a string with ARG."
 (put 'helm-resume-list-buffers-after-quit 'helm-only t)
 
 (defun helm-resume-p (resume)
-  "Whether current helm session is resumed or not."
+  "Whether current Helm session is resumed or not."
   (eq resume t))
 
 (defun helm-resume-select-buffer ()
@@ -2862,7 +2957,7 @@ Return nil if no `helm-buffer' found."
                      (helm-iter-next helm--cycle-resume-iterator))))))
 
 (defun helm-run-cycle-resume ()
-  "Same as `helm-cycle-resume' but intended to be called only from helm."
+  "Same as `helm-cycle-resume' but intended to be called only from Helm."
   (interactive)
   (when (cdr helm-buffers) ; only one session registered.
     ;; Setup a new iterator only on first hit on
@@ -2882,7 +2977,7 @@ Return nil if no `helm-buffer' found."
 
 ;;;###autoload
 (defun helm-other-buffer (sources buffer)
-  "Simplified `helm' interface with other `helm-buffer'.
+  "Simplified Helm interface with other `helm-buffer'.
 Call `helm' only with SOURCES and BUFFER as args."
   (helm :sources sources :buffer buffer))
 
@@ -2890,7 +2985,7 @@ Call `helm' only with SOURCES and BUFFER as args."
 ;;
 ;;
 (defun helm--nest (&rest same-as-helm)
-  "[internal]Allows calling `helm' within a running helm session.
+  "[INTERNAL] Allow calling `helm' within a running Helm session.
 
 Arguments SAME-AS-HELM are the same as `helm'.
 
@@ -3025,11 +3120,13 @@ frame configuration as per `helm-save-configuration-functions'."
   "Default function to split windows before displaying `helm-buffer'.
 
 It is used as default value for
-`helm-split-window-preferred-function' which is then the let-bounded
-value of `split-window-preferred-function' in `helm-display-buffer'.
-When `helm-display-function' which default to
-`helm-default-display-buffer' is called from `helm-display-buffer' the
-value of `split-window-preferred-function' will be used by `display-buffer'."
+`helm-split-window-preferred-function' which is then the
+let-bounded value of `split-window-preferred-function' in
+`helm-display-buffer'.  When `helm-display-function' which default
+to `helm-default-display-buffer' is called from
+`helm-display-buffer' the value of
+`split-window-preferred-function' will be used by
+`display-buffer'."
   (let* (split-width-threshold
          (win (if (and (fboundp 'window-in-direction)
                        ;; Don't try to split when starting in a minibuffer
@@ -3066,7 +3163,7 @@ value of `split-window-preferred-function' will be used by `display-buffer'."
 
 (defun helm-window-in-direction (direction)
   "Same as `window-in-direction' but check if window is dedicated.
-Returns nil when window is dedicated."
+Return nil when window is dedicated."
   (helm-aif (window-in-direction direction)
       (and (not (window-dedicated-p it)) it)))
 
@@ -3081,14 +3178,15 @@ Returns nil when window is dedicated."
 ;;
 ;;
 (defun helm-resolve-display-function (com)
-  "Decide which display function use according to `helm-commands-using-frame'.
+  "Decide which display function to use according to `helm-commands-using-frame'.
 
-The `helm-display-function' buffer local value takes precedence on
-`helm-commands-using-frame'.
+The `helm-display-function' buffer local value takes precedence
+on `helm-commands-using-frame'.
 If `helm-initial-frame' has no minibuffer, use
 `helm-display-buffer-in-own-frame' function.
 Fallback to global value of `helm-display-function' when no local
-value found and current command is not in `helm-commands-using-frame'."
+value found and current command is not in
+`helm-commands-using-frame'."
   (or (with-helm-buffer helm-display-function)
       (and (or (memq com helm-commands-using-frame)
                (and helm-use-frame-when-dedicated-window
@@ -3105,7 +3203,7 @@ value found and current command is not in `helm-commands-using-frame'."
   "Display BUFFER.
 
 The function used to display `helm-buffer' by calling
-`helm-display-function' which split window with
+`helm-display-function' which splits window with
 `helm-split-window-preferred-function'."
   (let ((split-window-preferred-function
          helm-split-window-preferred-function)
@@ -3143,7 +3241,7 @@ Arg ENABLE is the value of `no-other-window' window property."
 (defun helm-default-display-buffer (buffer &optional _resume)
   "Default function to display `helm-buffer' BUFFER.
 
-It is the default value of `helm-display-function'
+It is the default value of `helm-display-function'.
 It uses `switch-to-buffer' or `display-buffer' depending on the
 value of `helm-full-frame' or `helm-split-window-default-side'."
   (let (pop-up-frames
@@ -3175,14 +3273,14 @@ value of `helm-full-frame' or `helm-split-window-default-side'."
 (defvar tab-bar-mode)
 
 (defun helm-display-buffer-in-own-frame (buffer &optional resume)
-  "Display helm buffer BUFFER in a separate frame.
+  "Display Helm buffer BUFFER in a separate frame.
 
 Function suitable for `helm-display-function',
-`helm-completion-in-region-display-function'
-and/or `helm-show-completion-default-display-function'.
+`helm-completion-in-region-display-function' and/or
+`helm-show-completion-default-display-function'.
 
-See `helm-display-buffer-height' and `helm-display-buffer-width' to
-configure frame size.
+See `helm-display-buffer-height' and `helm-display-buffer-width'
+to configure frame size.
 
 Note that this feature is available only with emacs-25+."
   (cl-assert (and (fboundp 'window-absolute-pixel-edges)
@@ -3297,7 +3395,7 @@ Note that this feature is available only with emacs-25+."
 ;;
 (defun helm-get-sources (sources)
   "Transform each element of SOURCES in alist.
-Returns the resulting list."
+Return the resulting list."
   (when sources
     (mapcar (lambda (source)
               (if (listp source)
@@ -3305,8 +3403,8 @@ Returns the resulting list."
             (helm-normalize-sources sources))))
 
 (defun helm-initialize (resume input default sources)
-  "Start initialization of `helm' session.
-For RESUME INPUT DEFAULT and SOURCES See `helm'."
+  "Start initialization of Helm session.
+For RESUME INPUT DEFAULT and SOURCES see `helm'."
   (helm-log "start initialization: resume=%S input=%S"
             resume input)
   (helm-frame-or-window-configuration 'save)
@@ -3341,7 +3439,7 @@ For RESUME INPUT DEFAULT and SOURCES See `helm'."
     (helm-log "end initialization")))
 
 (defun helm-initialize-overlays (buffer)
-  "Initialize helm overlays in BUFFER."
+  "Initialize Helm overlays in BUFFER."
   (helm-log "overlay setup")
   (if helm-selection-overlay
       ;; make sure the overlay belongs to the helm buffer if
@@ -3363,10 +3461,10 @@ For RESUME INPUT DEFAULT and SOURCES See `helm'."
   (set sym (cons elm (delete elm (symbol-value sym)))))
 
 (defun helm--current-buffer ()
-  "[internal] Return `current-buffer' BEFORE `helm-buffer' is initialized.
-Note that it returns the minibuffer in use after helm has started
-and is intended for `helm-initial-setup'. To get the buffer where
-helm was started, use `helm-current-buffer' instead."
+  "[INTERNAL] Return `current-buffer' BEFORE `helm-buffer' is initialized.
+Note that it returns the minibuffer in use after Helm has started
+and is intended for `helm-initial-setup'.  To get the buffer where
+Helm was started, use `helm-current-buffer' instead."
   (if (minibuffer-window-active-p (minibuffer-window))
       ;; If minibuffer is active be sure to use it's buffer
       ;; as `helm-current-buffer', this allow to use helm
@@ -3396,7 +3494,7 @@ See :after-init-hook and :before-init-hook in `helm-source'."
            else do (helm-log-run-hook hv)))
 
 (defun helm-initial-setup (default sources)
-  "Initialize helm settings and set up the helm buffer."
+  "Initialize Helm settings and set up the Helm buffer."
   ;; Run global hook.
   (helm-log-run-hook 'helm-before-initialize-hook)
   ;; Run local source hook.
@@ -3450,8 +3548,8 @@ See :after-init-hook and :before-init-hook in `helm-source'."
 
 (define-derived-mode helm-major-mode
   fundamental-mode "Hmm"
-  "[Internal] Provide major-mode name in helm buffers.
-Unuseful when used outside helm, don't use it.")
+  "[INTERNAL] Provide major-mode name in Helm buffers.
+Unuseful when used outside Helm, don't use it.")
 (put 'helm-major-mode 'mode-class 'special)
 (put 'helm-major-mode 'helm-only t)
 
@@ -3489,9 +3587,9 @@ Unuseful when used outside helm, don't use it.")
     (get-buffer helm-buffer)))
 
 (define-minor-mode helm--minor-mode
-  "[INTERNAL] Enable keymap in helm minibuffer.
-Since this mode has no effect when run outside of helm context,
-please don't use it outside helm.
+  "[INTERNAL] Enable keymap in Helm minibuffer.
+Since this mode has no effect when run outside of Helm context,
+please don't use it outside of Helm.
 
 \\{helm-map}"
   :group 'helm
@@ -3507,7 +3605,7 @@ please don't use it outside helm.
                                 input preselect resume
                                 keymap default history)
   "Read pattern with prompt PROMPT and initial input INPUT.
-For PRESELECT RESUME KEYMAP DEFAULT HISTORY, See `helm'."
+For PRESELECT RESUME KEYMAP DEFAULT HISTORY, see `helm'."
   (with-helm-buffer
     (if (and (helm-resume-p resume)
              ;; When no source, helm-buffer is empty
@@ -3615,8 +3713,8 @@ For PRESELECT RESUME KEYMAP DEFAULT HISTORY, See `helm'."
 
 (defun helm-toggle-suspend-update ()
   "Enable or disable display update in helm.
-This can be useful for example for quietly writing a complex regexp
-without helm constantly updating."
+This can be useful for example for quietly writing a complex
+regexp without Helm constantly updating."
   (interactive)
   (helm-suspend-update (not helm-suspend-update-flag) t)
   (setq helm--suspend-update-interactive-flag
@@ -3660,9 +3758,9 @@ Update is reenabled when idle 1s."
 (put 'helm-delete-backward-no-update 'helm-only t)
 
 (defun helm--suspend-read-passwd (old--fn &rest args)
-  "Suspend helm while reading password.
-This is used to advice `tramp-read-passwd', `ange-ftp-get-passwd' and
-`epa-passphrase-callback-function'."
+  "Suspend Helm while reading password.
+This is used to advice `tramp-read-passwd', `ange-ftp-get-passwd'
+and `epa-passphrase-callback-function'."
   ;; Suspend update when prompting for a tramp password.
   (setq helm-suspend-update-flag t)
   (setq overriding-terminal-local-map nil)
@@ -3677,7 +3775,7 @@ This is used to advice `tramp-read-passwd', `ange-ftp-get-passwd' and
 (defun helm--maybe-update-keymap (&optional map)
   "Handle different keymaps in multiples sources.
 
-Overrides `helm-map' with the local map of current source. If no
+Overrides `helm-map' with the local map of current source.  If no
 map is found in current source, does nothing (keeps previous
 map)."
   (with-helm-buffer
@@ -3710,7 +3808,7 @@ map)."
   "[INTERNAL] Prevent escaping helm minibuffer with mouse clicks.
 Do nothing when used outside of helm context.
 
-WARNING: Do not use this mode yourself, it is internal to helm."
+WARNING: Do not use this mode yourself, it is internal to Helm."
   :group 'helm
   :global t
   :keymap helm--remap-mouse-mode-map
@@ -3721,7 +3819,7 @@ WARNING: Do not use this mode yourself, it is internal to helm."
 ;; Clean up
 
 (defun helm-cleanup ()
-  "Clean up the mess when helm exit or quit."
+  "Clean up the mess when Helm exit or quit."
   (helm-log "start cleanup")
   (with-current-buffer helm-buffer
     (let ((frame (selected-frame)))
@@ -3927,7 +4025,7 @@ Cache the candidates if there is no cached value yet."
      ,candidate))
 
 (defun helm--initialize-one-by-one-candidates (candidates source)
-  "Process the CANDIDATES with the `filter-one-by-one' function in SOURCE.
+  "Process CANDIDATES with the `filter-one-by-one' function in SOURCE.
 Return CANDIDATES unchanged when pattern is not empty."
   (helm-aif (and (string= helm-pattern "")
                  (assoc-default 'filter-one-by-one source))
@@ -3938,8 +4036,9 @@ Return CANDIDATES unchanged when pattern is not empty."
 (defun helm-process-filtered-candidate-transformer-maybe
     (candidates source process-p)
   "Execute `filtered-candidate-transformer' function(s) on CANDIDATES in SOURCE.
-When PROCESS-P is non-`nil' execute `filtered-candidate-transformer'
-functions if some, otherwise return CANDIDATES."
+When PROCESS-P is non-nil execute
+`filtered-candidate-transformer' functions if some, otherwise
+return CANDIDATES."
   (if process-p
       ;; When no filter return CANDIDATES unmodified.
       (helm-process-filtered-candidate-transformer candidates source)
@@ -3961,7 +4060,7 @@ functions if some, otherwise return CANDIDATES."
 (defun helm-transform-candidates (candidates source &optional process-p)
   "Transform CANDIDATES from SOURCE according to candidate transformers.
 
-When PROCESS-P is non-`nil' executes the
+When PROCESS-P is non-nil executes the
 `filtered-candidate-transformer' functions, otherwise processes
 `candidate-transformer' functions only,
 `filtered-candidate-transformer' functions being processed later,
@@ -3982,7 +4081,7 @@ maybe filtered CANDIDATES."
   "Apply candidate-number-limit attribute value.
 This overrides `helm-candidate-number-limit' variable.
 
-e.g:
+E.g.:
 If \(candidate-number-limit\) is in SOURCE, show all candidates in SOURCE.
 If \(candidate-number-limit . 123\) is in SOURCE limit candidate to 123."
   (helm-aif (assq 'candidate-number-limit source)
@@ -4094,7 +4193,7 @@ This function is used with sources built with `helm-source-sync'."
 Score is calculated for contiguous matches found with PATTERN.
 Score is 100 (maximum) if PATTERN is fully matched in CANDIDATE.
 One point bonus is added to score when PATTERN prefix matches
-CANDIDATE. Contiguous matches get a coefficient of 2."
+CANDIDATE.  Contiguous matches get a coefficient of 2."
   (let* ((cand (if (stringp candidate)
                    candidate (helm-stringify candidate)))
          (pat-lookup (helm--collect-pairs-in-string pattern))
@@ -4131,8 +4230,8 @@ CANDIDATE. Contiguous matches get a coefficient of 2."
   "The transformer for sorting candidates in fuzzy matching.
 It sorts on the display part by default.
 
-Sorts CANDIDATES by their scores as calculated by
-`helm-score-candidate-for-pattern'.  Set USE-REAL to non-`nil' to
+It sorts CANDIDATES by their scores as calculated by
+`helm-score-candidate-for-pattern'.  Set USE-REAL to non-nil to
 sort on the real part.  If BASENAME is non-nil assume we are
 completing filenames and sort on basename of candidates.  If
 PRESERVE-TIE-ORDER is nil, ties in scores are sorted by length of
@@ -4450,13 +4549,14 @@ emacs-27 to provide such scoring in emacs<27."
        (helm-while-no-input ,@body))))
 
 (defun helm--collect-matches (src-list)
-  "Returns a list of matches for each source in SRC-LIST.
+  "Return a list of matches for each source in SRC-LIST.
 
-The resulting value is a list of lists, e.g ((a b c) (c d) (e f)) or
-\(nil nil nil) for three sources when no matches found, however this
-function can be interrupted by new input and in this case returns a
-plain `nil' i.e not (nil), in this case `helm-update' is not rendering
-the source, keeping previous candidates in display."
+The resulting value is a list of lists, e.g. ((a b c) (c d) (e
+f)) or \(nil nil nil) for three sources when no matches found,
+however this function can be interrupted by new input and in this
+case returns a plain nil i.e. not (nil), in this case
+`helm-update' is not rendering the source, keeping previous
+candidates in display."
   (let ((matches (helm--maybe-use-while-no-input
                   (cl-loop for src in src-list
                            collect (helm-compute-matches src)))))
@@ -4467,7 +4567,7 @@ the source, keeping previous candidates in display."
 ;;
 ;;
 (cl-defun helm-set-case-fold-search (&optional (pattern helm-pattern))
-  "Used to set the value of `case-fold-search' in helm.
+  "Used to set the value of `case-fold-search' in Helm.
 Return t or nil depending on the value of `helm-case-fold-search'
 and `helm-pattern'."
   (if helm-alive-p
@@ -4607,8 +4707,8 @@ pattern has changed.
 
 Selection is preserved to current candidate if it still exists after
 update or moved to PRESELECT, if specified.
-The helm-window is recentered at the end when RECENTER is `t'
-which is the default, RECENTER can be also a number in this case it is
+The helm-window is re-centered at the end when RECENTER is t which
+is the default.  RECENTER can be also a number in this case it is
 passed as argument to `recenter'."
   (with-helm-buffer
     (let* ((source    (helm-get-current-source))
@@ -4645,19 +4745,21 @@ passed as argument to `recenter'."
 (defun helm-redisplay-buffer ()
   "Redisplay candidates in `helm-buffer'.
 
-Candidates are not recomputed, only redisplayed after modifying the
-whole list of candidates in each source with functions found in
-`redisplay' attribute of current source.  Note that candidates are
-redisplayed with their display part with all properties included only.
-This function is used in async sources to transform the whole list of
-candidates from the sentinel functions (i.e when all candidates have
-been computed) because other filters like `candidate-transformer' are
-modifying only each chunk of candidates from process-filter as they
-come in and not the whole list.  Use this for e.g sorting the whole
-list of async candidates once computed.
-Note: To ensure redisplay is done in async sources after helm
-reached `candidate-number-limit' you will have also to redisplay your
-candidates from `helm-async-outer-limit-hook'."
+Candidates are not recomputed, only redisplayed after modifying
+the whole list of candidates in each source with functions found
+in `redisplay' attribute of current source.  Note that candidates
+are redisplayed with their display part with all properties
+included only.  This function is used in async sources to
+transform the whole list of candidates from the sentinel
+functions (i.e. when all candidates have been computed) because
+other filters like `candidate-transformer' are modifying only
+each chunk of candidates from `process-filter' as they come in
+and not the whole list.  Use this for e.g. sorting the whole list
+of async candidates once computed.
+
+Note: To ensure redisplay is done in async sources after Helm
+reached `candidate-number-limit' you will have also to redisplay
+your candidates from `helm-async-outer-limit-hook'."
   (with-helm-buffer
     (let ((get-cands (lambda (source)
                        (let ((fns (assoc-default 'redisplay source))
@@ -4704,10 +4806,10 @@ candidates from `helm-async-outer-limit-hook'."
 
 (defun helm-insert-match (match insert-function &optional num source)
   "Insert MATCH into `helm-buffer' with INSERT-FUNCTION.
-If MATCH is a cons cell then insert the car as display with
-the cdr stored as real value in a `helm-realvalue' text property.
-Args NUM and SOURCE are also stored as text property when specified as
-respectively `helm-cand-num' and `helm-cur-source'."
+If MATCH is a cons cell then insert the car as display with the
+cdr stored as real value in a `helm-realvalue' text property.
+Args NUM and SOURCE are also stored as text property when
+specified as respectively `helm-cand-num' and `helm-cur-source'."
   (let ((start     (point-at-bol (point)))
         (dispvalue (helm-candidate-get-display match))
         (realvalue (cdr-safe match))
@@ -4805,8 +4907,8 @@ if SOURCE has header-name attribute."
 
 (defun helm-insert-header (name &optional display-string)
   "Insert header of source NAME into the helm buffer.
-If DISPLAY-STRING is non-`nil' and a string value then display
-this additional info after the source name by overlay."
+If DISPLAY-STRING is non-nil and a string value then display this
+additional info after the source name by overlay."
   (unless (bobp)
     (let ((start (point)))
       (insert (propertize "\n" 'face 'helm-eob-line))
@@ -4825,23 +4927,23 @@ this additional info after the source name by overlay."
                                               display-line-numbers-disable t))))
 
 (defun helm-insert-candidate-separator ()
-  "Insert separator of candidates into the helm buffer."
+  "Insert separator of candidates into the Helm buffer."
   (insert (propertize helm-candidate-separator 'face 'helm-separator))
   (put-text-property (point-at-bol)
                      (point-at-eol) 'helm-candidate-separator t)
   (insert "\n"))
 
 (defun helm-init-relative-display-line-numbers ()
-  "Enable `display-line-numbers' for helm buffers.
+  "Enable `display-line-numbers' for Helm buffers.
 This is intended to be added to `helm-after-initialize-hook'.
-This will work only in Emacs-26+, i.e. Emacs
-versions that have `display-line-numbers-mode'."
+This will work only in Emacs-26+, i.e. Emacs versions that have
+`display-line-numbers-mode'."
   (when (boundp 'display-line-numbers)
     (with-helm-buffer
       (setq display-line-numbers 'relative))))
 
 (define-minor-mode helm-display-line-numbers-mode
-  "Toggle display of line numbers in current helm buffer."
+  "Toggle display of line numbers in current Helm buffer."
   :group 'helm
   (with-helm-alive-p
     (cl-assert (boundp 'display-line-numbers) nil
@@ -4858,7 +4960,7 @@ versions that have `display-line-numbers-mode'."
 ;;; Async process
 ;;
 (defun helm-output-filter (process output-string)
-  "The `process-filter' function for helm async sources."
+  "The `process-filter' function for Helm async sources."
   (with-helm-quittable
     (helm-output-filter-1 (assoc process helm-async-processes) output-string)))
 
@@ -4997,7 +5099,7 @@ function."
                                         selection action
                                         preserve-saved-action)
   "Execute ACTION on current SELECTION.
-If PRESERVE-SAVED-ACTION is non-`nil', then save the action."
+If PRESERVE-SAVED-ACTION is non-nil, then save the action."
   (helm-log "executing action")
   (setq action (helm-get-default-action
                 (or action
@@ -5041,7 +5143,7 @@ Coerce source with coerce function."
 
 (defun helm-select-action ()
   "Select an action for the currently selected candidate.
-If action buffer is selected, back to the helm buffer."
+If action buffer is selected, back to the Helm buffer."
   (interactive)
   (with-helm-alive-p
     (let ((src (helm-get-current-source)))
@@ -5152,7 +5254,7 @@ If action buffer is selected, back to the helm buffer."
 
 (defun helm-display-source-at-screen-top-maybe (unit)
   "Display source at the top of screen when UNIT value is 'source.
-Returns nil for any other value of UNIT."
+Return nil for any other value of UNIT."
   (when (and helm-display-source-at-screen-top (eq unit 'source))
     (set-window-start (selected-window)
                       (save-excursion (forward-line -1) (point)))))
@@ -5160,8 +5262,8 @@ Returns nil for any other value of UNIT."
 (defun helm-skip-noncandidate-line (direction)
   "Skip source header or candidates separator when going in DIRECTION.
 DIRECTION is either 'next or 'previous.
-Same as `helm-skip-header-and-separator-line' but ensure
-point is moved to the right place when at bob or eob."
+Same as `helm-skip-header-and-separator-line' but ensure point is
+moved to the right place when at bob or eob."
   (helm-skip-header-and-separator-line direction)
   (and (bobp) (forward-line 1))     ; Skip first header.
   (and (eobp) (forward-line -1)))   ; Avoid last empty line.
@@ -5180,7 +5282,7 @@ DIRECTION is either 'next or 'previous."
                         -1 1)))))
 
 (defun helm-display-mode-line (source &optional force)
-  "Set up mode line and header line for `helm-buffer'.
+  "Set up mode-line and header-line for `helm-buffer'.
 
 SOURCE is a Helm source object.
 
@@ -5300,7 +5402,7 @@ mode and header lines."
    header-line-format))
 
 (defun helm-exchange-minibuffer-and-header-line ()
-  "Display minibuffer in header-line and vice versa for current helm session.
+  "Display minibuffer in header-line and vice versa for current Helm session.
 
 This is a toggle command."
   (interactive)
@@ -5346,8 +5448,8 @@ It has no effect if `helm-echo-input-in-header-line' is nil."
 
 (defun helm-show-candidate-number (&optional name)
   "Used to display candidate number in mode-line.
-You can specify NAME of candidates e.g \"Buffers\" otherwise
-it is \"Candidate\(s\)\" by default."
+You can specify NAME of candidates e.g. \"Buffers\" otherwise it
+is \"Candidate\(s\)\" by default."
   (when helm-alive-p
     (unless (helm-empty-source-p)
       ;; Build a fixed width string when candidate-number < 1000
@@ -5541,7 +5643,8 @@ Key arg DIRECTION can be one of:
 
 (defun helm-previous-line (&optional arg)
   "Move selection to the ARG previous line(s).
-Same behavior as `helm-next-line' when called with a numeric prefix arg."
+Same behavior as `helm-next-line' when called with a numeric
+prefix arg."
   (interactive "p")
   (with-helm-alive-p
     (helm--next-or-previous-line 'previous arg)))
@@ -5602,8 +5705,8 @@ next source)."
 (defun helm-goto-source (&optional source-or-name)
   "Move the selection to the source named SOURCE-OR-NAME.
 
-If SOURCE-OR-NAME is empty string or nil go to the first candidate of
-first source."
+If SOURCE-OR-NAME is empty string or nil go to the first
+candidate of first source."
   (helm-move-selection-common :where 'source :direction source-or-name))
 
 (defun helm--follow-action (arg)
@@ -5642,8 +5745,8 @@ first source."
 When RESUMEP is non nil move overlay to `helm-selection-point'.
 When NOMOUSE is specified do not set mouse bindings.
 
-Note that selection is unrelated to visible marks used for marking
-candidates."
+Note that selection is unrelated to visible marks used for
+marking candidates."
   (with-helm-buffer
     (when resumep
       (goto-char helm-selection-point))
@@ -5665,11 +5768,11 @@ candidates."
 
 (defun helm-confirm-and-exit-minibuffer ()
   "Maybe ask for confirmation when exiting helm.
-It is similar to `minibuffer-complete-and-exit' adapted to helm.
-If `minibuffer-completion-confirm' value is 'confirm,
-send minibuffer confirm message and exit on next hit.
-If `minibuffer-completion-confirm' value is t,
-don't exit and send message 'no match'."
+It is similar to `minibuffer-complete-and-exit' adapted to Helm.
+If `minibuffer-completion-confirm' value is 'confirm, send
+minibuffer confirm message and exit on next hit.  If
+`minibuffer-completion-confirm' value is t, don't exit and send
+message 'no match'."
   (interactive)
   (with-helm-alive-p
     (if (and (helm--updating-p)
@@ -5819,7 +5922,7 @@ If action buffer is displayed, kill it."
 ;;
 ;;
 (defun helm-debug-output ()
-  "Show all helm-related variables at this time."
+  "Show all Helm-related variables at this time."
   (interactive)
   (with-helm-alive-p
     (helm-help-internal " *Helm Debug*" 'helm-debug-output-function)))
@@ -5870,7 +5973,7 @@ CANDIDATE-OR-REGEXP can be a:
 - Nullary function, which moves to a candidate
 
 When CANDIDATE-OR-REGEXP is a cons cell, tries moving to first
-element of the cons cell, then the second, and so on. This allows
+element of the cons cell, then the second, and so on.  This allows
 selection of duplicate candidates after the first.
 
 Optional argument SOURCE is a Helm source object."
@@ -5935,11 +6038,11 @@ Optional argument SOURCE is a Helm source object."
           (if (< n 0) (bobp) (eobp))))))
 
 (defun helm-end-of-source-p (&optional at-point)
-  "Return non-`nil' if we are at eob or end of source."
+  "Return non-nil if we are at EOB or end of source."
   (helm-end-of-source-1 1 at-point))
 
 (defun helm-beginning-of-source-p (&optional at-point)
-  "Return non-`nil' if we are at bob or beginning of source."
+  "Return non-nil if we are at BOB or beginning of source."
   (helm-end-of-source-1 -1 at-point))
 
 (defun helm--edit-current-selection-internal (func)
@@ -5979,10 +6082,10 @@ Used generally to modify current selection."
 
 (defun helm-delete-minibuffer-contents (&optional arg)
   "Delete minibuffer contents.
-When `helm-delete-minibuffer-contents-from-point' is non-`nil',
+When `helm-delete-minibuffer-contents-from-point' is non-nil,
 delete minibuffer contents from point instead of deleting all.
-Giving a prefix arg reverses this behavior.
-When at the end of minibuffer, deletes all."
+With a prefix arg reverse this behaviour.  When at the end of
+minibuffer, delete all."
   (interactive "P")
   (let ((str (if helm-delete-minibuffer-contents-from-point
                  (if (or arg (eobp))
@@ -5997,13 +6100,14 @@ When at the end of minibuffer, deletes all."
 (defun helm-candidates-in-buffer (&optional source)
   "The top level function used to store candidates with `helm-source-in-buffer'.
 
-Candidates are stored in a buffer generated internally
-by `helm-candidate-buffer' function.
-Each candidate must be placed in one line.
+Candidates are stored in a buffer generated internally by
+`helm-candidate-buffer' function.  Each candidate must be placed
+in one line.
 
-The buffer is created and fed in the init attribute function of helm.
+The buffer is created and fed in the init attribute function of
+Helm.
 
-e.g:
+E.g.:
 
      (helm-build-in-buffer-source \"test\"
        :init (lambda ()
@@ -6015,14 +6119,13 @@ A shortcut can be used to simplify:
      (helm-build-in-buffer-source \"test\"
        :data '(foo foa fob bar baz))
 
-By default, `helm' makes candidates by evaluating the
-candidates function, then narrows them by `string-match' for each
-candidate.
+By default, Helm makes candidates by evaluating the candidates
+function, then narrows them by `string-match' for each candidate.
 
-But this is slow for large number of candidates. The new way is
-to store all candidates in a buffer and then narrow
-with `re-search-forward'. Search function is customizable by search
-attribute. The important point is that buffer processing is MUCH
+But this is slow for large number of candidates.  The new way is
+to store all candidates in a buffer and then narrow with
+`re-search-forward'.  Search function is customizable by search
+attribute.  The important point is that buffer processing is MUCH
 FASTER than string list processing and is the Emacs way.
 
 The init function writes all candidates to a newly-created
@@ -6038,20 +6141,21 @@ Class `helm-source-in-buffer' is implemented with three attributes:
     (volatile)
     (match identity)
 
-The volatile attribute is needed because `helm-candidates-in-buffer'
-creates candidates dynamically and need to be called every
-time `helm-pattern' changes.
+The volatile attribute is needed because
+`helm-candidates-in-buffer' creates candidates dynamically and
+need to be called every time `helm-pattern' changes.
 
-Because `helm-candidates-in-buffer' plays the role of `match' attribute
-function, specifying `(match identity)' makes the source slightly faster.
+Because `helm-candidates-in-buffer' plays the role of `match'
+attribute function, specifying `(match identity)' makes the
+source slightly faster.
 
-However if source contains `match-part' attribute, match is computed only
-on part of candidate returned by the call of function provided by this attribute.
-The function should have one arg, candidate, and return only
-a specific part of candidate.
+However if source contains `match-part' attribute, match is
+computed only on part of candidate returned by the call of
+function provided by this attribute.  The function should have one
+arg, candidate, and return only a specific part of candidate.
 
-To customize `helm-candidates-in-buffer' behavior,
-use `search', `get-line' and `match-part' attributes."
+To customize `helm-candidates-in-buffer' behaviour, use `search',
+`get-line' and `match-part' attributes."
   (let ((src (or source (helm-get-current-source))))
     (helm-candidates-in-buffer-1
      (helm-candidate-buffer)
@@ -6155,10 +6259,10 @@ use `search', `get-line' and `match-part' attributes."
 (defun helm-search-match-part (candidate pattern)
   "Match PATTERN only on match-part property value of CANDIDATE.
 
-Because `helm-search-match-part' maybe called even if unspecified
-in source (negation or fuzzy), the part to match fallback to the whole
-candidate even if match-part haven't been computed by match-part-fn
-and stored in the match-part property."
+Because `helm-search-match-part' may be called even if
+unspecified in source (negation or fuzzy), the part to match
+falls back to the whole candidate even if match-part hasn't been
+computed by match-part-fn and stored in the match-part property."
   (let ((part (or (get-text-property 0 'match-part candidate)
                   candidate))
         (fuzzy-regexp (cadr (gethash 'helm-pattern helm--fuzzy-regexp-cache)))
@@ -6208,17 +6312,17 @@ and stored in the match-part property."
 
 This is used to initialize a buffer for storing candidates for a
 candidates-in-buffer source, candidates will be searched in this
-buffer and displayed in `helm-buffer'.
-This should be used only in init functions, don't relay on this in
-other places unless you know what you are doing.
+buffer and displayed in `helm-buffer'.  This should be used only
+in init functions, don't relay on this in other places unless you
+know what you are doing.
 
-This function is still in public API only for backward compatibility,
-you should use instead `helm-init-candidates-in-buffer' for
-initializing your sources.
+This function is still in public API only for backward
+compatibility, you should use instead
+`helm-init-candidates-in-buffer' for initializing your sources.
 
-Internally, this function is called without argument and returns the
-buffer corresponding to current source i.e `helm--source-name' which
-is available in only some places.
+Internally, this function is called without argument and returns
+the buffer corresponding to current source i.e.
+`helm--source-name' which is available in only some places.
 
 Acceptable values of BUFFER-SPEC:
 
@@ -6227,15 +6331,18 @@ Acceptable values of BUFFER-SPEC:
   named \" *helm candidates:SOURCE*\".
   This is used by `helm-init-candidates-in-buffer' and it is
   the most common usage of BUFFER-SPEC.
-  The buffer will be killed and recreated at each new helm-session.
+  The buffer will be killed and recreated at each new
+  helm-session.
 
 - local (a symbol)
   Create a new local candidates buffer,
   named \" *helm candidates:SOURCE*HELM-CURRENT-BUFFER\".
-  You may want to use this when you want to have a different buffer
-  each time source is used from a different `helm-current-buffer'.
-  The buffer is erased and refilled at each new session but not killed.
-  You probably don't want to use this value for BUFFER-SPEC.
+  You may want to use this when you want to have a different
+  buffer each time source is used from a different
+  `helm-current-buffer'.
+  The buffer is erased and refilled at each new session but not
+  killed. You probably don't want to use this value for
+  BUFFER-SPEC.
 
 - nil (omit)
   Only return the candidates buffer of current source if found.
@@ -6243,18 +6350,18 @@ Acceptable values of BUFFER-SPEC:
 - A buffer
   Register a buffer as a candidates buffer.
   The buffer needs to exists, it is not created.
-  This allow you to use the buffer as a cache, it is faster because
-  the buffer is already drawn, but be careful when using this as you
-  may mangle your buffer depending what you write in your init(s)
-  function, IOW don't modify the contents of the buffer in init(s)
-  function but in a transformer.
+  This allow you to use the buffer as a cache, it is faster
+  because the buffer is already drawn, but be careful when using
+  this as you may mangle your buffer depending on what you write
+  in your init(s) function, IOW don't modify the contents of the
+  buffer in init(s) function but in a transformer.
   The buffer is not erased nor deleted.
   Generally it is safer to use a copy of buffer inserted
   in a global or local buffer.
 
-If for some reasons a global buffer and a local buffer exist and are
-belonging to the same source, the local buffer takes precedence on the
-global one and is used instead.
+If for some reasons a global buffer and a local buffer exist and
+are belonging to the same source, the local buffer takes
+precedence on the global one and is used instead.
 
 When forcing update only the global and local buffers are killed
 before running again the init function."
@@ -6305,17 +6412,17 @@ before running again the init function."
 (defun helm-init-candidates-in-buffer (buffer-spec data)
   "Register BUFFER-SPEC with DATA for a helm candidates-in-buffer session.
 
-Arg BUFFER-SPEC can be a buffer-name (stringp), a buffer-spec object
-\(bufferp), or a symbol, either 'local or 'global which is passed to
-`helm-candidate-buffer'.
+Arg BUFFER-SPEC can be a `buffer-name' (stringp), a buffer-spec
+object \(bufferp), or a symbol, either 'local or 'global which is
+passed to `helm-candidate-buffer'.
 The most common usage of BUFFER-SPEC is 'global.
 
 Arg DATA can be either a list or a plain string.
 Returns the resulting buffer.
 
 Use this in your init function to register a buffer for a
-`helm-source-in-buffer' session and feed it with DATA.
-You probably don't want to bother with this and use the :data slot
+`helm-source-in-buffer' session and feed it with DATA.  You
+probably don't want to bother with this and use the :data slot
 when initializing a source with `helm-source-in-buffer' class."
   (declare (indent 1))
   (let ((caching (and (or (stringp buffer-spec)
@@ -6411,7 +6518,7 @@ If N is positive enlarge, if negative narrow."
 (put 'helm-enlarge-window 'helm-only t)
 
 (defun helm-toggle-full-frame (&optional arg)
-  "Toggle helm-buffer full-frame view."
+  "Toggle `helm-buffer' full-frame view."
   (interactive "p")
   (cl-assert (null (helm-action-window))
              nil "Unable to toggle full frame from action window")
@@ -6542,18 +6649,18 @@ Possible values are 'left 'right 'below or 'above."
 (cl-defun helm-execute-persistent-action (&optional attr split)
   "Perform the associated action ATTR without quitting helm.
 
-Arg ATTR default will be `persistent-action' or `persistent-action-if'
-if unspecified depending on what's found in source, but it can be
-anything else.
+Arg ATTR default will be `persistent-action' or
+`persistent-action-if' if unspecified depending on what's found
+in source, but it can be anything else.
 In this case you have to add this new attribute to your source.
-See `persistent-action' and `persistent-action-if' slot documentation
-in `helm-source'.
+See `persistent-action' and `persistent-action-if' slot
+documentation in `helm-source'.
 
-When `helm-full-frame' is non-`nil', and
-`helm-buffer' is displayed in only one window, the helm window is
-split to display `helm-select-persistent-action-window' in other
-window to maintain visibility.  The argument SPLIT can be used to
-force splitting inconditionally, it is unused actually."
+When `helm-full-frame' is non-nil, and `helm-buffer' is displayed
+in only one window, the helm window is split to display
+`helm-select-persistent-action-window' in other window to
+maintain visibility.  The argument SPLIT can be used to force
+splitting inconditionally, it is unused actually."
   (interactive)
   (with-helm-alive-p
     (let ((source (helm-get-current-source)))
@@ -6614,10 +6721,10 @@ force splitting inconditionally, it is unused actually."
 
 (cl-defun helm-persistent-action-display-window (&key split)
   "Return the window that will be used for persistent action.
-If SPLIT is `t' window is split in persistent action, if it has the
-special symbol `never' don't split, if it is `nil' normally don't
-split but this may happen in case of dedicated-windows or unsuitable
-window to display persistent action buffer."
+If SPLIT is t window is split in persistent action, if it has the
+special symbol `never' don't split, if it is nil normally don't
+split but this may happen in case of dedicated-windows or
+unsuitable window to display persistent action buffer."
   (with-helm-window
     (let (prev-win cur-win)
       (setq helm-persistent-action-display-window
@@ -6745,7 +6852,7 @@ Meaning of prefix ARG is the same as in `reposition-window'."
     (push (cons source sel) helm-marked-candidates)))
 
 (defun helm-toggle-visible-mark (arg)
-  "Toggle helm visible mark at point ARG times.
+  "Toggle Helm visible mark at point ARG times.
 If ARG is negative toggle backward."
   (interactive "p")
   (with-helm-alive-p
@@ -6778,7 +6885,7 @@ If ARG is negative toggle backward."
   (helm-toggle-visible-mark -1))
 
 (defun helm-file-completion-source-p (&optional source)
-  "Return non-`nil' if current source is a file completion source."
+  "Return non-nil if current source is a file completion source."
   (or helm--completing-file-name ; helm-read-file-name
       (let ((cur-source (cdr (assq 'name
                                    (or source (helm-get-current-source))))))
@@ -6788,7 +6895,8 @@ If ARG is negative toggle backward."
 (defun helm-mark-all (&optional all)
   "Mark all visible unmarked candidates in current source.
 
-With a prefix arg mark all visible unmarked candidates in all sources."
+With a prefix arg mark all visible unmarked candidates in all
+sources."
   (interactive "P")
   (with-helm-alive-p
     (with-helm-window ; Using `with-helm-buffer' for some unknow reasons infloop.
@@ -6812,9 +6920,9 @@ With a prefix arg mark all visible unmarked candidates in all sources."
 (defun helm-mark-all-1 (&optional ensure-beg-of-source)
   "Mark all visible unmarked candidates in current source.
 Need to be wrapped in `with-helm-window'.
-Arg ENSURE-BEG-OF-SOURCE ensure we are at beginning of source when
-starting to mark candidates, if handled elsewhere before starting it
-is not needed."
+Arg ENSURE-BEG-OF-SOURCE ensure we are at beginning of source
+when starting to mark candidates, if handled elsewhere before
+starting it is not needed."
   (let* ((src        (helm-get-current-source))
          (follow     (if (helm-follow-mode-p src) 1 -1))
          (nomark     (assq 'nomark src))
@@ -6884,8 +6992,9 @@ is not needed."
 (defun helm-toggle-all-marks (&optional all)
   "Toggle all marks.
 
-Mark all visible candidates of current source or unmark all candidates
-visible or invisible in all sources of current helm session.
+Mark all visible candidates of current source or unmark all
+candidates visible or invisible in all sources of current Helm
+session.
 
 With a prefix argument mark all candidates in all sources."
   (interactive "P")
@@ -6919,8 +7028,8 @@ With a prefix argument mark all candidates in all sources."
   "Return marked candidates of current source, if any.
 
 Otherwise return one element list consisting of the current
-selection. When key WITH-WILDCARD is specified, expand it.
-When ALL-SOURCES key value is non-nil returns marked candidates of all
+selection.  When key WITH-WILDCARD is specified, expand it.  When
+ALL-SOURCES key value is non-nil returns marked candidates of all
 sources."
   (with-current-buffer helm-buffer
     (let* ((current-src (helm-get-current-source))
@@ -7011,8 +7120,8 @@ sources."
          points))))
 
 (defun helm-next-visible-mark (&optional prev)
-  "Move next helm visible mark.
-If PREV is non-`nil' move to precedent."
+  "Move next Helm visible mark.
+If PREV is non-nil move to precedent."
   (interactive)
   (with-helm-alive-p
     (with-helm-window
@@ -7046,8 +7155,8 @@ With a prefix arg set to real value of current selection."
 (defun helm-kill-selection-and-quit (arg)
   "Store display value of current selection to kill ring.
 With a prefix arg use real value of current selection.
-Display value is shown in `helm-buffer' and real value
-is used to perform actions."
+Display value is shown in `helm-buffer' and real value is used to
+perform actions."
   (interactive "P")
   (with-helm-alive-p
     (helm-run-after-exit
@@ -7081,30 +7190,36 @@ display values."
 ;;
 (defvar helm-follow-input-idle-delay nil
   "`helm-follow-mode' will execute its persistent action after this delay.
-Note that if the `follow-delay' attr is present in source,
-it will take precedence over this.")
+Note that if the `follow-delay' attr is present in source, it
+will take precedence over this.")
 
 (defun helm-follow-mode (&optional arg)
   "Execute persistent action every time the cursor is moved.
 
-This mode is source local, i.e It apply on current source only.
+This mode is source local, i.e. It applies on current source only.
 \\<helm-map>
 This mode can be enabled or disabled interactively at anytime during
 a helm session with \\[helm-follow-mode].
 
-When enabling interactively `helm-follow-mode' in a source, you can keep it enabled
-for next emacs sessions by setting `helm-follow-mode-persistent' to a non-nil value.
+When enabling interactively `helm-follow-mode' in a source, you
+can keep it enabled for next Emacs sessions by setting
+`helm-follow-mode-persistent' to a non-nil value.
 
-When `helm-follow-mode' is called with a prefix arg and `helm-follow-mode-persistent'
-is non-nil `helm-follow-mode' will be persistent only for this emacs session,
-but not for next emacs sessions, i.e the current source will not be saved
-to `helm-source-names-using-follow'.
-A prefix arg with `helm-follow-mode' already enabled will have no effect.
+When `helm-follow-mode' is called with a prefix arg and
+`helm-follow-mode-persistent' is non-nil `helm-follow-mode' will
+be persistent only for this Emacs session, but not for the next
+Emacs sessions, i.e. the current source will not be saved to
+`helm-source-names-using-follow'.
 
-Note that you can use instead of this mode the commands `helm-follow-action-forward'
-and `helm-follow-action-backward' at anytime in all helm sessions.
+A prefix arg with `helm-follow-mode' already enabled will have no
+effect.
 
-They are bound by default to \\[helm-follow-action-forward] and \\[helm-follow-action-backward]."
+Note that you can use instead of this mode the commands
+`helm-follow-action-forward' and `helm-follow-action-backward' at
+anytime in all Helm sessions.
+
+They are bound by default to \\[helm-follow-action-forward] and
+\\[helm-follow-action-backward]."
   (interactive (list (helm-aif (and current-prefix-arg
                                     (prefix-numeric-value current-prefix-arg))
                          (unless (helm-follow-mode-p) it))))
@@ -7152,8 +7267,9 @@ They are bound by default to \\[helm-follow-action-forward] and \\[helm-follow-a
 (defun helm-follow-execute-persistent-action-maybe (&optional delay)
   "Execute persistent action in mode `helm-follow-mode'.
 
-This happen after: DELAY or the 'follow-attr value of current source
-or `helm-follow-input-idle-delay' or `helm-input-idle-delay' secs."
+This happen after: DELAY or the 'follow-attr value of current
+source or `helm-follow-input-idle-delay' or
+`helm-input-idle-delay' secs."
   (let* ((src (helm-get-current-source))
          (at (or delay
                  (assoc-default 'follow-delay src)
@@ -7198,9 +7314,8 @@ or `helm-follow-input-idle-delay' or `helm-input-idle-delay' secs."
 (define-minor-mode helm-autoresize-mode
   "Auto resize helm window when enabled.
 Helm window is re-sized according to `helm-autoresize-max-height'
-and `helm-autoresize-min-height'. Note that when this mode is
-enabled, helm behaves as if `helm-always-two-windows' is
-enabled.
+and `helm-autoresize-min-height'.  Note that when this mode is
+enabled, Helm behaves as if `helm-always-two-windows' is enabled.
 
 See `fit-window-to-buffer' for more infos."
   :group 'helm
@@ -7212,13 +7327,14 @@ See `fit-window-to-buffer' for more infos."
     (remove-hook 'helm-window-configuration-hook 'helm--autoresize-hook)))
 
 (defun helm-help ()
-  "Generate helm's help according to `help-message' attribute.
+  "Generate Helm's help according to `help-message' attribute.
 
-If `helm-buffer' is empty, provide completions on `helm-sources' to
-choose its local documentation.
-If source doesn't have any `help-message' attribute, a generic message
-explaining this is added instead.
-The global `helm-help-message' is always added after this local help."
+If `helm-buffer' is empty, provide completions on `helm-sources'
+to choose its local documentation.
+If source doesn't have any `help-message' attribute, a generic
+message explaining this is added instead.
+The global `helm-help-message' is always added after this local
+help."
   (interactive)
   (require 'helm-mode) ; for helm-comp-read.
   (with-helm-alive-p


### PR DESCRIPTION
Hi,

this is my attempt at doing something useful for Helm besides opening tickets. :)

I'd like to go through the docstrings in the Helm codebase and see if there is something to fix. This is not me saying Helm has a poor documentation. I'm not aiming at changing the documentation meaning and purpose at all. On the contrary, my intent is only to fix some grammar[1] and other minor things. 

This PR is not completed yet. I opened it as a work-in-progress to show what I have done so far and to understand if this is something welcomed so I can go on with it. I will update here when my work is ready.

Some questions before proceeding with my editing:

- Do you want me to apply filling to the docstrings?
- Do you want one or two spaces after a period? Emacs usually uses two spaces.
- How should the word "Helm" appear in the documentation? It seems to be spelled differently in various occasions: "Helm", "helm", "\`helm\`".

Let me know what you think. :)

[1] I am not an English native speaker, but I have a Cambridge Advanced English (Grade A) certificate. If you prefer an English native speaker for this, then I am not the right guy.