### PR TITLE
* doc/helm.org: Use relative path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,10 +160,10 @@ DESTDIR=${PREFIX}share/emacs/site-lisp/helm/
 # On Debian, paths in `Info-default-directory-list' are in the order
 # as below:
 
-# INFODIR	= /usr/local/share/info/
-# INFODIR	= /usr/local/info/
-INFODIR		= /usr/share/info/
-# INFODIR	= /usr/local/share/info/
+# INFODIR	= /usr/local/share/info
+# INFODIR	= /usr/local/info
+INFODIR		= /usr/share/info
+# INFODIR	= /usr/local/share/info
 
 # /usr/share/info is where Debian puts the info file for EMMS. So,
 # just mimic it.
@@ -195,7 +195,7 @@ install-info:	$(INFOFILES)
 	done
 
 clean-install-info:
-	for f in $(INFOFILES:doc/%=%) ; do					\
-		$(RM) $(INFODIR)/$$f						\
-		$(INSTALL_INFO) --info-dir=$(INFODIR) --remove $(INFODIR)/$$f;	\
+	for f in $(INFOFILES:doc/%=%) ; do						\
+		$(INSTALL_INFO) --remove --info-dir=$(INFODIR) --remove $(INFODIR)/$$f;	\
+		$(RM) $(INFODIR)/$$f;							\
 	done

--- a/doc/helm.org
+++ b/doc/helm.org
@@ -12453,7 +12453,7 @@ that are mentioned in the manual.  For a more complete list, use
 
 * Export Setup                                                          :noexport:
 
-#+setupfile: /home/rameshnedunchezian/src/helm/doc/doc-setup.org
+#+setupfile: doc-setup.org
 #+options: H:4
 
 #+export_file_name: helm.texi


### PR DESCRIPTION
    * doc/helm.org: Use relative path
    * doc/Makefile: Fix errors with `make  clean-install-info'
