### PR TITLE
[helm--maybe-use-while-no-input] *helm.el: change for unexpected dbus event interruption

### DIFF
--- a/helm.el
+++ b/helm.el
@@ -4635,7 +4635,13 @@ emacs-27 to provide such scoring in emacs<27."
          ;; Tramp will ask for passwd, don't use `helm-while-no-input'.
          ,@body
        (helm-log "Using here `helm-while-no-input'")
-       (helm-while-no-input ,@body))))
+       ;; Emacs bug#47205, unexpected dbus-event is triggered on dbus init.
+       ;; Ignoring the dbus-event work on emacs28+; for emacs27 or older
+       ;; version, require tramp-archive can workaround the issue.
+       (let ((while-no-input-ignore-events
+              (cons 'dbus-event while-no-input-ignore-events)))
+         (unless (> emacs-major-version 28) (require 'tramp-archive))
+         (helm-while-no-input ,@body)))))
 
 (defun helm--collect-matches (src-list)
   "Return a list of matches for each source in SRC-LIST.


### PR DESCRIPTION
Hi,

There is a bug that unexpected dbus event will interrupt in `helm--maybe-use-while-no-input`. 
It's can easyly reproduce with the steps list in issue https://github.com/bbatsov/helm-projectile/issues/154.
The root cause is `helm-while-no-input` will be interrupted from the form-body which loading `tramp-archive` first time.
For more details can refer Emacs bug#47205: http://emacs.1067599.n8.nabble.com/bug-47205-27-1-91-bug-unexpected-input-event-interrupted-expand-file-td531725.html

This patch try to apply the solution for Emacs28+, and workaround for emacs27.

Thanks.