### PR TITLE
Fix eshell completion when candidate is a directory

### DIFF
--- a/helm-eshell.el
+++ b/helm-eshell.el
@@ -163,7 +163,7 @@ at point."
                                    (if (file-remote-p i) i
                                      (expand-file-name
                                       i (file-name-directory
-                                         (if (file-directory-p pcomplete-stub)
+                                         (if (directory-name-p pcomplete-stub)
                                              entry
                                            (directory-file-name entry))))))
               ;; Compare them to avoid dups.

--- a/helm-eshell.el
+++ b/helm-eshell.el
@@ -163,7 +163,9 @@ at point."
                                    (if (file-remote-p i) i
                                      (expand-file-name
                                       i (file-name-directory
-                                         (directory-file-name entry)))))
+                                         (if (file-directory-p pcomplete-stub)
+                                             entry
+                                           (directory-file-name entry))))))
               ;; Compare them to avoid dups.
               for file-entry-p = (and (stringp exp-entry)
                                       (stringp file-cand)


### PR DESCRIPTION
In #2412 I introduced a regression to `helm-esh-pcomplete` whereby the function will not complete when the completion input is a directory with a closing separator. 

For example, `ls /etc/` should complete with the contents of the `/etc` directory. It does not currently because we take candidates from the parent directory, which does not generate any valid, existing file candidates.

This is fixed in this PR by not using the parent directory when the completion stub is a directory with the ending separator. This covers both the regression and the issue fixed by #2412.

