### PR TITLE
remove Travis CI coverage for 24.5; add coverage for newer versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,12 @@ jobs:
       env: EMACS_CI=emacs-25-3
     - os: linux
       dist: bionic
+      env: EMACS_CI=emacs-26-1
+    - os: linux
+      dist: bionic
+      env: EMACS_CI=emacs-26-2
+    - os: linux
+      dist: bionic
       env: EMACS_CI=emacs-26-3
     - os: linux
       dist: bionic
@@ -45,3 +51,8 @@ script:
   - export PATH=$HOME/.cask/bin:$PATH
   - emacs --version
   - cask build
+
+allow_failures:
+  - os: linux
+    dist: bionic
+    env: EMACS_CI=emacs-snapshot

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,10 @@ jobs:
   include:
     - os: linux
       dist: bionic
-      env: EMACS_CI=emacs-24-5
+      env: EMACS_CI=emacs-25-1
+    - os: linux
+      dist: bionic
+      env: EMACS_CI=emacs-25-2
     - os: linux
       dist: bionic
       env: EMACS_CI=emacs-25-3


### PR DESCRIPTION
Succeeds: https://travis-ci.org/github/emacs-helm/helm/builds/721927202