### PR TITLE
Fix helm-ff--cleanup-cache.

### DIFF
--- a/helm-files.el
+++ b/helm-files.el
@@ -4303,7 +4303,7 @@ source is `helm-source-find-files'."
                        (unless (file-remote-p k)
                          (remhash k helm-ff--list-directory-cache)))
                      helm-ff--list-directory-cache))
-    (nil (clrhash helm-ff--list-directory-cache))))
+    ((nil) (clrhash helm-ff--list-directory-cache))))
 
 (defun helm-find-files-cleanup ()
   (helm-ff--cleanup-cache)


### PR DESCRIPTION
A value of `nil` for `helm-ff-keep-cached-candidates` causes an error because
the `nil` key in the `cl-ecase` form is understood as `()`, i.e. no key at all.

Fixes #2328