### PR TITLE
helm-misc.el (helm-minibuffer-history-old-key): Check existence

### DIFF
--- a/helm-misc.el
+++ b/helm-misc.el
@@ -219,6 +219,7 @@ It is added to `extended-command-history'.
                         minibuffer-local-must-match-filename-map ; Older Emacsen
                         minibuffer-local-must-match-map
                         minibuffer-local-ns-map)
+           when (and (boundp map) (symbol-value map))
            collect (cons map (lookup-key (symbol-value map) "\C-r"))))
 
 ;;;###autoload


### PR DESCRIPTION
The latest Emacs 29 does not have
minibuffer-local-must-match-filename-map, so we must guard any attempt
at looking up its symbol-value.