### PR TITLE
Add hidden flag to rg command

### DIFF
--- a/helm-grep.el
+++ b/helm-grep.el
@@ -1444,12 +1444,12 @@ colorization of backend, however it is still supported.
 
 For ripgrep here is the command line to use:
 
-    rg --color=always --smart-case --no-heading --line-number %s %s %s
+    rg --color=always --hidden --smart-case --no-heading --line-number %s %s %s
 
 And to customize colors (always for ripgrep) use something like this:
 
     rg --color=always --colors 'match:bg:yellow' --colors 'match:fg:black'
-\--smart-case --no-heading --line-number %s %s %s
+\--hidden --smart-case --no-heading --line-number %s %s %s
 
 This will change color for matched items from foreground red (the
 default) to a yellow background with a black foreground.  Note


### PR DESCRIPTION
Search hidden files and directories. By default, hidden
files and directories are skipped. Note that if a hidden
file or a directory is whitelisted in an ignore file,
then it will be searched even if this flag isn’t
provided.