### PR TITLE
Do not highlight a sequence of 0’s as a file extension

### DIFF
--- a/helm-files.el
+++ b/helm-files.el
@@ -3691,7 +3691,7 @@ return directly CANDIDATES."
 (defsubst helm-ff-file-extension (file)
   "Returns FILE extension if it is not a number."
   (helm-aif (file-name-extension file)
-      (and (not (string= "0" it))
+      (and (not (string-match "\\`0+\\'" it))
            (zerop (string-to-number it))
            it)))
 


### PR DESCRIPTION
Currently, only a single 0 would be exempt from being highlighted as a
file extension.  E.g., in

```
foo.txt.0
foo.txt.1
foo.txt.2
```

none of the 0, 1, and 2 will be highlighted.  However, in

```
bar.txt.00
bar.txt.01
bar.txt.02
```

the 00 will be highlighted, but the 01 and 02 won’t.  This commit
fixes that.