### PR TITLE
Fix: quote an initform in defclass helm-source

### DIFF
--- a/helm-source.el
+++ b/helm-source.el
@@ -686,7 +686,7 @@
 
    (group
     :initarg :group
-    :initform helm
+    :initform 'helm
     :custom symbol
     :documentation
     "  The current source group, default to `helm' when not specified."))


### PR DESCRIPTION
Emacs 28 is going to get an update that will break code with unquoted symbols in initforms.  This seems to be the only one such in Helm.