### PR TITLE
helm-net.el: Remove Mosaic in default browser alist

### DIFF
--- a/helm-net.el
+++ b/helm-net.el
@@ -273,7 +273,6 @@ Can be \"-new-tab\" (default) or \"-new-window\"."
     (,browse-url-mozilla-program . browse-url-mozilla)
     (,browse-url-galeon-program . browse-url-galeon)
     (,browse-url-netscape-program . browse-url-netscape)
-    (,browse-url-mosaic-program . browse-url-mosaic)
     (,browse-url-xterm-program . browse-url-text-xterm)
     ("emacs" . eww-browse-url))
   "*Alist of \(executable . function\) to try to find a suitable url browser.")


### PR DESCRIPTION
* `helm-net.el` (`helm-browse-url-default-browser-alist`): Delete `browse-url-mosaic-program`, which was deprecated in Emacs 25.1 and will be removed in Emacs 28.1.

----

Fixes #2357.