### PR TITLE
highlight filename extension when find files

### DIFF
--- a/helm-for-files.el
+++ b/helm-for-files.el
@@ -193,11 +193,18 @@ Colorize only symlinks, directories and files."
                                     'match-part (funcall mp-fn disp)
                                     'help-echo (expand-file-name i))
                         i))
-                 (t (cons (propertize disp
-                                      'face 'helm-ff-file
-                                      'match-part (funcall mp-fn disp)
-                                      'help-echo (expand-file-name i))
-                          i)))))
+                 (t (let* ((ext (file-name-extension disp))
+                           (disp (propertize disp
+                                             'face 'helm-ff-file
+                                             'match-part (funcall mp-fn disp)
+                                             'help-echo (expand-file-name i))))
+                      (when (condition-case _err
+                                (string-match (format "\\.\\(%s\\)$" ext) disp)
+                              (invalid-regexp nil))
+                        (add-face-text-property
+                         (match-beginning 1) (match-end 1)
+                         'helm-ff-file-extension nil disp))
+                      (cons disp i))))))
 
 (defclass helm-files-in-current-dir-source (helm-source-sync helm-type-file)
   ((candidates :initform (lambda ()


### PR DESCRIPTION
Hi,

I created this PR to enable Helm to highlight the file name extensions of files when calling `helm-mini` for `helm-find-files` 
(by using the face `'helm-ff-file-extension`).

This is useful for users to quickly see what file types they want to look for.

- Here is a screenshot of the current display of file names (in recent files) when calling `helm-mini`:

![helm-before](https://user-images.githubusercontent.com/193967/133023906-3b904f2e-dfc3-4465-823e-2da69679bfc3.png)

- This is how it looks like after applying my patch:

![helm-after](https://user-images.githubusercontent.com/193967/133023913-77972401-d9f9-4794-8a2a-f1d71eaa396f.png)

Can you advise if this PR is useful and can be merged?

Thank you!