### PR TITLE
highlight file extension in buffer names

### DIFF
--- a/helm-buffers.el
+++ b/helm-buffers.el
@@ -431,9 +431,18 @@ The list is reordered with `helm-buffer-list-reorder-fn'."
   (append
    (list
     (concat prefix
-            (propertize buf-name 'face face1
-                        'help-echo help-echo
-                        'type type)))
+            (let* ((buf-fname (buffer-file-name (get-buffer buf-name)))
+                   (ext (if buf-fname (file-name-extension buf-fname) ""))
+                   (buf-name (propertize buf-name 'face face1
+                                         'help-echo help-echo
+                                         'type type)))
+              (when (condition-case _err
+                                (string-match (format "\\.\\(%s\\)" ext) buf-name)
+                              (invalid-regexp nil))
+                        (add-face-text-property
+                         (match-beginning 1) (match-end 1)
+                         'helm-ff-file-extension nil buf-name))
+              buf-name)))
    (and details
         (list size mode
               (propertize


### PR DESCRIPTION
Hi,

I created another PR that is similar to https://github.com/emacs-helm/helm/pull/2439, but this new PR is to highlight the file name extension of opened buffers.

Here is a screenshot of how it looks like, on the first 3 buffers of the list.

![helm-buffer](https://user-images.githubusercontent.com/193967/133045393-e0ab60f4-20de-4664-b9ff-dfd36cbe24fa.png)

Please consider merging it too.

Thank you!
