### PR TITLE
Handle nil value for helm-buffers-sort-fn

### DIFF
--- a/helm-buffers.el
+++ b/helm-buffers.el
@@ -541,15 +541,20 @@ buffers)."
                                         (and helm-buffers-fuzzy-matching ""))))
                      (cons (if helm-buffer-details-flag
                                (concat
-                                (funcall helm-fuzzy-matching-highlight-fn
-                                         truncbuf)
+                                (if helm-fuzzy-matching-highlight-fn
+                                    (funcall helm-fuzzy-matching-highlight-fn
+                                             truncbuf)
+                                  truncbuf)
                                 helm-buffers-column-separator
                                 formatted-size
                                 helm-buffers-column-separator
                                 fmode
                                 helm-buffers-column-separator
                                 meta)
-                             (funcall helm-fuzzy-matching-highlight-fn name))
+                             (if helm-fuzzy-matching-highlight-fn
+                                 (funcall helm-fuzzy-matching-highlight-fn
+                                          name)
+                               name))
                            (get-buffer i)))))
 
 (defun helm-buffer--get-preselection (buffer)
@@ -591,7 +596,8 @@ buffers)."
            finally return (mapconcat 'identity lst (or separator " "))))
 
 (defun helm-buffers-sort-transformer (candidates source)
-  (if (string= helm-pattern "")
+  (if (or (string= helm-pattern "")
+          (null helm-buffers-sort-fn))
       candidates
     (let ((helm-pattern (helm-buffers--pattern-sans-filters)))
       (funcall helm-buffers-sort-fn candidates source))))

--- a/helm.el
+++ b/helm.el
@@ -4398,8 +4398,9 @@ to the matching method in use."
 (defun helm-fuzzy-highlight-matches (candidates _source)
   "The filtered-candidate-transformer function to highlight fuzzy matches.
 See `helm-fuzzy-default-highlight-match'."
-  (cl-loop for c in candidates
-           collect (funcall helm-fuzzy-matching-highlight-fn c)))
+  (if helm-fuzzy-matching-highlight-fn
+      (mapcar helm-fuzzy-matching-highlight-fn candidates)
+    candidates))
 
 
 ;;; helm-flex style


### PR DESCRIPTION
...or for `helm-fuzzy-matching-highlight-fn`.  By default, `helm-buffers-sort-fn` is initialized with the value of `helm-fuzzy-sort-fn`, and the documentation string for `helm-fuzzy-sort-fn` states that it may be set to `nil` to indicate that no sorting should be done.  Similarly, the documentation string for `helm-fuzzy-matching-highlight-fn` states that it may be set to `nil` to indicate that no highlighting should be done.  Thus functions that use `helm-buffers-sort-fn` or `helm-fuzzy-matching-highlight-fn` to sort or highlight a list of candidates must handle nil values for these options by using the candidates directly.

This change fixes https://github.com/emacs-helm/helm/issues/2343.

* `helm-buffers.el` (`helm-highlight-buffers`): Handle nil value for `helm-fuzzy-matching-highlight-fn`.
(`helm-buffers-sort-transformer`): Handle nil value for `helm-buffers-sort-fn`.
* `helm.el` (`helm-fuzzy-highlight-matches`): Handle nil value for `helm-fuzzy-matching-highlight-fn`.