### PR TITLE
Fix issues running emacs built from the native-comp branch

### DIFF
--- a/helm-lib.el
+++ b/helm-lib.el
@@ -363,6 +363,18 @@ available APPEND is ignored."
       (setq guess (abbreviate-file-name (expand-file-name guess))))
     (read-file-name prompt (file-name-directory guess) nil nil
                     (file-name-nondirectory guess))))
+
+;; The native-comp branch of emacs "is a modified Emacs capable of compiling
+;; and running Emacs Lisp as native code in form of re-loadable elf files."
+;; (https://akrl.sdf.org/gccemacs.html). The function subr-native-elisp-p is a
+;; native function available only in this branch and evaluates to true if the
+;; argument supplied is a natively compiled lisp function. Use this function
+;; if it's available, otherwise return nil. Helm needs to distinguish compiled
+;; functions from other symbols in a various places.
+(defun helm-subr-native-elisp-p (object)
+  (if (fboundp 'subr-native-elisp-p)
+      (subr-native-elisp-p object)
+    nil))
 
 ;;; Macros helper.
 ;;
@@ -1110,7 +1122,8 @@ Example:
 
 (defun helm-symbol-name (obj)
   (if (or (and (consp obj) (functionp obj))
-          (byte-code-function-p obj))
+          (byte-code-function-p obj)
+          (helm-subr-native-elisp-p obj))
       "Anonymous"
       (symbol-name obj)))
 

--- a/helm-mode.el
+++ b/helm-mode.el
@@ -1093,6 +1093,7 @@ See documentation of `completing-read' and `all-completions' for details."
           (cl-loop for h in minibuffer-setup-hook
                    unless (or (consp h) ; a lambda.
                               (byte-code-function-p h)
+                              (helm-subr-native-elisp-p h)
                               (memq h helm-mode-minibuffer-setup-hook-black-list))
                    collect h))
          ;; Disable hack that could be used before `completing-read'.

--- a/helm-types.el
+++ b/helm-types.el
@@ -297,7 +297,8 @@
                              (describe-function (timer--function tm))))
     ("Find Function" . (lambda (tm)
                          (helm-aif (timer--function tm)
-                             (if (byte-code-function-p it)
+                             (if (or (byte-code-function-p it)
+                                     (helm-subr-native-elisp-p it))
                                  (message "Can't find anonymous function `%s'" it)
                                  (find-function it))))))
   "Default actions for type timers."

--- a/helm.el
+++ b/helm.el
@@ -2352,8 +2352,10 @@ i.e. functions called with RET."
   (let ((actions (helm-get-actions-from-current-source)))
     (when actions
       (cl-assert (or (eq action actions)
-                     ;; Compiled lambda
+                     ;; Compiled lambdas
                      (byte-code-function-p action)
+                     ;; Natively compiled (libgccjit)
+                     (helm-subr-native-elisp-p action)
                      ;; Lambdas
                      (and (listp action) (functionp action))
                      ;; One of current actions.
@@ -5231,7 +5233,8 @@ If action buffer is selected, back to the Helm buffer."
                            (if (functionp actions)
                                (message "Sole action: %s"
                                         (if (or (consp actions)
-                                                (byte-code-function-p actions))
+                                                (byte-code-function-p actions)
+                                                (helm-subr-native-elisp-p actions))
                                             "Anonymous" actions))
                              (helm-show-action-buffer actions)
                              ;; Be sure the minibuffer is entirely deleted (#907).
@@ -5255,7 +5258,8 @@ If action buffer is selected, back to the Helm buffer."
             (if (functionp it)
                 (message "Sole action: %s"
                          (if (or (consp it)
-                                 (byte-code-function-p it))
+                                 (byte-code-function-p it)
+                                 (helm-subr-native-elisp-p it))
                              "Anonymous" it))
               (setq helm-saved-action
                     (x-popup-menu


### PR DESCRIPTION
The emacs native-comp branch provides "a modified Emacs capable of
compiling and running Emacs Lisp as native code in form of re-loadable
elf files" (https://akrl.sdf.org/gccemacs.html). Emacs lisp files are
compiled into ELF shared objects, by default stored under
~/.emacs.d/eln-cache/. Functions that are natively-compiled do not
return t to byte-code-function-p, but do return t to
subr-native-elisp-p, a function that is built-in to the native-comp
emacs.

I generated the stack-trace below using a hydra that invoked
lsp-find-reference. The problem is that helm-symbol-name tries to call
symbol-name on an object if it is not functionp OR byte-code-function-p;
when running with native-comp, this now needs to include
subr-native-elisp-p too. I've also modified some other functions that
use a similar pattern.

Debugger entered--Lisp error: (wrong-type-argument symbolp #<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_8>)
  helm-symbol-name(#<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_8>)
  helm-source--header-line(#<helm-source-sync helm-source-sync-1582bda979a6>)
  #f(compiled-function (source) #<bytecode 0x19d62c8ed2c2da34>)(#<helm-source-sync helm-source-sync-1582bda979a6>)
  apply(#f(compiled-function (source) #<bytecode 0x19d62c8ed2c2da34>) #<helm-source-sync helm-source-sync-1582bda979a6>)
  #f(compiled-function (&rest args) #<bytecode -0x3feeee56fec87b4>)(#<helm-source-sync helm-source-sync-1582bda979a6>)
  apply(#f(compiled-function (&rest args) #<bytecode -0x3feeee56fec87b4>) #<helm-source-sync helm-source-sync-1582bda979a6> nil)
  helm--setup-source(#<helm-source-sync helm-source-sync-1582bda979a6>)
  helm-make-source("Helm Xref" helm-source-sync :candidates ((#("loader.go:248:\11c.PacketPsmlData = make..." 0 9 (font-lock-face helm-xref-file-name) 10 13 (font-lock-face helm-xref-line-number) 17 31 (face highlight)) . #<xref-item xref-item-1582bda94f8e>) (#("loader.go:307:\11return c.PacketPsmlData" 0 9 (font-lock-face helm-xref-file-name) 10 13 (font-lock-face helm-xref-line-number) 24 38 (face highlight)) . #<xref-item xref-item-1582bda94fe4>) (#("loader.go:981:\11return len(c.PacketPsml..." 0 9 (font-lock-face helm-xref-file-name) 10 13 (font-lock-face helm-xref-line-number) 28 42 (face highlight)) . #<xref-item xref-item-1582bda95032>) (#("loader.go:1164:\11\11\11if len(c.PacketPsmlD..." 0 9 (font-lock-face helm-xref-file-name) 10 14 (font-lock-face helm-xref-line-number) 27 41 (face highlight)) . #<xref-item xref-item-1582bda95088>) (#("loader.go:1165:\11\11\11\11sidx, err = strconv..." 0 9 (font-lock-face helm-xref-file-name) 10 14 (font-lock-face helm-xref-line-number) 46 60 (face highlight)) . #<xref-item xref-item-1582bda950e6>) (#("loader.go:1169:\11\11\11\11if len(c.PacketPsml..." 0 9 (font-lock-face helm-xref-file-name) 10 14 (font-lock-face helm-xref-line-number) 28 42 (face highlight)) . #<xref-item xref-item-1582bda9513c>) (#("loader.go:1174:\11\11\11\11\11eidx, err = strcon..." 0 9 (font-lock-face helm-xref-file-name) 10 14 (font-lock-face helm-xref-line-number) 47 61 (face highlight)) . #<xref-item xref-item-1582bda9518a>) (#("loader.go:1179:\11\11\11\11\11eidx, err = strcon..." 0 9 (font-lock-face helm-xref-file-name) 10 14 (font-lock-face helm-xref-line-number) 47 61 (face highlight)) . #<xref-item xref-item-1582bda951e0>) (#("loader.go:1179:\11\11\11\11\11eidx, err = strcon..." 0 9 (font-lock-face helm-xref-file-name) 10 14 (font-lock-face helm-xref-line-number) 68 82 (face highlight)) . #<xref-item xref-item-1582bda9523e>) (#("loader.go:1184:\11\11\11\11\11c.KillAfterReading..." 0 9 (font-lock-face helm-xref-file-name) 10 14 (font-lock-face helm-xref-line-number) 55 69 (face highlight)) . #<xref-item xref-item-1582bda95294>) (#("loader.go:1570:\11c.PacketPsmlData = mak..." 0 9 (font-lock-face helm-xref-file-name) 10 14 (font-lock-face helm-xref-line-number) 18 32 (face highlight)) . #<xref-item xref-item-1582bda952e2>) (#("loader.go:1866:\11\11\11\11c.PacketPsmlData = ..." 0 9 (font-lock-face helm-xref-file-name) 10 14 (font-lock-face helm-xref-line-number) 21 35 (face highlight)) . #<xref-item xref-item-1582bda95346>) (#("loader.go:1866:\11\11\11\11c.PacketPsmlData = ..." 0 9 (font-lock-face helm-xref-file-name) 10 14 (font-lock-face helm-xref-line-number) 47 61 (face highlight)) . #<xref-item xref-item-1582bda9539c>) (#("loader.go:1875:\11\11\11\11c.PacketNumberMap[p..." 0 9 (font-lock-face helm-xref-file-name) 10 14 (font-lock-face helm-xref-line-number) 51 65 (face highlight)) . #<xref-item xref-item-1582bda953ea>) (#("loader_test.go:492:\11assert.Equal(t, 18..." 0 14 (font-lock-face helm-xref-file-name) 15 18 (font-lock-face helm-xref-line-number) 51 65 (face highlight)) . #<xref-item xref-item-1582bda955ac>) (#("loader_test.go:493:\11assert.Equal(t, \"1..." 0 14 (font-lock-face helm-xref-file-name) 15 18 (font-lock-face helm-xref-line-number) 61 75 (face highlight)) . #<xref-item xref-item-1582bda955fa>) (#("loader_test.go:564:\11\11\11assert.Equal(t, ..." 0 14 (font-lock-face helm-xref-file-name) 15 18 (font-lock-face helm-xref-line-number) 56 70 (face highlight)) . #<xref-item xref-item-1582bda95650>) (#("loader_test.go:565:\11\11\11assert.Equal(t, ..." 0 14 (font-lock-face helm-xref-file-name) 15 18 (font-lock-face helm-xref-line-number) 63 77 (face highlight)) . #<xref-item xref-item-1582bda956ae>) (#("loader_test.go:614:\11\11\11assert.Equal(t, ..." 0 14 (font-lock-face helm-xref-file-name) 15 18 (font-lock-face helm-xref-line-number) 52 66 (face highlight)) . #<xref-item xref-item-1582bda956f2>) (#("ui.go:261:\11\11\11\11curRowProg.cur, curRowPr..." 0 5 (font-lock-face helm-xref-file-name) 6 9 (font-lock-face helm-xref-line-number) 78 92 (face highlight)) . #<xref-item xref-item-1582bda97864>) (#("ui.go:1474:\11if len(Loader.PacketPsmlDa..." 0 5 (font-lock-face helm-xref-file-name) 6 10 (font-lock-face helm-xref-line-number) 26 40 (face highlight)) . #<xref-item xref-item-1582bda978b2>) (#("ui.go:1475:\11\11summary = psmlSummary(Loa..." 0 5 (font-lock-face helm-xref-file-name) 6 10 (font-lock-face helm-xref-line-number) 42 56 (face highlight)) . #<xref-item xref-item-1582bda97908>) (#("ui.go:1478:\11packetNum, err := strconv...." 0 5 (font-lock-face helm-xref-file-name) 6 10 (font-lock-face helm-xref-line-number) 50 64 (face highlight)) . #<xref-item xref-item-1582bda97966>)) :persistent-action #<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_8> :action (("Switch to buffer" lambda (item) (helm-xref-goto-xref-item item 'switch-to-buffer)) ("Other window" lambda (item) (helm-xref-goto-xref-item item 'switch-to-buffer-other-window))) :candidate-number-limit 9999)
  helm-xref-source()
  helm-xref-show-xrefs-27(#f(compiled-function (&rest _) #<bytecode 0xa967d2ed68a0d4>) ((window . #<window 3 on loader.go>) (display-action)))
  lsp-show-xrefs((#<xref-item xref-item-1582bda94f8e> #<xref-item xref-item-1582bda94fe4> #<xref-item xref-item-1582bda95032> #<xref-item xref-item-1582bda95088> #<xref-item xref-item-1582bda950e6> #<xref-item xref-item-1582bda9513c> #<xref-item xref-item-1582bda9518a> #<xref-item xref-item-1582bda951e0> #<xref-item xref-item-1582bda9523e> #<xref-item xref-item-1582bda95294> #<xref-item xref-item-1582bda952e2> #<xref-item xref-item-1582bda95346> #<xref-item xref-item-1582bda9539c> #<xref-item xref-item-1582bda953ea> #<xref-item xref-item-1582bda955ac> #<xref-item xref-item-1582bda955fa> #<xref-item xref-item-1582bda95650> #<xref-item xref-item-1582bda956ae> #<xref-item xref-item-1582bda956f2> #<xref-item xref-item-1582bda97864> #<xref-item xref-item-1582bda978b2> #<xref-item xref-item-1582bda97908> #<xref-item xref-item-1582bda97966>) nil t)
  lsp-find-locations("textDocument/references" (:context (:includeDeclaration :json-false)) :display-action nil :references\? t)
  lsp-find-references()
  funcall-interactively(lsp-find-references)
  hydra--call-interactively-remap-maybe(lsp-find-references)
  (progn (setq this-command 'lsp-find-references) (hydra--call-interactively-remap-maybe #'lsp-find-references))
  netrom/lsp-hydra/lsp-find-references-and-exit()
  funcall-interactively(netrom/lsp-hydra/lsp-find-references-and-exit)
  command-execute(netrom/lsp-hydra/lsp-find-references-and-exit)