### PR TITLE
* doc/helm-manual-1.org: Update.  Arrange for generating variable, co…

### DIFF
--- a/doc/doc-setup.org
+++ b/doc/doc-setup.org
@@ -28,7 +28,7 @@
 # returns major.minor version number.  This is sufficient since bugfix
 # releases are not expected to add features and therefore imply manual
 # modifications.
-#+macro: version (eval (with-current-buffer (find-file-noselect "../lisp/org.el") (org-with-point-at 1 (if (re-search-forward "Version: +\\([0-9.]+\\)" nil t) (mapconcat #'identity (cl-subseq (split-string (match-string-no-properties 1) "\\.") 0 2) ".") (error "Missing \"Version\" keyword in \"org.el\"")))))
+#+macro: version (eval (with-current-buffer (find-file-noselect "../helm.el") (org-with-point-at 1 (if (re-search-forward "Version: +\\([0-9.]+\\)" nil t) (mapconcat #'identity (cl-subseq (split-string (match-string-no-properties 1) "\\.") 0 3) ".") (error "Missing \"Version\" keyword in \"helm.el\"")))))
 
 # The "kbd" macro turns KBD into @kbd{KBD}.  Additionally, it
 # encloses case-sensitive special keys (SPC, RET...) within @key{...}.

--- a/doc/helm-manual-1.org
+++ b/doc/helm-manual-1.org
@@ -1,12 +1,5 @@
-#+title: The Helm Manual 1
-# #+subtitle:  Release {{{version}}}
-# #+author:    The Org Mode Developers
-# #+date:      {{{modification-time}}}
-#+language:  en
-
-# #+texinfo: @insertcopying
-
 * Table Of Contents                                                   :TOC_4:
+
 - [[#requirements][Requirements]]
 - [[#download][Download]]
 - [[#installation-upgrade-and-configuration][Installation, Upgrade, and Configuration]]
@@ -79,9 +72,9 @@ or
 
 # #+begin_src emacs-lisp
 #  (use-package helm
-# 	      :straight t
-# 	      :config
-# 	      [...])
+#	      :straight t
+#	      :config
+#	      [...])
 # #+end_src
 
 #+begin_src emacs-lisp
@@ -144,6 +137,8 @@ Above steps
 
 - creates an executable called =/usr/local/bin/helm=.  This file is in
   fact a symbolic link to to the script =emacs-helm.sh=.
+
+  #+cindex: emacs-helm.sh
 
 If you want to install =helm= in a path other than =/usr/local/=, pass
 that target path through a =PREFIX= variable.
@@ -269,7 +264,10 @@ one, it is not, helm is much more powerful than that.
 
 Helm is divided in two distinct categories of commands,
 
-- helm natives commands :: these commands are a fresh implementation
+#+cindex: helm native commands
+#+cindex: helmized commands
+
+- *helm natives commands* :: these commands are a fresh implementation
   of an existing Emacs command and enhance them in useful ways.
 
 - *helmized commands* :: these Emacs native commands modified by
@@ -326,9 +324,9 @@ requires:
 * General Helm Commands
 
 #+CAPTION: A typical ~helm-M-x~ with =emacs-helm.sh=
-#+ATTR_HTML: :width 800  
-#+ATTR_ORG: :width 800  
-[[./helm-M-x.png]]  
+#+ATTR_HTML: :width 800
+#+ATTR_ORG: :width 800
+[[./helm-M-x.png]]
 
 Helm's functionality needs only a few general key bindings as shown
 below. These are also documented in the mode line.
@@ -369,11 +367,939 @@ below. These are also documented in the mode line.
 Yank symbol at point from ~helm-current-buffer~ (i.e. buffer where a
 helm command was invoked):
 
-{{{kbd(M-n)}}} copies symbol at point to minibuffer
+# {{{kbd(M-n)}}} copies symbol at point to minibuffer
 
-{{{kbd(C-w)}}} appends word next to point to the minibuffer and advance to next
-word, hitting {{{kbd(C-_)}}} undo last insertion and rewind yank point in
-~helm-current-buffer~
+# {{{kbd(C-w)}}} appends word next to point to the minibuffer and advance to next
+# word, hitting {{{kbd(C-_)}}} undo last insertion and rewind yank point in
+# ~helm-current-buffer~
+
+- {{{kbd(C-w)}}} (~helm-yank-text-at-point~) :: Append word next to
+  point to the minibuffer and advance to next word
+
+   (helm-yank-text-at-point ARG)
+
+   Yank text at point in `helm-current-buffer' into minibuffer.
+
+- {{{kbd(C-_)}}} (~helm-undo-yank-text-at-point~) :: Undo last
+  insertion and rewind yank point in ~helm-current-buffer~
+
+   Undo last entry added by `helm-yank-text-at-point'.
+
+** Commands in keymap ~helm-map~
+
+*** file
+
+ - {{{kbd(C-x C-f)}}} (~helm-quit-and-find-file~) ::
+
+   #+findex: helm-quit-and-find-file @r{(helm-map)}
+
+   #+kindex: C-x C-f @r{(helm-map)}
+
+   Drop into `helm-find-files' from `helm'.
+   If current selection is a buffer or a file, `helm-find-files'
+   from its directory.
+
+*** buffer
+
+ - {{{kbd(M-<)}}} (~helm-beginning-of-buffer~) ::
+
+   #+findex: helm-beginning-of-buffer @r{(helm-map)}
+
+   #+kindex: M-< @r{(helm-map)}
+
+   Move selection at the top.
+
+ - {{{kbd(C-c TAB)}}} (~helm-copy-to-buffer~) ::
+
+   #+findex: helm-copy-to-buffer @r{(helm-map)}
+
+   #+kindex: C-c TAB @r{(helm-map)}
+
+   Copy selection or marked candidates to `helm-current-buffer'.
+   Note that the real values of candidates are copied and not the
+   display values.
+
+ - {{{kbd(M->)}}} (~helm-end-of-buffer~) ::
+
+   #+findex: helm-end-of-buffer @r{(helm-map)}
+
+   #+kindex: M-> @r{(helm-map)}
+
+   Move selection at the bottom.
+
+ - {{{kbd(C-x C-b)}}} (~helm-resume-list-buffers-after-quit~) ::
+
+   #+findex: helm-resume-list-buffers-after-quit @r{(helm-map)}
+
+   #+kindex: C-x C-b @r{(helm-map)}
+
+   List Helm buffers that can be resumed within a running Helm.
+
+*** page
+
+ - {{{kbd(C-v)}}} ::
+ - {{{kbd(<next>)}}} (~helm-next-page~) ::
+
+   #+findex: helm-next-page @r{(helm-map)}
+
+   #+kindex: C-v @r{(helm-map)}
+   #+kindex: <next> @r{(helm-map)}
+
+   Move selection forward with a pageful.
+
+ - {{{kbd(<prior>)}}} ::
+ - {{{kbd(M-v)}}} (~helm-previous-page~) ::
+
+   #+findex: helm-previous-page @r{(helm-map)}
+
+   #+kindex: <prior> @r{(helm-map)}
+   #+kindex: M-v @r{(helm-map)}
+
+   Move selection back with a pageful.
+
+*** line
+
+ - {{{kbd(C-n)}}} ::
+ - {{{kbd(<down>)}}} (~helm-next-line~) ::
+
+   #+findex: helm-next-line @r{(helm-map)}
+
+   #+kindex: C-n @r{(helm-map)}
+   #+kindex: <down> @r{(helm-map)}
+
+   (helm-next-line &optional ARG)
+
+   Move selection to the next ARG line(s).
+   When numeric prefix arg is > than the number of candidates, then
+   move to the last candidate of current source (i.e. don't move to
+   next source).
+
+ - {{{kbd(C-p)}}} ::
+ - {{{kbd(<up>)}}} (~helm-previous-line~) ::
+
+   #+findex: helm-previous-line @r{(helm-map)}
+
+   #+kindex: C-p @r{(helm-map)}
+   #+kindex: <up> @r{(helm-map)}
+
+   (helm-previous-line &optional ARG)
+
+   Move selection to the ARG previous line(s).
+   Same behavior as `helm-next-line' when called with a numeric
+   prefix arg.
+
+ - {{{kbd(C-c >)}}} (~helm-toggle-truncate-line~) ::
+
+   #+findex: helm-toggle-truncate-line @r{(helm-map)}
+
+   #+kindex: C-c > @r{(helm-map)}
+
+   Toggle `truncate-lines' value in `helm-buffer'
+
+*** source
+
+ - {{{kbd(C-M-e)}}} (~helm-display-all-sources~) ::
+
+   #+findex: helm-display-all-sources @r{(helm-map)}
+
+   #+kindex: C-M-e @r{(helm-map)}
+
+   Display all sources previously hidden by `helm-set-source-filter'.
+
+ - {{{kbd(<right>)}}} ::
+ - {{{kbd(C-o)}}} (~helm-next-source~) ::
+
+   #+findex: helm-next-source @r{(helm-map)}
+
+   #+kindex: <right> @r{(helm-map)}
+   #+kindex: C-o @r{(helm-map)}
+
+   Move selection to the next source.
+
+ - {{{kbd(<left>)}}} ::
+ - {{{kbd(M-o)}}} (~helm-previous-source~) ::
+
+   #+findex: helm-previous-source @r{(helm-map)}
+
+   #+kindex: <left> @r{(helm-map)}
+   #+kindex: M-o @r{(helm-map)}
+
+   Move selection to the previous source.
+
+ - {{{kbd(C-M-a)}}} (~helm-show-all-candidates-in-source~) ::
+
+   #+findex: helm-show-all-candidates-in-source @r{(helm-map)}
+
+   #+kindex: C-M-a @r{(helm-map)}
+
+   (helm-show-all-candidates-in-source ARG)
+
+   Toggle all or only candidate-number-limit cands in current source.
+   With a numeric prefix arg show only the ARG number of candidates.
+   The prefix arg has no effect when toggling to only
+   candidate-number-limit.
+
+*** minibuffer
+
+ - {{{kbd(nil)}}} (~abort-minibuffers~) ::
+
+   #+findex: abort-minibuffers @r{(helm-map)}
+
+   (abort-minibuffers)
+
+   Abort the current minibuffer.
+   If we are not currently in the innermost minibuffer, prompt the user to
+   confirm the aborting of the current minibuffer and all contained ones.
+
+ - {{{kbd(nil)}}} (~exit-minibuffer~) ::
+
+   #+findex: exit-minibuffer @r{(helm-map)}
+
+   Terminate this minibuffer argument.
+
+ - {{{kbd(nil)}}} (~file-cache-minibuffer-complete~) ::
+
+   #+findex: file-cache-minibuffer-complete @r{(helm-map)}
+
+   (file-cache-minibuffer-complete ARG)
+
+   Complete a filename in the minibuffer using a preloaded cache.
+   Filecache does two kinds of substitution: it completes on names in
+   the cache, and, once it has found a unique name, it cycles through
+   the directories that the name is available in.  With a prefix argument,
+   the name is considered already unique; only the second substitution
+   (directories) is done.
+
+ - {{{kbd(C-k)}}} (~helm-delete-minibuffer-contents~) ::
+
+   #+findex: helm-delete-minibuffer-contents @r{(helm-map)}
+
+   #+kindex: C-k @r{(helm-map)}
+
+   (helm-delete-minibuffer-contents &optional ARG)
+
+   Delete minibuffer contents.
+   When `helm-delete-minibuffer-contents-from-point' is non-nil,
+   delete minibuffer contents from point instead of deleting all.
+   With a prefix arg reverse this behaviour.  When at the end of
+   minibuffer, delete all.
+
+ - {{{kbd(C-c %)}}} (~helm-exchange-minibuffer-and-header-line~) ::
+
+   #+findex: helm-exchange-minibuffer-and-header-line @r{(helm-map)}
+
+   #+kindex: C-c % @r{(helm-map)}
+
+   Display minibuffer in header-line and vice versa for current Helm session.
+
+   This is a toggle command.
+
+ - {{{kbd(RET)}}} (~helm-maybe-exit-minibuffer~) ::
+
+   #+findex: helm-maybe-exit-minibuffer @r{(helm-map)}
+
+   #+kindex: RET @r{(helm-map)}
+
+ - {{{kbd(nil)}}} (~minibuffer-beginning-of-buffer~) ::
+
+   #+findex: minibuffer-beginning-of-buffer @r{(helm-map)}
+
+   (minibuffer-beginning-of-buffer &optional ARG)
+
+   Move to the logical beginning of the minibuffer.
+   This command behaves like `beginning-of-buffer', but if point is
+   after the end of the prompt, move to the end of the prompt.
+   Otherwise move to the start of the buffer.
+
+*** history
+
+ - {{{kbd(C-r)}}} (~helm-minibuffer-history~) ::
+
+   #+findex: helm-minibuffer-history @r{(helm-map)}
+
+   #+kindex: C-r @r{(helm-map)}
+
+   Preconfigured `helm' for `minibuffer-history'.
+
+ - {{{kbd(<XF86Forward>)}}} ::
+ - {{{kbd(M-n)}}} (~next-history-element~) ::
+
+   #+findex: next-history-element @r{(helm-map)}
+
+   #+kindex: <XF86Forward> @r{(helm-map)}
+   #+kindex: M-n @r{(helm-map)}
+
+   (next-history-element N)
+
+   Puts next element of the minibuffer history in the minibuffer.
+   With argument N, it uses the Nth following element.  The position
+   in the history can go beyond the current position and invoke "future
+   history."
+
+ - {{{kbd(nil)}}} (~next-line-or-history-element~) ::
+
+   #+findex: next-line-or-history-element @r{(helm-map)}
+
+   (next-line-or-history-element &optional ARG)
+
+   Move cursor vertically down ARG lines, or to the next history element.
+   When point moves over the bottom line of multi-line minibuffer, puts ARGth
+   next element of the minibuffer history in the minibuffer.
+
+ - {{{kbd(nil)}}} (~next-matching-history-element~) ::
+
+   #+findex: next-matching-history-element @r{(helm-map)}
+
+   (next-matching-history-element REGEXP N)
+
+   Find the next history element that matches REGEXP.
+   (The next history element refers to a more recent action.)
+   With prefix argument N, search for Nth next match.
+   If N is negative, find the previous or Nth previous match.
+   Normally, history elements are matched case-insensitively if
+   `case-fold-search' is non-nil, but an uppercase letter in REGEXP
+   makes the search case-sensitive.
+
+ - {{{kbd(<XF86Back>)}}} ::
+ - {{{kbd(M-p)}}} (~previous-history-element~) ::
+
+   #+findex: previous-history-element @r{(helm-map)}
+
+   #+kindex: <XF86Back> @r{(helm-map)}
+   #+kindex: M-p @r{(helm-map)}
+
+   (previous-history-element N)
+
+   Puts previous element of the minibuffer history in the minibuffer.
+   With argument N, it uses the Nth previous element.
+
+ - {{{kbd(nil)}}} (~previous-line-or-history-element~) ::
+
+   #+findex: previous-line-or-history-element @r{(helm-map)}
+
+   (previous-line-or-history-element &optional ARG)
+
+   Move cursor vertically up ARG lines, or to the previous history element.
+   When point moves over the top line of multi-line minibuffer, puts ARGth
+   previous element of the minibuffer history in the minibuffer.
+
+ - {{{kbd(M-r)}}} (~previous-matching-history-element~) ::
+
+   #+findex: previous-matching-history-element @r{(helm-map)}
+
+   #+kindex: M-r @r{(helm-map)}
+
+   (previous-matching-history-element REGEXP N)
+
+   Find the previous history element that matches REGEXP.
+   (Previous history elements refer to earlier actions.)
+   With prefix argument N, search for Nth previous match.
+   If N is negative, find the next or Nth next match.
+   Normally, history elements are matched case-insensitively if
+   `case-fold-search' is non-nil, but an uppercase letter in REGEXP
+   makes the search case-sensitive.
+   See also `minibuffer-history-case-insensitive-variables'.
+
+*** mark
+
+ - {{{kbd(M-a)}}} (~helm-mark-all~) ::
+
+   #+findex: helm-mark-all @r{(helm-map)}
+
+   #+kindex: M-a @r{(helm-map)}
+
+   (helm-mark-all &optional ALL)
+
+   Mark all visible unmarked candidates in current source.
+
+   With a prefix arg mark all visible unmarked candidates in all
+   sources.
+
+ - {{{kbd(M-))}}} (~helm-next-visible-mark~) ::
+
+   #+findex: helm-next-visible-mark @r{(helm-map)}
+
+   #+kindex: M-) @r{(helm-map)}
+
+   (helm-next-visible-mark &optional PREV)
+
+   Move next Helm visible mark.
+   If PREV is non-nil move to precedent.
+
+ - {{{kbd(M-()}}} (~helm-prev-visible-mark~) ::
+
+   #+findex: helm-prev-visible-mark @r{(helm-map)}
+
+   #+kindex: M-( @r{(helm-map)}
+
+   Move previous helm visible mark.
+
+ - {{{kbd(M-m)}}} (~helm-toggle-all-marks~) ::
+
+   #+findex: helm-toggle-all-marks @r{(helm-map)}
+
+   #+kindex: M-m @r{(helm-map)}
+
+   (helm-toggle-all-marks &optional ALL)
+
+   Toggle all marks.
+
+   Mark all visible candidates of current source or unmark all
+   candidates visible or invisible in all sources of current Helm
+   session.
+
+   With a prefix argument mark all candidates in all sources.
+
+ - {{{kbd(C-@)}}} (~helm-toggle-visible-mark~) ::
+
+   #+findex: helm-toggle-visible-mark @r{(helm-map)}
+
+   #+kindex: C-@ @r{(helm-map)}
+
+   (helm-toggle-visible-mark ARG)
+
+   Toggle Helm visible mark at point ARG times.
+   If ARG is negative toggle backward.
+
+ - {{{kbd(M-SPC)}}} (~helm-toggle-visible-mark-backward~) ::
+
+   #+findex: helm-toggle-visible-mark-backward @r{(helm-map)}
+
+   #+kindex: M-SPC @r{(helm-map)}
+
+ - {{{kbd(C-SPC)}}} (~helm-toggle-visible-mark-forward~) ::
+
+   #+findex: helm-toggle-visible-mark-forward @r{(helm-map)}
+
+   #+kindex: C-SPC @r{(helm-map)}
+
+ - {{{kbd(M-U)}}} (~helm-unmark-all~) ::
+
+   #+findex: helm-unmark-all @r{(helm-map)}
+
+   #+kindex: M-U @r{(helm-map)}
+
+   Unmark all candidates in all sources of current helm session.
+
+*** window
+
+ # - {{{kbd(C-{)}}} (~helm-enlarge-window~) ::
+
+ #   #+findex: helm-enlarge-window @r{(helm-map)}
+
+ #   #+kindex: C-{ @r{(helm-map)}
+
+ #   Enlarge helm window.
+
+ # - {{{kbd(C-})}}} (~helm-narrow-window~) ::
+
+ #   #+findex: helm-narrow-window @r{(helm-map)}
+
+ #   #+kindex: C-} @r{(helm-map)}
+
+ #   Narrow helm window.
+
+ - {{{kbd(C-l)}}} (~helm-recenter-top-bottom-other-window~) ::
+
+   #+findex: helm-recenter-top-bottom-other-window @r{(helm-map)}
+
+   #+kindex: C-l @r{(helm-map)}
+
+   (helm-recenter-top-bottom-other-window &optional ARG)
+
+   Run `recenter-top-bottom' in other window.
+   Meaning of prefix ARG is the same as in `recenter-top-bottom'.
+
+ - {{{kbd(C-M-l)}}} (~helm-reposition-window-other-window~) ::
+
+   #+findex: helm-reposition-window-other-window @r{(helm-map)}
+
+   #+kindex: C-M-l @r{(helm-map)}
+
+   (helm-reposition-window-other-window &optional ARG)
+
+   Run `reposition-window' in other window.
+   Meaning of prefix ARG is the same as in `reposition-window'.
+
+ - {{{kbd(C-M-<down>)}}} ::
+ - {{{kbd(M-<next>)}}} ::
+ - {{{kbd(C-M-v)}}} (~helm-scroll-other-window~) ::
+
+   #+findex: helm-scroll-other-window @r{(helm-map)}
+
+   #+kindex: C-M-<down> @r{(helm-map)}
+   #+kindex: M-<next> @r{(helm-map)}
+   #+kindex: C-M-v @r{(helm-map)}
+
+   (helm-scroll-other-window &optional ARG)
+
+   Scroll other window upward ARG many lines.
+   When arg is not provided scroll `helm-scroll-amount' lines.
+   See `scroll-other-window'.
+
+ - {{{kbd(C-M-<up>)}}} ::
+ - {{{kbd(M-<prior>)}}} ::
+ - {{{kbd(C-M-S-v)}}} ::
+ - {{{kbd(C-M-y)}}} (~helm-scroll-other-window-down~) ::
+
+   #+findex: helm-scroll-other-window-down @r{(helm-map)}
+
+   #+kindex: C-M-<up> @r{(helm-map)}
+   #+kindex: M-<prior> @r{(helm-map)}
+   #+kindex: C-M-S-v @r{(helm-map)}
+   #+kindex: C-M-y @r{(helm-map)}
+
+   (helm-scroll-other-window-down &optional ARG)
+
+   Scroll other window downward ARG many lines.
+   When arg is not provided scroll `helm-scroll-amount' lines.
+   See `scroll-other-window-down'.
+
+ - {{{kbd(C-c -)}}} (~helm-swap-windows~) ::
+
+   #+findex: helm-swap-windows @r{(helm-map)}
+
+   #+kindex: C-c - @r{(helm-map)}
+
+   Swap window holding `helm-buffer' with other window.
+
+ - {{{kbd(C-t)}}} (~helm-toggle-resplit-and-swap-windows~) ::
+
+   #+findex: helm-toggle-resplit-and-swap-windows @r{(helm-map)}
+
+   #+kindex: C-t @r{(helm-map)}
+
+   Multi key command to re-split and swap Helm window.
+   First call runs `helm-toggle-resplit-window',
+   and second call within 1s runs `helm-swap-windows'.
+
+*** action
+
+ - {{{kbd(C-j)}}} (~helm-execute-persistent-action~) ::
+
+   #+findex: helm-execute-persistent-action @r{(helm-map)}
+
+   #+kindex: C-j @r{(helm-map)}
+
+   (helm-execute-persistent-action &optional ATTR SPLIT)
+
+   Perform the associated action ATTR without quitting helm.
+
+   Arg ATTR default will be `persistent-action' or
+   `persistent-action-if' if unspecified depending on what's found
+   in source, but it can be anything else.
+   In this case you have to add this new attribute to your source.
+   See `persistent-action' and `persistent-action-if' slot
+   documentation in `helm-source'.
+
+   When `helm-full-frame' is non-nil, and `helm-buffer' is displayed
+   in only one window, the helm window is split to display
+   `helm-select-persistent-action-window' in other window to
+   maintain visibility.  The argument SPLIT can be used to force
+   splitting inconditionally, it is unused actually.
+
+ - {{{kbd(C-<up>)}}} (~helm-follow-action-backward~) ::
+
+   #+findex: helm-follow-action-backward @r{(helm-map)}
+
+   #+kindex: C-<up> @r{(helm-map)}
+
+   Go to previous line and execute persistent action.
+
+ - {{{kbd(C-<down>)}}} (~helm-follow-action-forward~) ::
+
+   #+findex: helm-follow-action-forward @r{(helm-map)}
+
+   #+kindex: C-<down> @r{(helm-map)}
+
+   Go to next line and execute persistent action.
+
+ - {{{kbd(TAB)}}} (~helm-select-action~) ::
+
+   #+findex: helm-select-action @r{(helm-map)}
+
+   #+kindex: TAB @r{(helm-map)}
+
+   Select an action for the currently selected candidate.
+   If action buffer is selected, back to the Helm buffer.
+
+*** COMMENT nth
+
+ - {{{kbd(C-x 1)}}} (~helm-execute-selection-action-at-nth-+1~) ::
+
+   #+findex: helm-execute-selection-action-at-nth-+1 @r{(helm-map)}
+
+   #+kindex: C-x 1 @r{(helm-map)}
+
+ - {{{kbd(C-c 1)}}} (~helm-execute-selection-action-at-nth-+1~) ::
+
+   #+findex: helm-execute-selection-action-at-nth-+1 @r{(helm-map)}
+
+   #+kindex: C-c 1 @r{(helm-map)}
+
+ - {{{kbd(C-x 2)}}} (~helm-execute-selection-action-at-nth-+2~) ::
+
+   #+findex: helm-execute-selection-action-at-nth-+2 @r{(helm-map)}
+
+   #+kindex: C-x 2 @r{(helm-map)}
+
+ - {{{kbd(C-c 2)}}} (~helm-execute-selection-action-at-nth-+2~) ::
+
+   #+findex: helm-execute-selection-action-at-nth-+2 @r{(helm-map)}
+
+   #+kindex: C-c 2 @r{(helm-map)}
+
+ - {{{kbd(C-x 3)}}} (~helm-execute-selection-action-at-nth-+3~) ::
+
+   #+findex: helm-execute-selection-action-at-nth-+3 @r{(helm-map)}
+
+   #+kindex: C-x 3 @r{(helm-map)}
+
+ - {{{kbd(C-c 3)}}} (~helm-execute-selection-action-at-nth-+3~) ::
+
+   #+findex: helm-execute-selection-action-at-nth-+3 @r{(helm-map)}
+
+   #+kindex: C-c 3 @r{(helm-map)}
+
+ - {{{kbd(C-x 4)}}} (~helm-execute-selection-action-at-nth-+4~) ::
+
+   #+findex: helm-execute-selection-action-at-nth-+4 @r{(helm-map)}
+
+   #+kindex: C-x 4 @r{(helm-map)}
+
+ - {{{kbd(C-c 4)}}} (~helm-execute-selection-action-at-nth-+4~) ::
+
+   #+findex: helm-execute-selection-action-at-nth-+4 @r{(helm-map)}
+
+   #+kindex: C-c 4 @r{(helm-map)}
+
+ - {{{kbd(C-x 5)}}} (~helm-execute-selection-action-at-nth-+5~) ::
+
+   #+findex: helm-execute-selection-action-at-nth-+5 @r{(helm-map)}
+
+   #+kindex: C-x 5 @r{(helm-map)}
+
+ - {{{kbd(C-c 5)}}} (~helm-execute-selection-action-at-nth-+5~) ::
+
+   #+findex: helm-execute-selection-action-at-nth-+5 @r{(helm-map)}
+
+   #+kindex: C-c 5 @r{(helm-map)}
+
+ - {{{kbd(C-x 6)}}} (~helm-execute-selection-action-at-nth-+6~) ::
+
+   #+findex: helm-execute-selection-action-at-nth-+6 @r{(helm-map)}
+
+   #+kindex: C-x 6 @r{(helm-map)}
+
+ - {{{kbd(C-c 6)}}} (~helm-execute-selection-action-at-nth-+6~) ::
+
+   #+findex: helm-execute-selection-action-at-nth-+6 @r{(helm-map)}
+
+   #+kindex: C-c 6 @r{(helm-map)}
+
+ - {{{kbd(C-x 7)}}} (~helm-execute-selection-action-at-nth-+7~) ::
+
+   #+findex: helm-execute-selection-action-at-nth-+7 @r{(helm-map)}
+
+   #+kindex: C-x 7 @r{(helm-map)}
+
+ - {{{kbd(C-c 7)}}} (~helm-execute-selection-action-at-nth-+7~) ::
+
+   #+findex: helm-execute-selection-action-at-nth-+7 @r{(helm-map)}
+
+   #+kindex: C-c 7 @r{(helm-map)}
+
+ - {{{kbd(C-x 8)}}} (~helm-execute-selection-action-at-nth-+8~) ::
+
+   #+findex: helm-execute-selection-action-at-nth-+8 @r{(helm-map)}
+
+   #+kindex: C-x 8 @r{(helm-map)}
+
+ - {{{kbd(C-c 8)}}} (~helm-execute-selection-action-at-nth-+8~) ::
+
+   #+findex: helm-execute-selection-action-at-nth-+8 @r{(helm-map)}
+
+   #+kindex: C-c 8 @r{(helm-map)}
+
+ - {{{kbd(C-x 9)}}} (~helm-execute-selection-action-at-nth-+9~) ::
+
+   #+findex: helm-execute-selection-action-at-nth-+9 @r{(helm-map)}
+
+   #+kindex: C-x 9 @r{(helm-map)}
+
+ - {{{kbd(C-c 9)}}} (~helm-execute-selection-action-at-nth-+9~) ::
+
+   #+findex: helm-execute-selection-action-at-nth-+9 @r{(helm-map)}
+
+   #+kindex: C-c 9 @r{(helm-map)}
+
+*** COMMENT lambda-p
+
+ - {{{kbd(<f1>)}}} (~(lambda nil (interactive) (helm-select-nth-action 0))~) ::
+
+   #+findex: (lambda nil (interactive) (helm-select-nth-action 0)) @r{(helm-map)}
+
+   #+kindex: <f1> @r{(helm-map)}
+
+ - {{{kbd(<f2>)}}} (~(lambda nil (interactive) (helm-select-nth-action 1))~) ::
+
+   #+findex: (lambda nil (interactive) (helm-select-nth-action 1)) @r{(helm-map)}
+
+   #+kindex: <f2> @r{(helm-map)}
+
+ - {{{kbd(<f11>)}}} (~(lambda nil (interactive) (helm-select-nth-action 10))~) ::
+
+   #+findex: (lambda nil (interactive) (helm-select-nth-action 10)) @r{(helm-map)}
+
+   #+kindex: <f11> @r{(helm-map)}
+
+ - {{{kbd(<f12>)}}} (~(lambda nil (interactive) (helm-select-nth-action 11))~) ::
+
+   #+findex: (lambda nil (interactive) (helm-select-nth-action 11)) @r{(helm-map)}
+
+   #+kindex: <f12> @r{(helm-map)}
+
+ - {{{kbd(<f13>)}}} (~(lambda nil (interactive) (helm-select-nth-action 12))~) ::
+
+   #+findex: (lambda nil (interactive) (helm-select-nth-action 12)) @r{(helm-map)}
+
+   #+kindex: <f13> @r{(helm-map)}
+
+ - {{{kbd(<f3>)}}} (~(lambda nil (interactive) (helm-select-nth-action 2))~) ::
+
+   #+findex: (lambda nil (interactive) (helm-select-nth-action 2)) @r{(helm-map)}
+
+   #+kindex: <f3> @r{(helm-map)}
+
+ - {{{kbd(<f4>)}}} (~(lambda nil (interactive) (helm-select-nth-action 3))~) ::
+
+   #+findex: (lambda nil (interactive) (helm-select-nth-action 3)) @r{(helm-map)}
+
+   #+kindex: <f4> @r{(helm-map)}
+
+ - {{{kbd(<f5>)}}} (~(lambda nil (interactive) (helm-select-nth-action 4))~) ::
+
+   #+findex: (lambda nil (interactive) (helm-select-nth-action 4)) @r{(helm-map)}
+
+   #+kindex: <f5> @r{(helm-map)}
+
+ - {{{kbd(<f6>)}}} (~(lambda nil (interactive) (helm-select-nth-action 5))~) ::
+
+   #+findex: (lambda nil (interactive) (helm-select-nth-action 5)) @r{(helm-map)}
+
+   #+kindex: <f6> @r{(helm-map)}
+
+ - {{{kbd(<f7>)}}} (~(lambda nil (interactive) (helm-select-nth-action 6))~) ::
+
+   #+findex: (lambda nil (interactive) (helm-select-nth-action 6)) @r{(helm-map)}
+
+   #+kindex: <f7> @r{(helm-map)}
+
+ - {{{kbd(<f8>)}}} (~(lambda nil (interactive) (helm-select-nth-action 7))~) ::
+
+   #+findex: (lambda nil (interactive) (helm-select-nth-action 7)) @r{(helm-map)}
+
+   #+kindex: <f8> @r{(helm-map)}
+
+ - {{{kbd(<f9>)}}} (~(lambda nil (interactive) (helm-select-nth-action 8))~) ::
+
+   #+findex: (lambda nil (interactive) (helm-select-nth-action 8)) @r{(helm-map)}
+
+   #+kindex: <f9> @r{(helm-map)}
+
+ - {{{kbd(<f10>)}}} (~(lambda nil (interactive) (helm-select-nth-action 9))~) ::
+
+   #+findex: (lambda nil (interactive) (helm-select-nth-action 9)) @r{(helm-map)}
+
+   #+kindex: <f10> @r{(helm-map)}
+
+*** other-mode-p
+
+*** minor-mode-p
+
+ - {{{kbd(C-c l)}}} (~helm-display-line-numbers-mode~) ::
+
+   #+findex: helm-display-line-numbers-mode @r{(helm-map)}
+
+   #+kindex: C-c l @r{(helm-map)}
+
+   (helm-display-line-numbers-mode &optional ARG)
+
+   Toggle display of line numbers in current Helm buffer.
+
+   If called interactively, toggle `Helm-Display-Line-Numbers mode'.
+   If the prefix argument is positive, enable the mode, and if it is
+   zero or negative, disable the mode.
+
+   If called from Lisp, toggle the mode if ARG is `toggle'.  Enable
+   the mode if ARG is nil, omitted, or is a positive number.
+   Disable the mode if ARG is a negative number.
+
+   The mode's hook is called both when the mode is enabled and when
+   it is disabled.
+
+ - {{{kbd(C-c C-f)}}} (~helm-follow-mode~) ::
+
+   #+findex: helm-follow-mode @r{(helm-map)}
+
+   #+kindex: C-c C-f @r{(helm-map)}
+
+   (helm-follow-mode &optional ARG)
+
+   Execute persistent action every time the cursor is moved.
+
+   This mode is source local, i.e. It applies on current source only.
+   \<helm-map>
+   This mode can be enabled or disabled interactively at anytime during
+   a helm session with \[helm-follow-mode].
+
+   When enabling interactively `helm-follow-mode' in a source, you
+   can keep it enabled for next Emacs sessions by setting
+   `helm-follow-mode-persistent' to a non-nil value.
+
+   When `helm-follow-mode' is called with a prefix arg and
+   `helm-follow-mode-persistent' is non-nil `helm-follow-mode' will
+   be persistent only for this Emacs session, but not for the next
+   Emacs sessions, i.e. the current source will not be saved to
+   `helm-source-names-using-follow'.
+
+   A prefix arg with `helm-follow-mode' already enabled will have no
+   effect.
+
+   Note that you can use instead of this mode the commands
+   `helm-follow-action-forward' and `helm-follow-action-backward' at
+   anytime in all Helm sessions.
+
+   They are bound by default to \[helm-follow-action-forward] and
+   \[helm-follow-action-backward].
+
+*** uncategorized
+
+ - {{{kbd(nil)}}} (~ezmenu-byte-code-function~) ::
+
+   #+findex: ezmenu-byte-code-function @r{(helm-map)}
+
+ - {{{kbd(C-h c)}}} (~helm-customize-group~) ::
+
+   #+findex: helm-customize-group @r{(helm-map)}
+
+   #+kindex: C-h c @r{(helm-map)}
+
+   Jump to customization group of current source.
+
+   Default to Helm group when group is not defined in source.
+
+ - {{{kbd(C-h C-d)}}} (~helm-enable-or-switch-to-debug~) ::
+
+   #+findex: helm-enable-or-switch-to-debug @r{(helm-map)}
+
+   #+kindex: C-h C-d @r{(helm-map)}
+
+   First hit enable helm debugging, second hit switch to debug buffer.
+
+ - {{{kbd(<help> m)}}} ::
+ - {{{kbd(C-h m)}}} ::
+ - {{{kbd(C-c ?)}}} (~helm-help~) ::
+
+   #+findex: helm-help @r{(helm-map)}
+
+   #+kindex: <help> m @r{(helm-map)}
+   #+kindex: C-h m @r{(helm-map)}
+   #+kindex: C-c ? @r{(helm-map)}
+
+   Generate Helm's help according to `help-message' attribute.
+
+   If `helm-buffer' is empty, provide completions on `helm-sources'
+   to choose its local documentation.
+   If source doesn't have any `help-message' attribute, a generic
+   message explaining this is added instead.
+   The global `helm-help-message' is always added after this local
+   help.
+
+ - {{{kbd(C-g)}}} (~helm-keyboard-quit~) ::
+
+   #+findex: helm-keyboard-quit @r{(helm-map)}
+
+   #+kindex: C-g @r{(helm-map)}
+
+   Quit minibuffer in helm.
+   If action buffer is displayed, kill it.
+
+ - {{{kbd(C-c C-k)}}} (~helm-kill-selection-and-quit~) ::
+
+   #+findex: helm-kill-selection-and-quit @r{(helm-map)}
+
+   #+kindex: C-c C-k @r{(helm-map)}
+
+   (helm-kill-selection-and-quit ARG)
+
+   Store display value of current selection to kill ring.
+   With a prefix arg use real value of current selection.
+   Display value is shown in `helm-buffer' and real value is used to
+   perform actions.
+
+ - {{{kbd(C-c C-u)}}} (~helm-refresh~) ::
+
+   #+findex: helm-refresh @r{(helm-map)}
+
+   #+kindex: C-c C-u @r{(helm-map)}
+
+   Force recalculation and update of candidates.
+
+ - {{{kbd(C-x b)}}} (~helm-resume-previous-session-after-quit~) ::
+
+   #+findex: helm-resume-previous-session-after-quit @r{(helm-map)}
+
+   #+kindex: C-x b @r{(helm-map)}
+
+   Resume previous Helm session within a running Helm.
+
+ - {{{kbd(C-c _)}}} (~helm-toggle-full-frame~) ::
+
+   #+findex: helm-toggle-full-frame @r{(helm-map)}
+
+   #+kindex: C-c _ @r{(helm-map)}
+
+   (helm-toggle-full-frame &optional ARG)
+
+   Toggle `helm-buffer' full-frame view.
+
+ - {{{kbd(C-!)}}} (~helm-toggle-suspend-update~) ::
+
+   #+findex: helm-toggle-suspend-update @r{(helm-map)}
+
+   #+kindex: C-! @r{(helm-map)}
+
+   Enable or disable display update in helm.
+   This can be useful for example for quietly writing a complex
+   regexp without Helm constantly updating.
+
+ - {{{kbd(C-c C-y)}}} (~helm-yank-selection~) ::
+
+   #+findex: helm-yank-selection @r{(helm-map)}
+
+   #+kindex: C-c C-y @r{(helm-map)}
+
+   (helm-yank-selection ARG)
+
+   Set minibuffer contents to current display selection.
+   With a prefix arg set to real value of current selection.
+
+ - {{{kbd(C-<tab>)}}} ::
+ - {{{kbd(C-s)}}} ::
+ - {{{kbd(C-h h)}}} ::
+ - {{{kbd(C-h C-h)}}} ::
+ - {{{kbd(M-s)}}} (~undefined~) ::
+
+   #+findex: undefined @r{(helm-map)}
+
+   #+kindex: C-<tab> @r{(helm-map)}
+   #+kindex: C-s @r{(helm-map)}
+   #+kindex: C-h h @r{(helm-map)}
+   #+kindex: C-h C-h @r{(helm-map)}
+   #+kindex: M-s @r{(helm-map)}
+
+   Beep to tell the user this binding is undefined.
 
 *  Preconfigured Helm Commands
 
@@ -381,7 +1307,23 @@ Invoke {{{kbd(M-x helm-M-x RET)}}} and type =helm= to discover Helm
 commands.  The =Menu Bar -> Helm= menu item is another way to discover
 helm commands.
 
-#+vindex: helm-command-prefix-key
+- ~helm-command-prefix-key~ ::
+
+  #+vindex: helm-command-prefix-key
+
+  *Standard Value*: "C-x c"
+
+  The key ‘helm-command-prefix’ is bound to in the global map.
+
+- ~helm-minibuffer-history-key~ ::
+
+  #+vindex: helm-minibuffer-history-key
+
+  *Standard Value*: "C-r"
+
+  The key ‘helm-minibuffer-history’ is bound to in minibuffer local maps.
+
+# #+vindex: helm-command-prefix-key
 ~helm-command-prefix-key~ (default value {{{kbd(C-x c)}}}) is the
 prefix for the preconfigured helm menu.
 
@@ -403,6 +1345,540 @@ following to your init file.
 #+begin_src emacs-lisp
   (global-set-key (kbd "M-x") 'helm-M-x)
 #+end_src
+
+** List of Preconfigured Helm Commands
+
+# Commands in keymap ~helm-command-map~
+
+Commands in keymap ~helm-command-map~ (excludes parent-keymap)
+
+*** Emacs Commands
+
+ - {{{kbd(M-x)}}} ::
+ - {{{kbd(C-x c M-x)}}} (~helm-M-x~) ::
+
+   #+findex: helm-M-x @r{(helm-command-map)}
+
+   #+kindex: M-x @r{(helm-command-map)}
+   #+kindex: C-x c M-x @r{(helm-command-map)}
+
+   (helm-M-x ARG)
+
+   Preconfigured `helm' for Emacs commands.
+   It is `helm' replacement of regular `M-x'
+   `execute-extended-command'.
+
+   Unlike regular `M-x' Emacs vanilla `execute-extended-command'
+   command, the prefix args if needed, can be passed AFTER starting
+   `helm-M-x'.  When a prefix arg is passed BEFORE starting
+   `helm-M-x', the first `C-u' while in `helm-M-x' session will
+   disable it.
+
+   You can get help on each command by persistent action.
+
+*** Listing Buffers
+
+ - {{{kbd(C-x C-b)}}} ::
+ - {{{kbd(C-x c C-x C-b)}}} (~helm-buffers-list~) ::
+
+   #+findex: helm-buffers-list @r{(helm-command-map)}
+
+   #+kindex: C-x C-b @r{(helm-command-map)}
+   #+kindex: C-x c C-x C-b @r{(helm-command-map)}
+
+   Preconfigured `helm' to list buffers.
+
+*** Finding Files
+
+ - {{{kbd(C-x C-f)}}} ::
+ - {{{kbd(C-x c C-x C-f)}}} (~helm-find-files~) ::
+
+   #+findex: helm-find-files @r{(helm-command-map)}
+
+   #+kindex: C-x C-f @r{(helm-command-map)}
+   #+kindex: C-x c C-x C-f @r{(helm-command-map)}
+
+   (helm-find-files ARG)
+
+   Preconfigured `helm' for helm implementation of `find-file'.
+   Called with a prefix arg show history if some.
+   Don't call it from programs, use `helm-find-files-1' instead.
+   This is the starting point for nearly all actions you can do on
+   files.
+
+ - {{{kbd(f)}}} ::
+ - {{{kbd(C-x c f)}}} (~helm-multi-files~) ::
+
+   #+findex: helm-multi-files @r{(helm-command-map)}
+
+   #+kindex: f @r{(helm-command-map)}
+   #+kindex: C-x c f @r{(helm-command-map)}
+
+   Preconfigured helm like `helm-for-files' but running locate only on demand.
+
+   Allow toggling back and forth from locate to others sources with
+   `helm-multi-files-toggle-locate-binding' key.
+   This avoids launching locate needlessly when what you are
+   searching for is already found.
+
+ - {{{kbd(C-c f)}}} ::
+ - {{{kbd(C-x c C-c f)}}} (~helm-recentf~) ::
+
+   #+findex: helm-recentf @r{(helm-command-map)}
+
+   #+kindex: C-c f @r{(helm-command-map)}
+   #+kindex: C-x c C-c f @r{(helm-command-map)}
+
+   Preconfigured `helm' for `recentf'.
+
+*** Locating Files
+
+ - {{{kbd(/)}}} ::
+ - {{{kbd(C-x c /)}}} (~helm-find~) ::
+
+   #+findex: helm-find @r{(helm-command-map)}
+
+   #+kindex: / @r{(helm-command-map)}
+   #+kindex: C-x c / @r{(helm-command-map)}
+
+   (helm-find ARG)
+
+   Preconfigured `helm' for the find shell command.
+
+   Recursively find files whose names are matched by all specified
+   globbing PATTERNs under the current directory using the external
+   program specified in `find-program' (usually "find").  Every
+   input PATTERN is silently wrapped into two stars: *PATTERN*.
+
+   With prefix argument, prompt for a directory to search.
+
+   When user option `helm-findutils-search-full-path' is non-nil,
+   match against complete paths, otherwise, against file names
+   without directory part.
+
+   The (possibly empty) list of globbing PATTERNs can be followed by
+   the separator "*" plus any number of additional arguments that
+   are passed to "find" literally.
+
+ - {{{kbd(l)}}} ::
+ - {{{kbd(C-x c l)}}} (~helm-locate~) ::
+
+   #+findex: helm-locate @r{(helm-command-map)}
+
+   #+kindex: l @r{(helm-command-map)}
+   #+kindex: C-x c l @r{(helm-command-map)}
+
+   (helm-locate ARG)
+
+   Preconfigured `helm' for Locate.
+   Note: you can add locate options after entering pattern.
+   See 'man locate' for valid options and also `helm-locate-command'.
+
+   You can specify a local database with prefix argument ARG.
+   With two prefix arg, refresh the current local db or create it if
+   it doesn't exists.
+
+   To create a user specific db, use
+   "updatedb -l 0 -o db_path -U directory".
+   Where db_path is a filename matched by
+   `helm-locate-db-file-regexp'.
+
+*** Editing
+
+ - {{{kbd(C-c SPC)}}} ::
+ - {{{kbd(C-x c C-c SPC)}}} (~helm-all-mark-rings~) ::
+
+   #+findex: helm-all-mark-rings @r{(helm-command-map)}
+
+   #+kindex: C-c SPC @r{(helm-command-map)}
+   #+kindex: C-x c C-c SPC @r{(helm-command-map)}
+
+   Preconfigured `helm' for `helm-source-global-mark-ring' and
+   `helm-source-mark-ring'.
+
+ - {{{kbd(M-y)}}} ::
+ - {{{kbd(C-x c M-y)}}} (~helm-show-kill-ring~) ::
+
+   #+findex: helm-show-kill-ring @r{(helm-command-map)}
+
+   #+kindex: M-y @r{(helm-command-map)}
+   #+kindex: C-x c M-y @r{(helm-command-map)}
+
+   Preconfigured `helm' for `kill-ring'.
+   It is drop-in replacement of `yank-pop'.
+
+   First call open the kill-ring browser, next calls move to next line.
+
+ - {{{kbd(C-x r i)}}} ::
+ - {{{kbd(C-x c C-x r i)}}} (~helm-register~) ::
+
+   #+findex: helm-register @r{(helm-command-map)}
+
+   #+kindex: C-x r i @r{(helm-command-map)}
+   #+kindex: C-x c C-x r i @r{(helm-command-map)}
+
+   Preconfigured `helm' for Emacs registers.
+
+*** Grepping etc.
+
+ - {{{kbd(M-s o)}}} ::
+ - {{{kbd(C-x c M-s o)}}} (~helm-occur~) ::
+
+   #+findex: helm-occur @r{(helm-command-map)}
+
+   #+kindex: M-s o @r{(helm-command-map)}
+   #+kindex: C-x c M-s o @r{(helm-command-map)}
+
+   Preconfigured helm for searching lines matching pattern in `current-buffer'.
+
+   When `helm-source-occur' is member of
+   `helm-sources-using-default-as-input' which is the default,
+   symbol at point is searched at startup.
+
+   When a region is marked search only in this region by narrowing.
+
+   To search in multiples buffers start from one of the commands listing
+   buffers (i.e. a helm command using `helm-source-buffers-list' like
+   `helm-mini') and use the multi occur buffers action.
+
+   This is the helm implementation that collect lines matching pattern
+   like vanilla Emacs `occur' but have nothing to do with it, the search
+   engine beeing completely different and also much faster.
+
+ - {{{kbd(M-g a)}}} ::
+ - {{{kbd(C-x c M-g a)}}} (~helm-do-grep-ag~) ::
+
+   #+findex: helm-do-grep-ag @r{(helm-command-map)}
+
+   #+kindex: M-g a @r{(helm-command-map)}
+   #+kindex: C-x c M-g a @r{(helm-command-map)}
+
+   (helm-do-grep-ag ARG)
+
+   Preconfigured `helm' for grepping with AG in `default-directory'.
+   With prefix arg prompt for type if available with your AG
+   version.
+
+*** Navigating with Tags etc
+
+ - {{{kbd(e)}}} ::
+ - {{{kbd(C-x c e)}}} (~helm-etags-select~) ::
+
+   #+findex: helm-etags-select @r{(helm-command-map)}
+
+   #+kindex: e @r{(helm-command-map)}
+   #+kindex: C-x c e @r{(helm-command-map)}
+
+   (helm-etags-select REINIT)
+
+   Preconfigured helm for etags.
+   If called with a prefix argument REINIT
+   or if any of the tag files have been modified, reinitialize cache.
+
+   This function aggregates three sources of tag files:
+
+     1) An automatically located file in the parent directories,
+	by `helm-etags-get-tag-file'.
+     2) `tags-file-name', which is commonly set by `find-tag' command.
+     3) `tags-table-list' which is commonly set by `visit-tags-table' command.
+
+ - {{{kbd(i)}}} ::
+ - {{{kbd(C-x c i)}}} (~helm-imenu~) ::
+
+   #+findex: helm-imenu @r{(helm-command-map)}
+
+   #+kindex: i @r{(helm-command-map)}
+   #+kindex: C-x c i @r{(helm-command-map)}
+
+   Preconfigured `helm' for `imenu'.
+
+ - {{{kbd(I)}}} ::
+ - {{{kbd(C-x c I)}}} (~helm-imenu-in-all-buffers~) ::
+
+   #+findex: helm-imenu-in-all-buffers @r{(helm-command-map)}
+
+   #+kindex: I @r{(helm-command-map)}
+   #+kindex: C-x c I @r{(helm-command-map)}
+
+   Preconfigured `helm' for fetching imenu entries in all buffers with similar mode as current.
+   A mode is similar as current if it is the same, it is derived
+   i.e. `derived-mode-p' or it have an association in
+   `helm-imenu-all-buffer-assoc'.
+
+*** Emacs-related Help
+
+ - {{{kbd(a)}}} ::
+ - {{{kbd(C-x c a)}}} (~helm-apropos~) ::
+
+   #+findex: helm-apropos @r{(helm-command-map)}
+
+   #+kindex: a @r{(helm-command-map)}
+   #+kindex: C-x c a @r{(helm-command-map)}
+
+   (helm-apropos DEFAULT)
+
+   Preconfigured Helm to describe commands, functions, variables and faces.
+   In non interactives calls DEFAULT argument should be provided as
+   a string, i.e. the `symbol-name' of any existing symbol.
+
+ - {{{kbd(h i)}}} ::
+ - {{{kbd(C-x c h i)}}} (~helm-info-at-point~) ::
+
+   #+findex: helm-info-at-point @r{(helm-command-map)}
+
+   #+kindex: h i @r{(helm-command-map)}
+   #+kindex: C-x c h i @r{(helm-command-map)}
+
+   Preconfigured `helm' for searching info at point.
+
+ - {{{kbd(h r)}}} ::
+ - {{{kbd(C-x c h r)}}} (~helm-info-emacs~) ::
+
+   #+findex: helm-info-emacs @r{(helm-command-map)}
+
+   #+kindex: h r @r{(helm-command-map)}
+   #+kindex: C-x c h r @r{(helm-command-map)}
+
+   Predefined helm for emacs info.
+
+ - {{{kbd(h g)}}} ::
+ - {{{kbd(C-x c h g)}}} (~helm-info-gnus~) ::
+
+   #+findex: helm-info-gnus @r{(helm-command-map)}
+
+   #+kindex: h g @r{(helm-command-map)}
+   #+kindex: C-x c h g @r{(helm-command-map)}
+
+   Predefined helm for gnus info.
+
+*** Helm-related Commands
+
+ - {{{kbd(h h)}}} ::
+ - {{{kbd(C-x c h h)}}} (~helm-documentation~) ::
+
+   #+findex: helm-documentation @r{(helm-command-map)}
+
+   #+kindex: h h @r{(helm-command-map)}
+   #+kindex: C-x c h h @r{(helm-command-map)}
+
+   Preconfigured `helm' for Helm documentation.
+   With a prefix arg refresh the documentation.
+
+   Find here the documentation of all documented sources.
+
+ - {{{kbd(b)}}} ::
+ - {{{kbd(C-x c b)}}} (~helm-resume~) ::
+
+   #+findex: helm-resume @r{(helm-command-map)}
+
+   #+kindex: b @r{(helm-command-map)}
+   #+kindex: C-x c b @r{(helm-command-map)}
+
+   (helm-resume ARG)
+
+   Resume a previous Helm session.
+   Call with a prefix arg to choose among existing Helm
+   buffers (sessions).  When calling from Lisp, specify a
+   `buffer-name' as a string with ARG.
+
+*** Completion at Point
+
+ - {{{kbd(<tab>)}}} ::
+ - {{{kbd(C-x c <tab>)}}} (~helm-lisp-completion-at-point~) ::
+
+   #+findex: helm-lisp-completion-at-point @r{(helm-command-map)}
+
+   #+kindex: <tab> @r{(helm-command-map)}
+   #+kindex: C-x c <tab> @r{(helm-command-map)}
+
+   Preconfigured Helm for Lisp symbol completion at point.
+
+*** Utilities
+
+ - {{{kbd(C-,)}}} ::
+ - {{{kbd(C-x c C-,)}}} (~helm-calcul-expression~) ::
+
+   #+findex: helm-calcul-expression @r{(helm-command-map)}
+
+   #+kindex: C-, @r{(helm-command-map)}
+   #+kindex: C-x c C-, @r{(helm-command-map)}
+
+   Preconfigured `helm' for `helm-source-calculation-result'.
+
+ - {{{kbd(C-:)}}} ::
+ - {{{kbd(C-x c C-:)}}} (~helm-eval-expression-with-eldoc~) ::
+
+   #+findex: helm-eval-expression-with-eldoc @r{(helm-command-map)}
+
+   #+kindex: C-: @r{(helm-command-map)}
+   #+kindex: C-x c C-: @r{(helm-command-map)}
+
+   Preconfigured `helm' for `helm-source-evaluation-result' with `eldoc' support.
+
+ - {{{kbd(r)}}} ::
+ - {{{kbd(C-x c r)}}} (~helm-regexp~) ::
+
+   #+findex: helm-regexp @r{(helm-command-map)}
+
+   #+kindex: r @r{(helm-command-map)}
+   #+kindex: C-x c r @r{(helm-command-map)}
+
+   Preconfigured helm to build regexps.
+   `query-replace-regexp' can be run from there against found regexp.
+
+*** Emacs-related
+
+ - {{{kbd(@)}}} ::
+ - {{{kbd(C-x c @)}}} (~helm-list-elisp-packages~) ::
+
+   #+findex: helm-list-elisp-packages @r{(helm-command-map)}
+
+   #+kindex: @ @r{(helm-command-map)}
+   #+kindex: C-x c @ @r{(helm-command-map)}
+
+   (helm-list-elisp-packages ARG)
+
+   Preconfigured `helm' for listing and handling Emacs packages.
+
+ - {{{kbd(p)}}} ::
+ - {{{kbd(C-x c p)}}} (~helm-list-emacs-process~) ::
+
+   #+findex: helm-list-emacs-process @r{(helm-command-map)}
+
+   #+kindex: p @r{(helm-command-map)}
+   #+kindex: C-x c p @r{(helm-command-map)}
+
+   Preconfigured `helm' for Emacs process.
+
+*** Bookmarks
+
+ - {{{kbd(C-x r b)}}} ::
+ - {{{kbd(C-x c C-x r b)}}} (~helm-filtered-bookmarks~) ::
+
+   #+findex: helm-filtered-bookmarks @r{(helm-command-map)}
+
+   #+kindex: C-x r b @r{(helm-command-map)}
+   #+kindex: C-x c C-x r b @r{(helm-command-map)}
+
+   Preconfigured `helm' for bookmarks (filtered by category).
+   Optional source `helm-source-bookmark-addressbook' is loaded only
+   if external addressbook-bookmark package is installed.
+
+*** GID
+
+ - {{{kbd(M-g i)}}} ::
+ - {{{kbd(C-x c M-g i)}}} (~helm-gid~) ::
+
+   #+findex: helm-gid @r{(helm-command-map)}
+
+   #+kindex: M-g i @r{(helm-command-map)}
+   #+kindex: C-x c M-g i @r{(helm-command-map)}
+
+   Preconfigured `helm' for `gid' command line of `ID-Utils'.
+   Need A database created with the command `mkid' above
+   `default-directory'.
+   Need id-utils as dependency which provide `mkid', `gid' etc..
+   See <https://www.gnu.org/software/idutils/>.
+
+ - {{{kbd(m)}}} ::
+ - {{{kbd(C-x c m)}}} (~helm-man-woman~) ::
+
+   #+findex: helm-man-woman @r{(helm-command-map)}
+
+   #+kindex: m @r{(helm-command-map)}
+   #+kindex: C-x c m @r{(helm-command-map)}
+
+   (helm-man-woman ARG)
+
+   Preconfigured `helm' for Man and Woman pages.
+   With a prefix arg reinitialize the cache.
+
+*** Interface to System-related Utilities
+
+ - {{{kbd(C-c C-x)}}} ::
+ - {{{kbd(C-x c C-c C-x)}}} (~helm-run-external-command~) ::
+
+   #+findex: helm-run-external-command @r{(helm-command-map)}
+
+   #+kindex: C-c C-x @r{(helm-command-map)}
+   #+kindex: C-x c C-c C-x @r{(helm-command-map)}
+
+   (helm-run-external-command PROGRAM)
+
+   Preconfigured `helm' to run External PROGRAM asyncronously from Emacs.
+   If program is already running exit with error.
+   You can set your own list of commands with
+   `helm-external-commands-list'.
+
+ - {{{kbd(t)}}} ::
+ - {{{kbd(C-x c t)}}} (~helm-top~) ::
+
+   #+findex: helm-top @r{(helm-command-map)}
+
+   #+kindex: t @r{(helm-command-map)}
+   #+kindex: C-x c t @r{(helm-command-map)}
+
+   Preconfigured `helm' for top command.
+
+*** Web Search
+
+ - {{{kbd(C-c g)}}} ::
+ - {{{kbd(C-x c C-c g)}}} (~helm-google-suggest~) ::
+
+   #+findex: helm-google-suggest @r{(helm-command-map)}
+
+   #+kindex: C-c g @r{(helm-command-map)}
+   #+kindex: C-x c C-c g @r{(helm-command-map)}
+
+   Preconfigured `helm' for Google search with Google suggest.
+
+ - {{{kbd(s)}}} ::
+ - {{{kbd(C-x c s)}}} (~helm-surfraw~) ::
+
+   #+findex: helm-surfraw @r{(helm-command-map)}
+
+   #+kindex: s @r{(helm-command-map)}
+   #+kindex: C-x c s @r{(helm-command-map)}
+
+   (helm-surfraw PATTERN ENGINE)
+
+   Preconfigured `helm' to search PATTERN with search ENGINE.
+
+*** Misc.
+
+ - {{{kbd(c)}}} ::
+ - {{{kbd(C-x c c)}}} (~helm-colors~) ::
+
+   #+findex: helm-colors @r{(helm-command-map)}
+
+   #+kindex: c @r{(helm-command-map)}
+   #+kindex: C-x c c @r{(helm-command-map)}
+
+   Preconfigured `helm' for color.
+
+ - {{{kbd(F)}}} ::
+ - {{{kbd(C-x c F)}}} (~helm-select-xfont~) ::
+
+   #+findex: helm-select-xfont @r{(helm-command-map)}
+
+   #+kindex: F @r{(helm-command-map)}
+   #+kindex: C-x c F @r{(helm-command-map)}
+
+   Preconfigured `helm' to select Xfont.
+
+ - {{{kbd(8)}}} ::
+ - {{{kbd(C-x c 8)}}} (~helm-ucs~) ::
+
+   #+findex: helm-ucs @r{(helm-command-map)}
+
+   #+kindex: 8 @r{(helm-command-map)}
+   #+kindex: C-x c 8 @r{(helm-command-map)}
+
+   (helm-ucs ARG)
+
+   Preconfigured `helm' for `ucs-names'.
+
+   Called with a prefix arg force reloading cache.
 
 * Show Helm Commands
 
@@ -469,9 +1945,127 @@ Then enable ~helm-mode~ with:
 
 Or, enable ~helm-mode~ interactively with {{{kbd(M-x helm-mode)}}}.
 
+- ~helm-mode~ ::
+
+  #+vindex: helm-mode
+
+  (helm-mode &optional ARG)
+
+  Toggle generic helm completion.
+
+  If called interactively, toggle `Helm mode'.  If the prefix
+  argument is positive, enable the mode, and if it is zero or
+  negative, disable the mode.
+
+  If called from Lisp, toggle the mode if ARG is `toggle'.  Enable
+  the mode if ARG is nil, omitted, or is a positive number.
+  Disable the mode if ARG is a negative number.
+
+  The mode's hook is called both when the mode is enabled and when
+  it is disabled.
+
+  All functions in Emacs that use `completing-read',
+  `read-file-name', `completion-in-region' and friends will use helm
+  interface when this mode is turned on.
+
+  However you can modify this behavior for functions of your choice
+  with `helm-completing-read-handlers-alist'.
+
+  Called with a positive arg, turn on unconditionally, with a
+  negative arg turn off.
+  You can toggle it with M-x `helm-mode'.
+
+  About `ido-mode':
+  DO NOT enable `ido-everywhere' when using `helm-mode'.  Instead of
+  using `ido-mode', add the commands where you want to use ido to
+  `helm-completing-read-handlers-alist' with `ido' as value.
+
+  Note: This mode is incompatible with Emacs23.
+
 ** Customize helm-mode
 
-#+vindex: helm-completing-read-handlers-alist
+- ~helm-completing-read-handlers-alist~ ::
+
+  #+vindex: helm-completing-read-handlers-alist
+
+  Completing read functions for specific Emacs commands.
+
+  By default ‘helm-mode’ use ‘helm-completing-read-default-handler’ to
+  provide helm completion in each ‘completing-read’ or ‘read-file-name’
+  found, but other functions can be specified here for specific
+  commands. This also allows disabling helm completion for some commands
+  when needed.
+
+  Each entry is a cons cell like (EMACS_COMMAND . COMPLETING-READ_HANDLER)
+  where key and value are symbols.
+
+  Each key is an Emacs command that use originaly ‘completing-read’.
+
+  Each value maybe a helm function that takes same arguments as
+  ‘completing-read’ plus NAME and BUFFER, where NAME is the name of the new
+  helm source and BUFFER the name of the buffer we will use, but it can
+  be also a function not using helm, in this case the function should
+  take the same args as ‘completing-read’ and not be prefixed by "helm-".
+
+  ‘helm’ will use the name of the command calling ‘completing-read’ as
+  NAME and BUFFER will be computed as well with NAME but prefixed with
+  "*helm-mode-".
+
+  This function prefix name must start by "helm-" when it uses helm,
+  otherwise ‘helm’ assumes the function is not a helm function and
+  expects the same args as ‘completing-read’, this allows you to define a
+  handler not using helm completion.
+
+  Example:
+
+      (defun foo/test ()
+	(interactive)
+	(message "%S" (completing-read "test: " ’(a b c d e))))
+
+      (defun helm-foo/test-completing-read-handler (prompt collection
+						    predicate require-match
+						    initial-input hist def
+						    inherit-input-method
+						    name buffer)
+	(helm-comp-read prompt collection :marked-candidates t
+					  :name name
+					  :buffer buffer))
+
+      (add-to-list ’helm-completing-read-handlers-alist
+		   ’(foo/test . helm-foo/test-completing-read-handler))
+
+  We want here to make the regular ‘completing-read’ in ‘foo/test’
+  return a list of candidate(s) instead of a single candidate.
+
+  Note that this function will be reused for ALL the ‘completing-read’
+  of this command, so it should handle all cases. E.g.,
+  if first ‘completing-read’ completes against symbols and
+  second ‘completing-read’ should handle only buffer,
+  your specialized function should handle both.
+
+  If the value of an entry is nil completion will fall back to
+  Emacs vanilla behaviour.
+  Example:
+
+  If you want to disable helm completion for ‘describe-function’, use:
+
+      (describe-function . nil)
+
+  Ido is also supported, you can use ‘ido-completing-read’ and
+  ‘ido-read-file-name’ as value of an entry or just ’ido.
+  Example:
+  Enable ido completion for ‘find-file’:
+
+      (find-file . ido)
+
+  same as
+
+      (find-file . ido-read-file-name)
+
+  Note that you don’t need to enable ‘ido-mode’ for this to work, see
+  ‘helm-mode’ documentation.
+
+# #+vindex: helm-completing-read-handlers-alist
 To customize the completion interface or disable completion for
 specific commands in ~helm-mode~, edit
 ~helm-completing-read-handlers-alist~. See {{{kbd(C-h v)}}}
@@ -558,6 +2152,8 @@ version control have a corresponding backend indicator.
 
 * Quick Try with =emacs-helm.sh=
 
+#+cindex: emacs-helm.sh
+
 To try Helm with a default configurations in a minimal Emacs, run the
 provided =emacs-helm.sh= script in Helm's installation directory.  If
 installed through the Emacs package manager,
@@ -588,6 +2184,66 @@ But normally =emacs-helm.sh= should work out of the box with
 installations of emacs-async= done with package.el, straight.el or from
 source with the Makefile.
 
+* How to report Helm Bugs
+
+** Confirming bugs
+
+To confirm that a bug is, in fact, a Helm problem, it is important to
+/replicate the behavior with a minimal Emacs configuration/. This
+precludes the possibility that the bug is caused by factors outside of
+Helm.
+
+The easiest and recommended way to do so is through the
+=emacs-helm.sh= script.
+
+*** =emacs-helm.sh=
+
+If your system supports it, you should run the =emacs-helm.sh= script
+to start an Emacs instance with minimal, Helm-specific configuration.
+
+This is useful for debugging, and easier than starting Emacs with
+=emacs -Q= and configuring Helm from scratch.
+
+If Helm is installed via MELPA, the =emacs-helm.sh= script should be
+located at =~/.emacs.d/elpa/helm-<version>/emacs-helm.sh=.
+
+Of course you have to cd to your helm directory and run the script
+from there, an alternative is symlinking it to somewhere in your
+=PATH= e.g. "~/bin" (See note at bottom for those that have installed
+from source with =make=).
+
+You can use the -h argument for help:
+
+    : $ helm -h
+    : Usage: helm [-P} Emacs path [-h} help [--] EMACS ARGS
+
+If your emacs binary is not in a standard place i.e. "emacs", you can
+specify the path with "-P".
+
+~Note~: If you have installed Helm from Git and used =make && sudo
+make install= you can run directly =helm= at command line from any
+place i.e. no need to cd to helm directory.
+
+*** =emacs -Q=
+
+If you cannot run the =emacs-helm.sh= script, be sure to reproduce the
+problem with =emacs -Q=, then installing Helm as described in the
+Install section.
+
+** Reporting bugs
+
+To report a bug, [[https://github.com/emacs-helm/helm/issues][open an
+issue]]. Be sure that you've confirmed the bug as described in the
+previous section, and include relevant information for the maintainer
+to identify the bug.
+
+*** Version info
+
+When reporting bugs, it is important to include the Helm version
+number, which can be found in the
+[[https://github.com/emacs-helm/helm/blob/master/helm-pkg.el][helm-pkg.el]]
+file.
+
 * Useful links
 
 - [[https://github.com/emacs-helm/helm][Helm on GitHub]]
@@ -601,7 +2257,7 @@ source with the Makefile.
 
 # - [[http://dir.gmane.org/gmane.emacs.helm.user][Helm Gmane]] (=gmane.emacs.helm.user=)
 
-* Contributing to the Wiki
+* COMMENT Contributing to the Wiki
 
 1. Prefer using [[http://orgmode.org/][Org mode]] for Wiki pages.
 
@@ -623,14 +2279,900 @@ source with the Makefile.
       toc-org-insert-toc))
 #+end_src
 
+* File: helm-buffers.el
+
+** Commands in keymap ~helm-buffer-map~ (excludes parent-keymap)
+
+*** uncategorized ! switch
+
+ - {{{kbd(C-c C-o)}}} (~helm-buffer-switch-other-frame~) ::
+
+   #+findex: helm-buffer-switch-other-frame @r{(helm-buffer-map)}
+
+   #+kindex: C-c C-o @r{(helm-buffer-map)}
+
+   Run switch to other frame action from `helm-source-buffers-list'.
+
+ - {{{kbd(C-c o)}}} (~helm-buffer-switch-other-window~) ::
+
+   #+findex: helm-buffer-switch-other-window @r{(helm-buffer-map)}
+
+   #+kindex: C-c o @r{(helm-buffer-map)}
+
+   Run switch to other window action from `helm-source-buffers-list'.
+
+*** uncategorized ! persistent
+
+ - {{{kbd(C-=)}}} (~helm-buffer-diff-persistent~) ::
+
+   #+findex: helm-buffer-diff-persistent @r{(helm-buffer-map)}
+
+   #+kindex: C-= @r{(helm-buffer-map)}
+
+   Toggle diff buffer without quitting helm.
+
+ - {{{kbd(M-G)}}} (~helm-buffer-revert-persistent~) ::
+
+   #+findex: helm-buffer-revert-persistent @r{(helm-buffer-map)}
+
+   #+kindex: M-G @r{(helm-buffer-map)}
+
+   Revert buffer without quitting helm.
+
+ - {{{kbd(C-x C-s)}}} (~helm-buffer-save-persistent~) ::
+
+   #+findex: helm-buffer-save-persistent @r{(helm-buffer-map)}
+
+   #+kindex: C-x C-s @r{(helm-buffer-map)}
+
+   Save buffer without quitting Helm.
+
+*** uncategorized ! buffers
+
+ - {{{kbd(C-M-SPC)}}} (~helm-buffers-mark-similar-buffers~) ::
+
+   #+findex: helm-buffers-mark-similar-buffers @r{(helm-buffer-map)}
+
+   #+kindex: C-M-SPC @r{(helm-buffer-map)}
+
+   Mark All buffers that have same property `type' than current.
+   I.e. same color.
+
+ - {{{kbd(C-c C-t)}}} (~helm-buffers-switch-to-buffer-new-tab~) ::
+
+   #+findex: helm-buffers-switch-to-buffer-new-tab @r{(helm-buffer-map)}
+
+   #+kindex: C-c C-t @r{(helm-buffer-map)}
+
+   Run switch to buffer in other tab action from `helm-source-buffers-list'.
+
+ - {{{kbd(C-c a)}}} (~helm-buffers-toggle-show-hidden-buffers~) ::
+
+   #+findex: helm-buffers-toggle-show-hidden-buffers @r{(helm-buffer-map)}
+
+   #+kindex: C-c a @r{(helm-buffer-map)}
+
+ - {{{kbd(C-])}}} (~helm-toggle-buffers-details~) ::
+
+   #+findex: helm-toggle-buffers-details @r{(helm-buffer-map)}
+
+   #+kindex: C-] @r{(helm-buffer-map)}
+
+*** uncategorized ! run ! kill
+
+ - {{{kbd(C-c d)}}} (~helm-buffer-run-kill-persistent~) ::
+
+   #+findex: helm-buffer-run-kill-persistent @r{(helm-buffer-map)}
+
+   #+kindex: C-c d @r{(helm-buffer-map)}
+
+   Kill buffer without quitting Helm.
+
+*** uncategorized ! run ! ediff
+
+ - {{{kbd(C-c =)}}} (~helm-buffer-run-ediff~) ::
+
+   #+findex: helm-buffer-run-ediff @r{(helm-buffer-map)}
+
+   #+kindex: C-c = @r{(helm-buffer-map)}
+
+   Run ediff action from `helm-source-buffers-list'.
+
+ - {{{kbd(M-=)}}} (~helm-buffer-run-ediff-merge~) ::
+
+   #+findex: helm-buffer-run-ediff-merge @r{(helm-buffer-map)}
+
+   #+kindex: M-= @r{(helm-buffer-map)}
+
+   Run ediff action from `helm-source-buffers-list'.
+
+*** uncategorized ! run ! replace
+
+ - {{{kbd(M-%)}}} (~helm-buffer-run-query-replace~) ::
+
+   #+findex: helm-buffer-run-query-replace @r{(helm-buffer-map)}
+
+   #+kindex: M-% @r{(helm-buffer-map)}
+
+   Run Query replace action from `helm-source-buffers-list'.
+
+ - {{{kbd(C-M-%)}}} (~helm-buffer-run-query-replace-regexp~) ::
+
+   #+findex: helm-buffer-run-query-replace-regexp @r{(helm-buffer-map)}
+
+   #+kindex: C-M-% @r{(helm-buffer-map)}
+
+   Run Query replace regexp action from `helm-source-buffers-list'.
+
+*** uncategorized ! run ! buffers
+
+ - {{{kbd(M-D)}}} (~helm-buffer-run-kill-buffers~) ::
+
+   #+findex: helm-buffer-run-kill-buffers @r{(helm-buffer-map)}
+
+   #+kindex: M-D @r{(helm-buffer-map)}
+
+   Run kill buffer action from `helm-source-buffers-list'.
+
+ - {{{kbd(C-x s)}}} (~helm-buffer-run-save-some-buffers~) ::
+
+   #+findex: helm-buffer-run-save-some-buffers @r{(helm-buffer-map)}
+
+   #+kindex: C-x s @r{(helm-buffer-map)}
+
+   Save unsaved file buffers without quitting Helm.
+
+ - {{{kbd(C-x C-d)}}} (~helm-buffers-run-browse-project~) ::
+
+   #+findex: helm-buffers-run-browse-project @r{(helm-buffer-map)}
+
+   #+kindex: C-x C-d @r{(helm-buffer-map)}
+
+   Run `helm-buffers-browse-project' from key.
+
+ - {{{kbd(C-s)}}} (~helm-buffers-run-occur~) ::
+
+   #+findex: helm-buffers-run-occur @r{(helm-buffer-map)}
+
+   #+kindex: C-s @r{(helm-buffer-map)}
+
+   Run `helm-multi-occur-as-action' by key.
+
+*** uncategorized ! run ! uncategorized
+
+ - {{{kbd(M-g M-g)}}} (~helm-buffer-run-goto-line~) ::
+
+   #+findex: helm-buffer-run-goto-line @r{(helm-buffer-map)}
+
+   #+kindex: M-g M-g @r{(helm-buffer-map)}
+
+   Switch to buffer at line number.
+
+ - {{{kbd(M-R)}}} (~helm-buffer-run-rename-buffer~) ::
+
+   #+findex: helm-buffer-run-rename-buffer @r{(helm-buffer-map)}
+
+   #+kindex: M-R @r{(helm-buffer-map)}
+
+   Run rename buffer action from `helm-source-buffers-list'.
+
+ - {{{kbd(M-g s)}}} (~helm-buffer-run-zgrep~) ::
+
+   #+findex: helm-buffer-run-zgrep @r{(helm-buffer-map)}
+
+   #+kindex: M-g s @r{(helm-buffer-map)}
+
+   Run Grep action from `helm-source-buffers-list'.
+
+** Commands in keymap ~helm-buffer-not-found-map~ (excludes parent-keymap)
+
+*** uncategorized
+
+ - {{{kbd(C-c C-o)}}} (~helm-buffers-not-found-run-switch-of~) ::
+
+   #+findex: helm-buffers-not-found-run-switch-of @r{(helm-buffer-not-found-map)}
+
+   #+kindex: C-c C-o @r{(helm-buffer-not-found-map)}
+
+   Run create new buffer other frame action from keymap.
+
+ - {{{kbd(C-c o)}}} (~helm-buffers-not-found-run-switch-ow~) ::
+
+   #+findex: helm-buffers-not-found-run-switch-ow @r{(helm-buffer-not-found-map)}
+
+   #+kindex: C-c o @r{(helm-buffer-not-found-map)}
+
+   Run create new buffer other window action from keymap.
+
+* File: helm-files.el
+
+** Commands in keymap ~helm-browse-project-map~ (excludes parent-keymap)
+
+ - {{{kbd(M-g a)}}} (~helm-browse-project-run-ag~) ::
+
+   #+findex: helm-browse-project-run-ag @r{(helm-browse-project-map)}
+
+   #+kindex: M-g a @r{(helm-browse-project-map)}
+
+   Run `helm-grep' AG from `helm-browse-project'.
+
+** Commands in keymap ~helm-file-name-history-map~ (excludes parent-keymap)
+
+*** uncategorized
+
+ - {{{kbd(C-x C-f)}}} (~helm-ff-file-name-history-run-ff~) ::
+
+   #+findex: helm-ff-file-name-history-run-ff @r{(helm-file-name-history-map)}
+
+   #+kindex: C-x C-f @r{(helm-file-name-history-map)}
+
+   Switch back to current HFF session with selection as preselect.
+
+ - {{{kbd(C-c d)}}} (~helm-file-name-history-show-or-hide-deleted~) ::
+
+   #+findex: helm-file-name-history-show-or-hide-deleted @r{(helm-file-name-history-map)}
+
+   #+kindex: C-c d @r{(helm-file-name-history-map)}
+
+** Commands in keymap ~helm-find-files-map~ (excludes parent-keymap)
+
+*** Default Action
+
+ - {{{kbd(RET)}}} (~helm-ff-RET~) ::
+
+   #+findex: helm-ff-RET @r{(helm-find-files-map)}
+
+   #+kindex: RET @r{(helm-find-files-map)}
+
+   Default action for RET in `helm-find-files'.
+
+   Behave differently depending on `helm-selection':
+
+   - candidate basename is "." => open it in dired.
+   - candidate is a directory    => expand it.
+   - candidate is a file         => open it.
+
+*** Traversing Directories
+
+ - {{{kbd(<left>)}}} ::
+ - {{{kbd(C-l)}}} (~helm-find-files-up-one-level~) ::
+
+   #+findex: helm-find-files-up-one-level @r{(helm-find-files-map)}
+
+   #+kindex: <left> @r{(helm-find-files-map)}
+   #+kindex: C-l @r{(helm-find-files-map)}
+
+   (helm-find-files-up-one-level ARG)
+
+   Go up one level like unix command `cd ..'.
+   If prefix numeric arg is given go ARG level up.
+
+ - {{{kbd(C-r)}}} (~helm-find-files-down-last-level~) ::
+
+   #+findex: helm-find-files-down-last-level @r{(helm-find-files-map)}
+
+   #+kindex: C-r @r{(helm-find-files-map)}
+
+   Retrieve previous paths reached by `C-l' in helm-find-files.
+
+*** Finding and Previewing Files
+
+ - {{{kbd(C-x C-v)}}} (~helm-ff-run-find-alternate-file~) ::
+
+   #+findex: helm-ff-run-find-alternate-file @r{(helm-find-files-map)}
+
+   #+kindex: C-x C-v @r{(helm-find-files-map)}
+
+ - {{{kbd(C-c C-x)}}} (~helm-ff-run-open-file-externally~) ::
+
+   #+findex: helm-ff-run-open-file-externally @r{(helm-find-files-map)}
+
+   #+kindex: C-c C-x @r{(helm-find-files-map)}
+
+   Run open file externally command action from `helm-source-find-files'.
+
+ - {{{kbd(C-c X)}}} (~helm-ff-run-open-file-with-default-tool~) ::
+
+   #+findex: helm-ff-run-open-file-with-default-tool @r{(helm-find-files-map)}
+
+   #+kindex: C-c X @r{(helm-find-files-map)}
+
+   Run open file externally command action from `helm-source-find-files'.
+
+ - {{{kbd(C-c C-v)}}} (~helm-ff-run-preview-file-externally~) ::
+
+   #+findex: helm-ff-run-preview-file-externally @r{(helm-find-files-map)}
+
+   #+kindex: C-c C-v @r{(helm-find-files-map)}
+
+ - {{{kbd(C-<backspace>)}}} ::
+ - {{{kbd(C-c DEL)}}} (~helm-ff-run-toggle-auto-update~) ::
+
+   #+findex: helm-ff-run-toggle-auto-update @r{(helm-find-files-map)}
+
+   #+kindex: C-<backspace> @r{(helm-find-files-map)}
+   #+kindex: C-c DEL @r{(helm-find-files-map)}
+
+ - {{{kbd(C-c C-t)}}} (~helm-ff-find-file-other-tab~) ::
+
+   #+findex: helm-ff-find-file-other-tab @r{(helm-find-files-map)}
+
+   #+kindex: C-c C-t @r{(helm-find-files-map)}
+
+   Run find file in other tab action from `helm-source-buffers-list'.
+
+*** Switch to other frame  or window
+
+ - {{{kbd(C-c C-o)}}} (~helm-ff-run-switch-other-frame~) ::
+
+   #+findex: helm-ff-run-switch-other-frame @r{(helm-find-files-map)}
+
+   #+kindex: C-c C-o @r{(helm-find-files-map)}
+
+   Run switch to other frame action from `helm-source-find-files'.
+
+ - {{{kbd(C-c o)}}} (~helm-ff-run-switch-other-window~) ::
+
+   #+findex: helm-ff-run-switch-other-window @r{(helm-find-files-map)}
+
+   #+kindex: C-c o @r{(helm-find-files-map)}
+
+   Run switch to other window action from `helm-source-find-files'.
+   When a prefix arg is provided, split is done vertically.
+
+*** File System Operations
+
+ - {{{kbd(M-C)}}} (~helm-ff-run-copy-file~) ::
+
+   #+findex: helm-ff-run-copy-file @r{(helm-find-files-map)}
+
+   #+kindex: M-C @r{(helm-find-files-map)}
+
+   Run Copy file action from `helm-source-find-files'.
+
+ - {{{kbd(M-D)}}} (~helm-ff-run-delete-file~) ::
+
+   #+findex: helm-ff-run-delete-file @r{(helm-find-files-map)}
+
+   #+kindex: M-D @r{(helm-find-files-map)}
+
+   Run Delete file action from `helm-source-find-files'.
+
+ - {{{kbd(C-c r)}}} (~helm-ff-run-find-file-as-root~) ::
+
+   #+findex: helm-ff-run-find-file-as-root @r{(helm-find-files-map)}
+
+   #+kindex: C-c r @r{(helm-find-files-map)}
+
+ - {{{kbd(C-c C-a)}}} (~helm-ff-run-mail-attach-files~) ::
+
+   #+findex: helm-ff-run-mail-attach-files @r{(helm-find-files-map)}
+
+   #+kindex: C-c C-a @r{(helm-find-files-map)}
+
+   Run mail attach files command action from `helm-source-find-files'.
+
+ - {{{kbd(C-x C-q)}}} (~helm-ff-run-marked-files-in-dired~) ::
+
+   #+findex: helm-ff-run-marked-files-in-dired @r{(helm-find-files-map)}
+
+   #+kindex: C-x C-q @r{(helm-find-files-map)}
+
+   Execute `helm-marked-files-in-dired' interactively.
+
+ - {{{kbd(C-c p)}}} (~helm-ff-run-print-file~) ::
+
+   #+findex: helm-ff-run-print-file @r{(helm-find-files-map)}
+
+   #+kindex: C-c p @r{(helm-find-files-map)}
+
+   Run Print file action from `helm-source-find-files'.
+
+ - {{{kbd(M-R)}}} (~helm-ff-run-rename-file~) ::
+
+   #+findex: helm-ff-run-rename-file @r{(helm-find-files-map)}
+
+   #+kindex: M-R @r{(helm-find-files-map)}
+
+   Run Rename file action from `helm-source-find-files'.
+
+ - {{{kbd(M-V)}}} (~helm-ff-run-rsync-file~) ::
+
+   #+findex: helm-ff-run-rsync-file @r{(helm-find-files-map)}
+
+   #+kindex: M-V @r{(helm-find-files-map)}
+
+   Run Rsync file action from `helm-source-find-files'.
+
+ - {{{kbd(M-T)}}} (~helm-ff-run-touch-files~) ::
+
+   #+findex: helm-ff-run-touch-files @r{(helm-find-files-map)}
+
+   #+kindex: M-T @r{(helm-find-files-map)}
+
+   Used to interactively run touch file action from keyboard.
+
+*** Links
+
+ - {{{kbd(M-H)}}} (~helm-ff-run-hardlink-file~) ::
+
+   #+findex: helm-ff-run-hardlink-file @r{(helm-find-files-map)}
+
+   #+kindex: M-H @r{(helm-find-files-map)}
+
+   Run Hardlink file action from `helm-source-find-files'.
+
+ - {{{kbd(M-S)}}} (~helm-ff-run-symlink-file~) ::
+
+   #+findex: helm-ff-run-symlink-file @r{(helm-find-files-map)}
+
+   #+kindex: M-S @r{(helm-find-files-map)}
+
+   Run Symlink file action from `helm-source-find-files'.
+
+ - {{{kbd(M-Y)}}} (~helm-ff-run-relsymlink-file~) ::
+
+   #+findex: helm-ff-run-relsymlink-file @r{(helm-find-files-map)}
+
+   #+kindex: M-Y @r{(helm-find-files-map)}
+
+   Run Symlink file action from `helm-source-find-files'.
+
+*** Sort
+
+ - {{{kbd(S-<f1>)}}} (~helm-ff-sort-alpha~) ::
+
+   #+findex: helm-ff-sort-alpha @r{(helm-find-files-map)}
+
+   #+kindex: S-<f1> @r{(helm-find-files-map)}
+
+ - {{{kbd(S-<f2>)}}} (~helm-ff-sort-by-newest~) ::
+
+   #+findex: helm-ff-sort-by-newest @r{(helm-find-files-map)}
+
+   #+kindex: S-<f2> @r{(helm-find-files-map)}
+
+ - {{{kbd(S-<f3>)}}} (~helm-ff-sort-by-size~) ::
+
+   #+findex: helm-ff-sort-by-size @r{(helm-find-files-map)}
+
+   #+kindex: S-<f3> @r{(helm-find-files-map)}
+
+*** Toggle View
+
+ - {{{kbd(S-<f4>)}}} (~helm-ff-toggle-dirs-only~) ::
+
+   #+findex: helm-ff-toggle-dirs-only @r{(helm-find-files-map)}
+
+   #+kindex: S-<f4> @r{(helm-find-files-map)}
+
+   Show only directories in helm-find-files.
+
+ - {{{kbd(S-<f5>)}}} (~helm-ff-toggle-files-only~) ::
+
+   #+findex: helm-ff-toggle-files-only @r{(helm-find-files-map)}
+
+   #+kindex: S-<f5> @r{(helm-find-files-map)}
+
+   Show only files in helm-find-files.
+
+ - {{{kbd(C-])}}} (~helm-ff-run-toggle-basename~) ::
+
+   #+findex: helm-ff-run-toggle-basename @r{(helm-find-files-map)}
+
+   #+kindex: C-] @r{(helm-find-files-map)}
+
+*** Image files
+
+ - {{{kbd(M--)}}} (~helm-ff-decrease-image-size-persistent~) ::
+
+   #+findex: helm-ff-decrease-image-size-persistent @r{(helm-find-files-map)}
+
+   #+kindex: M-- @r{(helm-find-files-map)}
+
+   Decrease image size without quitting helm.
+
+ - {{{kbd(M-+)}}} (~helm-ff-increase-image-size-persistent~) ::
+
+   #+findex: helm-ff-increase-image-size-persistent @r{(helm-find-files-map)}
+
+   #+kindex: M-+ @r{(helm-find-files-map)}
+
+   Increase image size without quitting helm.
+
+ - {{{kbd(M-l)}}} (~helm-ff-rotate-left-persistent~) ::
+
+   #+findex: helm-ff-rotate-left-persistent @r{(helm-find-files-map)}
+
+   #+kindex: M-l @r{(helm-find-files-map)}
+
+   Rotate image left without quitting helm.
+
+ - {{{kbd(M-r)}}} (~helm-ff-rotate-right-persistent~) ::
+
+   #+findex: helm-ff-rotate-right-persistent @r{(helm-find-files-map)}
+
+   #+kindex: M-r @r{(helm-find-files-map)}
+
+   Rotate image right without quitting helm.
+
+*** Persistent Actions
+
+ - {{{kbd(C-c d)}}} (~helm-ff-persistent-delete~) ::
+
+   #+findex: helm-ff-persistent-delete @r{(helm-find-files-map)}
+
+   #+kindex: C-c d @r{(helm-find-files-map)}
+
+   Delete current candidate without quitting.
+
+ - {{{kbd(M-i)}}} (~helm-ff-properties-persistent~) ::
+
+   #+findex: helm-ff-properties-persistent @r{(helm-find-files-map)}
+
+   #+kindex: M-i @r{(helm-find-files-map)}
+
+   Show properties without quitting helm.
+
+*** History Related
+
+ - {{{kbd(C-c h)}}} (~helm-ff-file-name-history~) ::
+
+   #+findex: helm-ff-file-name-history @r{(helm-find-files-map)}
+
+   #+kindex: C-c h @r{(helm-find-files-map)}
+
+   Switch to `file-name-history' without quitting `helm-find-files'.
+
+ - {{{kbd(M-p)}}} (~helm-find-files-history~) ::
+
+   #+findex: helm-find-files-history @r{(helm-find-files-map)}
+
+   #+kindex: M-p @r{(helm-find-files-map)}
+
+   (helm-find-files-history ARG &key (COMP-READ t))
+
+   The `helm-find-files' history.
+   Show the first `helm-ff-history-max-length' elements of
+   `helm-ff-history' in an `helm-comp-read'.
+
+*** Run =grep=
+
+ - {{{kbd(M-g g)}}} (~helm-ff-run-git-grep~) ::
+
+   #+findex: helm-ff-run-git-grep @r{(helm-find-files-map)}
+
+   #+kindex: M-g g @r{(helm-find-files-map)}
+
+   Run git-grep action from `helm-source-find-files'.
+
+ - {{{kbd(C-s)}}} ::
+ - {{{kbd(M-g s)}}} (~helm-ff-run-grep~) ::
+
+   #+findex: helm-ff-run-grep @r{(helm-find-files-map)}
+
+   #+kindex: C-s @r{(helm-find-files-map)}
+   #+kindex: M-g s @r{(helm-find-files-map)}
+
+   Run Grep action from `helm-source-find-files'.
+
+ - {{{kbd(M-g a)}}} (~helm-ff-run-grep-ag~) ::
+
+   #+findex: helm-ff-run-grep-ag @r{(helm-find-files-map)}
+
+   #+kindex: M-g a @r{(helm-find-files-map)}
+
+ - {{{kbd(M-g p)}}} (~helm-ff-run-pdfgrep~) ::
+
+   #+findex: helm-ff-run-pdfgrep @r{(helm-find-files-map)}
+
+   #+kindex: M-g p @r{(helm-find-files-map)}
+
+   Run Pdfgrep action from `helm-source-find-files'.
+
+ - {{{kbd(M-g z)}}} (~helm-ff-run-zgrep~) ::
+
+   #+findex: helm-ff-run-zgrep @r{(helm-find-files-map)}
+
+   #+kindex: M-g z @r{(helm-find-files-map)}
+
+   Run Grep action from `helm-source-find-files'.
+
+*** Run query replace
+
+ - {{{kbd(M-%)}}} (~helm-ff-run-query-replace~) ::
+
+   #+findex: helm-ff-run-query-replace @r{(helm-find-files-map)}
+
+   #+kindex: M-% @r{(helm-find-files-map)}
+
+ - {{{kbd(M-@)}}} (~helm-ff-run-query-replace-fnames-on-marked~) ::
+
+   #+findex: helm-ff-run-query-replace-fnames-on-marked @r{(helm-find-files-map)}
+
+   #+kindex: M-@ @r{(helm-find-files-map)}
+
+ - {{{kbd(C-M-%)}}} (~helm-ff-run-query-replace-regexp~) ::
+
+   #+findex: helm-ff-run-query-replace-regexp @r{(helm-find-files-map)}
+
+   #+kindex: C-M-% @r{(helm-find-files-map)}
+
+*** File operations for Elisp Development
+
+ - {{{kbd(M-B)}}} (~helm-ff-run-byte-compile-file~) ::
+
+   #+findex: helm-ff-run-byte-compile-file @r{(helm-find-files-map)}
+
+   #+kindex: M-B @r{(helm-find-files-map)}
+
+   Run Byte compile file action from `helm-source-find-files'.
+
+ - {{{kbd(M-L)}}} (~helm-ff-run-load-file~) ::
+
+   #+findex: helm-ff-run-load-file @r{(helm-find-files-map)}
+
+   #+kindex: M-L @r{(helm-find-files-map)}
+
+   Run Load file action from `helm-source-find-files'.
+
+*** Ediff
+
+ - {{{kbd(C-c =)}}} (~helm-ff-run-ediff-file~) ::
+
+   #+findex: helm-ff-run-ediff-file @r{(helm-find-files-map)}
+
+   #+kindex: C-c = @r{(helm-find-files-map)}
+
+   Run Ediff file action from `helm-source-find-files'.
+
+ - {{{kbd(M-=)}}} (~helm-ff-run-ediff-merge-file~) ::
+
+   #+findex: helm-ff-run-ediff-merge-file @r{(helm-find-files-map)}
+
+   #+kindex: M-= @r{(helm-find-files-map)}
+
+   Run Ediff merge file action from `helm-source-find-files'.
+
+*** Run programs
+
+ - {{{kbd(C-c /)}}} (~helm-ff-run-find-sh-command~) ::
+
+   #+findex: helm-ff-run-find-sh-command @r{(helm-find-files-map)}
+
+   #+kindex: C-c / @r{(helm-find-files-map)}
+
+   Run find shell command action with key from `helm-find-files'.
+
+ - {{{kbd(M-.)}}} (~helm-ff-run-etags~) ::
+
+   #+findex: helm-ff-run-etags @r{(helm-find-files-map)}
+
+   #+kindex: M-. @r{(helm-find-files-map)}
+
+   Run Etags command action from `helm-source-find-files'.
+
+ - {{{kbd(C-/)}}} (~helm-ff-run-fd~) ::
+
+   #+findex: helm-ff-run-fd @r{(helm-find-files-map)}
+
+   #+kindex: C-/ @r{(helm-find-files-map)}
+
+   Run fd shell command action with key from `helm-find-files'.
+
+ - {{{kbd(M-g i)}}} (~helm-ff-run-gid~) ::
+
+   #+findex: helm-ff-run-gid @r{(helm-find-files-map)}
+
+   #+kindex: M-g i @r{(helm-find-files-map)}
+
+ - {{{kbd(C-x C-f)}}} (~helm-ff-run-locate~) ::
+
+   #+findex: helm-ff-run-locate @r{(helm-find-files-map)}
+
+   #+kindex: C-x C-f @r{(helm-find-files-map)}
+
+   Run locate action from `helm-source-find-files'.
+
+*** Completing and Inserting File names in buffers
+
+ - {{{kbd(C-c i)}}} (~helm-ff-run-complete-fn-at-point~) ::
+
+   #+findex: helm-ff-run-complete-fn-at-point @r{(helm-find-files-map)}
+
+   #+kindex: C-c i @r{(helm-find-files-map)}
+
+   Run complete file name action from `helm-source-find-files'.
+
+ - {{{kbd(C-c @)}}} (~helm-ff-run-insert-org-link~) ::
+
+   #+findex: helm-ff-run-insert-org-link @r{(helm-find-files-map)}
+
+   #+kindex: C-c @ @r{(helm-find-files-map)}
+
+*** Project-related
+
+ - {{{kbd(C-x C-d)}}} (~helm-ff-run-browse-project~) ::
+
+   #+findex: helm-ff-run-browse-project @r{(helm-find-files-map)}
+
+   #+kindex: C-x C-d @r{(helm-find-files-map)}
+
+*** Eshell
+
+ - {{{kbd(M-!)}}} (~helm-ff-run-eshell-command-on-file~) ::
+
+   #+findex: helm-ff-run-eshell-command-on-file @r{(helm-find-files-map)}
+
+   #+kindex: M-! @r{(helm-find-files-map)}
+
+   Run eshell command on file action from `helm-source-find-files'.
+
+*** Bookmarks
+
+ - {{{kbd(C-x r b)}}} (~helm-find-files-switch-to-bookmark~) ::
+
+   #+findex: helm-find-files-switch-to-bookmark @r{(helm-find-files-map)}
+
+   #+kindex: C-x r b @r{(helm-find-files-map)}
+
+   Switch to helm-bookmark for `helm-find-files' from `helm-find-files.'
+
+ - {{{kbd(C-x r m)}}} (~helm-ff-bookmark-set~) ::
+
+   #+findex: helm-ff-bookmark-set @r{(helm-find-files-map)}
+
+   #+kindex: C-x r m @r{(helm-find-files-map)}
+
+   Record `helm-find-files' session in bookmarks.
+
+ - {{{kbd(C-_)}}} (~helm-ff-undo~) ::
+
+   #+findex: helm-ff-undo @r{(helm-find-files-map)}
+
+   #+kindex: C-_ @r{(helm-find-files-map)}
+
+   Undo minibuffer in `helm-find-files'.
+   Ensure disabling `helm-ff-auto-update-flag' before undoing.
+
+*** Misc.
+
+ - {{{kbd(M-e)}}} (~helm-ff-run-switch-to-shell~) ::
+
+   #+findex: helm-ff-run-switch-to-shell @r{(helm-find-files-map)}
+
+   #+kindex: M-e @r{(helm-find-files-map)}
+
+   Run switch to eshell action from `helm-source-find-files'.
+
+ - {{{kbd(M-K)}}} (~helm-ff-run-kill-buffer-persistent~) ::
+
+   #+findex: helm-ff-run-kill-buffer-persistent @r{(helm-find-files-map)}
+
+   #+kindex: M-K @r{(helm-find-files-map)}
+
+   Execute `helm-ff-kill-buffer-fname' without quitting.
+
+** Commands in keymap ~helm-read-file-map~ (excludes parent-keymap)
+
+ - {{{kbd(RET)}}} (~helm-ff-RET~) ::
+
+   #+findex: helm-ff-RET @r{(helm-read-file-map)}
+
+   #+kindex: RET @r{(helm-read-file-map)}
+
+   Default action for RET in `helm-find-files'.
+
+   Behave differently depending on `helm-selection':
+
+   - candidate basename is "." => open it in dired.
+   - candidate is a directory    => expand it.
+   - candidate is a file         => open it.
+
+ - {{{kbd(C-<return>)}}} ::
+ - {{{kbd(M-RET)}}} (~helm-cr-empty-string~) ::
+
+   #+findex: helm-cr-empty-string @r{(helm-read-file-map)}
+
+   #+kindex: C-<return> @r{(helm-read-file-map)}
+   #+kindex: M-RET @r{(helm-read-file-map)}
+
+   Return empty string.
+
+*** uncategorized ! files
+
+ - {{{kbd(C-r)}}} (~helm-find-files-down-last-level~) ::
+
+   #+findex: helm-find-files-down-last-level @r{(helm-read-file-map)}
+
+   #+kindex: C-r @r{(helm-read-file-map)}
+
+   Retrieve previous paths reached by `C-l' in helm-find-files.
+
+ - {{{kbd(<left>)}}} ::
+ - {{{kbd(C-l)}}} ::
+ - {{{kbd(C-.)}}} (~helm-find-files-up-one-level~) ::
+
+   #+findex: helm-find-files-up-one-level @r{(helm-read-file-map)}
+
+   #+kindex: <left> @r{(helm-read-file-map)}
+   #+kindex: C-l @r{(helm-read-file-map)}
+   #+kindex: C-. @r{(helm-read-file-map)}
+
+   (helm-find-files-up-one-level ARG)
+
+   Go up one level like unix command `cd ..'.
+   If prefix numeric arg is given go ARG level up.
+
+*** uncategorized ! ff
+
+ - {{{kbd(C-c h)}}} (~helm-ff-file-name-history~) ::
+
+   #+findex: helm-ff-file-name-history @r{(helm-read-file-map)}
+
+   #+kindex: C-c h @r{(helm-read-file-map)}
+
+   Switch to `file-name-history' without quitting `helm-find-files'.
+
+ - {{{kbd(C-<backspace>)}}} ::
+ - {{{kbd(C-c DEL)}}} (~helm-ff-run-toggle-auto-update~) ::
+
+   #+findex: helm-ff-run-toggle-auto-update @r{(helm-read-file-map)}
+
+   #+kindex: C-<backspace> @r{(helm-read-file-map)}
+   #+kindex: C-c DEL @r{(helm-read-file-map)}
+
+ - {{{kbd(C-])}}} (~helm-ff-run-toggle-basename~) ::
+
+   #+findex: helm-ff-run-toggle-basename @r{(helm-read-file-map)}
+
+   #+kindex: C-] @r{(helm-read-file-map)}
+
+ - {{{kbd(C-_)}}} (~helm-ff-undo~) ::
+
+   #+findex: helm-ff-undo @r{(helm-read-file-map)}
+
+   #+kindex: C-_ @r{(helm-read-file-map)}
+
+   Undo minibuffer in `helm-find-files'.
+   Ensure disabling `helm-ff-auto-update-flag' before undoing.
+
+* Main Index
+:PROPERTIES:
+:INDEX:    cp
+:DESCRIPTION: An index of Helm's concepts and features.
+:END:
+
+* Key Index
+:PROPERTIES:
+:DESCRIPTION: Key bindings and where they are described.
+:INDEX:    ky
+:END:
+
+* Command and Function Index
+:PROPERTIES:
+:DESCRIPTION: Command names and some internal functions.
+:INDEX:    fn
+:END:
+
+* Variable Index
+:PROPERTIES:
+:DESCRIPTION: Variables mentioned in the manual.
+:INDEX:    vr
+:END:
+
+This is not a complete index of variables and faces, only the ones
+that are mentioned in the manual.  For a more complete list, use
+{{{kbd(M-x org-customize)}}} and then click yourself through the tree.
+
 * Export Setup                                                          :noexport:
 
 #+setupfile: doc-setup.org
 
-#+export_file_name: helm-1.texi
+#+export_file_name: helm-manual-1.texi
 
 #+texinfo_dir_category: Emacs editing modes
-#+texinfo_dir_title: Helm 1: (helm-1)
+#+texinfo_dir_title: Helm Manual 1: (helm-manual-1)
 #+texinfo_dir_desc: Emacs incremental and narrowing framework
 
 * Footnotes
@@ -679,3 +3221,5 @@ and then helm-core resulting in an error like =void function foo...=.
 
 #+STARTUP: inlineimages
 #+EXCLUDE_TAGS: TOC_4
+
+# (info (org-texinfo-export-to-info))

--- a/doc/helm-manual.org
+++ b/doc/helm-manual.org
@@ -7,6 +7,7 @@
 # #+texinfo: @insertcopying
 
 * Table Of Contents                                                     :TOC_4:
+
 - [[#helm-generic-help][Helm Generic Help]]
   - [[#basics][Basics]]
   - [[#helm-sources][Helm sources]]
@@ -230,6 +231,7 @@
 - [[#footnotes][Footnotes]]
 
 * Helm Generic Help
+
 ** Basics
 
 # To navigate in this Help buffer see [[Helm help][here]].
@@ -1841,9 +1843,9 @@ When connection fails, be sure to delete your TRAMP connection with
 
 Use the sudo method:
 
-: /sudo:host: 
+: /sudo:host:
 
-or 
+or
 
 : simply /sudo::.
 
@@ -2531,6 +2533,7 @@ one of them for recursive searches, keeping grep or ack-grep to
 grep individual or marked files.  See [[Helm AG][Helm AG]].
 
 *** Meaning of the prefix argument
+
 **** With grep or ack-grep
 
 Grep recursively, in this case you are
@@ -3034,12 +3037,12 @@ Uses keymap ~helm-imenu-map~, which is not currently defined.
 
 Uses keymap ~helm-color-map~, which is not currently defined.
 
-|Keys|Description
-|-----------+----------|
-|M-x helm-color-run-insert-name|Insert the entry name.
-|M-x helm-color-run-kill-name|Kill the entry name.
-|M-x helm-color-run-insert-rgb|Insert entry in RGB format.
-|M-x helm-color-run-kill-rgb|Kill entry in RGB format.
+| Keys                           | Description                 |
+|--------------------------------+-----------------------------|
+| M-x helm-color-run-insert-name | Insert the entry name.      |
+| M-x helm-color-run-kill-name   | Kill the entry name.        |
+| M-x helm-color-run-insert-rgb  | Insert entry in RGB format. |
+| M-x helm-color-run-kill-rgb    | Kill entry in RGB format.   |
 
 * Helm Semantic
 
@@ -3126,7 +3129,7 @@ Uses keymap ~helm-kill-ring-map~, which is not currently defined.
 
 #+setupfile: doc-setup.org
 
-#+export_file_name: helm.texi
+#+export_file_name: helm-manual.texi
 
 #+texinfo_dir_category: Emacs editing modes
 #+texinfo_dir_title: Helm: (helm)
@@ -3136,8 +3139,8 @@ Uses keymap ~helm-kill-ring-map~, which is not currently defined.
 
 [fn:20] Delete from point to end or all depending on the value of
 ~helm-delete-minibuffer-contents-from-point~.
- 
-[fn:19] Behavior may change depending context in some source e.g. ~helm-find-files~. 
+
+[fn:19] Behavior may change depending context in some source e.g. ~helm-find-files~.
 
 [fn:1] https://github.com/coldnew/linum-relative
 


### PR DESCRIPTION

    * doc/helm-manual-1.org: Update.  Arrange for generating variable, command and key indices.
    * Makefile: Add target `doc' and `clean-doc'

`make doc' now generates texi, info and  html documenation.   The documentation  now has all the indices  one come to expect from a standard  documenation.

For info file generation, you need ox-texinfo from Org 9.4.6 (which is yet to be  released as on this date).  If you haven't noticed GNU ELPA is on 9.4.5 I think, but the version in Emacs Master  is 9.4.4, I think.

 As a temporary workaround, the make file will `wget's the latest ox-texinfo.el from Orgmode's official repo.

Here is a sample run from `make doc'.

```
rameshnedunchezian@debian:~/src/helm$ make doc
wget https://code.orgmode.org/bzg/org-mode/raw/maint/lisp/ox-texinfo.el -O doc/ox-texinfo.el
--2021-04-16 19:32:44--  https://code.orgmode.org/bzg/org-mode/raw/maint/lisp/ox-texinfo.el
Resolving code.orgmode.org (code.orgmode.org)... 45.77.159.66
Connecting to code.orgmode.org (code.orgmode.org)|45.77.159.66|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: unspecified [text/plain]
Saving to: ‘doc/ox-texinfo.el’

doc/ox-texinfo.el                         [  <=>                                                                   ]  62.52K   170KB/s    in 0.4s    

2021-04-16 19:32:49 (170 KB/s) - ‘doc/ox-texinfo.el’ saved [64019]

emacs -q -batch -L . -L /home/rameshnedunchezian/.emacs.d/elpa/async-20210117.718 -l doc/ox-texinfo.el  --file=doc/helm-bugs.org --eval '(org-texinfo-export-to-texinfo)'
makeinfo --no-split doc/helm-bugs.texi -o doc/helm-bugs.info
emacs -q -batch -L . -L /home/rameshnedunchezian/.emacs.d/elpa/async-20210117.718 -l doc/ox-texinfo.el  --file=doc/helm-devel.org --eval '(org-texinfo-export-to-texinfo)'
makeinfo --no-split doc/helm-devel.texi -o doc/helm-devel.info
emacs -q -batch -L . -L /home/rameshnedunchezian/.emacs.d/elpa/async-20210117.718 -l doc/ox-texinfo.el  --file=doc/helm-manual-1.org --eval '(org-texinfo-export-to-texinfo)'
makeinfo --no-split doc/helm-manual-1.texi -o doc/helm-manual-1.info
doc/helm-manual-1.texi:4: warning: @settitle missing argument
doc/helm-manual-1.texi:22: warning: @title missing argument
doc/helm-manual-1.texi:492: warning: could not find @image file `./helm-M-x.txt' nor alternate text
emacs -q -batch -L . -L /home/rameshnedunchezian/.emacs.d/elpa/async-20210117.718 -l doc/ox-texinfo.el  --file=doc/helm-manual.org --eval '(org-texinfo-export-to-texinfo)'
makeinfo --no-split doc/helm-manual.texi -o doc/helm-manual.info
makeinfo --html --number-sections --css-ref "https://www.gnu.org/software/emacs/manual.css" --no-split -o doc/helm-bugs.html doc/helm-bugs.texi
makeinfo --html --number-sections --css-ref "https://www.gnu.org/software/emacs/manual.css" --no-split -o doc/helm-devel.html doc/helm-devel.texi
makeinfo --html --number-sections --css-ref "https://www.gnu.org/software/emacs/manual.css" --no-split -o doc/helm-manual-1.html doc/helm-manual-1.texi
doc/helm-manual-1.texi:4: warning: @settitle missing argument
doc/helm-manual-1.texi:22: warning: @title missing argument
doc/helm-manual-1.texi: warning: must specify a title with a title command or @top
doc/helm-manual-1.texi:492: warning: @image file `./helm-M-x' (for HTML) not found, using `./helm-M-x.png'
makeinfo --html --number-sections --css-ref "https://www.gnu.org/software/emacs/manual.css" --no-split -o doc/helm-manual.html doc/helm-manual.texi
```