### PR TITLE
Preserve source ordering in `helm-fuzzy-match-sort-fn-preserve-ties-order'

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -4285,7 +4285,7 @@ The default function, `helm-fuzzy-matching-default-sort-fn',
 sorts ties by length, shortest first.  This function may be more
 useful when the order of the candidates is meaningful, e.g. with
 `recentf-list'."
-  (helm-fuzzy-matching-default-sort-fn-1 candidates nil t))
+  (helm-fuzzy-matching-default-sort-fn-1 candidates nil nil t))
 
 (defun helm--maybe-get-migemo-pattern (pattern)
   (or (and helm-migemo-mode


### PR DESCRIPTION
With:
```
(setq helm-buffers-fuzzy-matching t
  helm-fuzzy-sort-fn 'helm-fuzzy-match-sort-fn-preserve-ties-order)
```
the ordering of buffers in helm-buffers-list is still "shortest match first" rather than the expected "recent match first" once some input is entered. This seems to be because the call to helm-fuzzy-matching-default-sort-fn-1 is incorrect.

I'm new to helm - if this analysis is wrong I'm happy to learn more!