### PR TITLE
Fix issues running emacs built from the native-comp branch (#2375)

### DIFF
--- a/helm-lib.el
+++ b/helm-lib.el
@@ -363,6 +363,17 @@ available APPEND is ignored."
       (setq guess (abbreviate-file-name (expand-file-name guess))))
     (read-file-name prompt (file-name-directory guess) nil nil
                     (file-name-nondirectory guess))))
+
+;; The native-comp branch of emacs "is a modified Emacs capable of compiling
+;; and running Emacs Lisp as native code in form of re-loadable elf files."
+;; (https://akrl.sdf.org/gccemacs.html). The function subr-native-elisp-p is a
+;; native function available only in this branch and evaluates to true if the
+;; argument supplied is a natively compiled lisp function. Use this function
+;; if it's available, otherwise return nil. Helm needs to distinguish compiled
+;; functions from other symbols in a various places.
+(defun helm-subr-native-elisp-p (object)
+  (when (fboundp 'subr-native-elisp-p)
+      (subr-native-elisp-p object)))
 
 ;;; Macros helper.
 ;;
@@ -1110,7 +1121,8 @@ Example:
 
 (defun helm-symbol-name (obj)
   (if (or (and (consp obj) (functionp obj))
-          (byte-code-function-p obj))
+          (byte-code-function-p obj)
+          (helm-subr-native-elisp-p obj))
       "Anonymous"
       (symbol-name obj)))
 

--- a/helm-mode.el
+++ b/helm-mode.el
@@ -1093,6 +1093,7 @@ See documentation of `completing-read' and `all-completions' for details."
           (cl-loop for h in minibuffer-setup-hook
                    unless (or (consp h) ; a lambda.
                               (byte-code-function-p h)
+                              (helm-subr-native-elisp-p h)
                               (memq h helm-mode-minibuffer-setup-hook-black-list))
                    collect h))
          ;; Disable hack that could be used before `completing-read'.

--- a/helm-types.el
+++ b/helm-types.el
@@ -297,7 +297,8 @@
                              (describe-function (timer--function tm))))
     ("Find Function" . (lambda (tm)
                          (helm-aif (timer--function tm)
-                             (if (byte-code-function-p it)
+                             (if (or (byte-code-function-p it)
+                                     (helm-subr-native-elisp-p it))
                                  (message "Can't find anonymous function `%s'" it)
                                  (find-function it))))))
   "Default actions for type timers."

--- a/helm.el
+++ b/helm.el
@@ -2352,8 +2352,10 @@ i.e. functions called with RET."
   (let ((actions (helm-get-actions-from-current-source)))
     (when actions
       (cl-assert (or (eq action actions)
-                     ;; Compiled lambda
+                     ;; Compiled lambdas
                      (byte-code-function-p action)
+                     ;; Natively compiled (libgccjit)
+                     (helm-subr-native-elisp-p action)
                      ;; Lambdas
                      (and (listp action) (functionp action))
                      ;; One of current actions.
@@ -5231,7 +5233,8 @@ If action buffer is selected, back to the Helm buffer."
                            (if (functionp actions)
                                (message "Sole action: %s"
                                         (if (or (consp actions)
-                                                (byte-code-function-p actions))
+                                                (byte-code-function-p actions)
+                                                (helm-subr-native-elisp-p actions))
                                             "Anonymous" actions))
                              (helm-show-action-buffer actions)
                              ;; Be sure the minibuffer is entirely deleted (#907).
@@ -5255,7 +5258,8 @@ If action buffer is selected, back to the Helm buffer."
             (if (functionp it)
                 (message "Sole action: %s"
                          (if (or (consp it)
-                                 (byte-code-function-p it))
+                                 (byte-code-function-p it)
+                                 (helm-subr-native-elisp-p it))
                              "Anonymous" it))
               (setq helm-saved-action
                     (x-popup-menu


### PR DESCRIPTION
The emacs native-comp branch provides "a modified Emacs capable of
compiling and running Emacs Lisp as native code in form of re-loadable
elf files" (https://akrl.sdf.org/gccemacs.html). Functions that are
natively-compiled do not return t to byte-code-function-p, but do return
t to subr-native-elisp-p, a function that is built-in to the native-comp
emacs.

The problem here is that helm-symbol-name tries to call symbol-name on
an object if it is not functionp OR byte-code-function-p; when running
with native-comp, this now needs to include subr-native-elisp-p
too. I've also modified some other functions that use a similar pattern.