### PR TITLE
Fix helm-comp-read error when result is a list

### DIFF
--- a/helm-mode.el
+++ b/helm-mode.el
@@ -863,8 +863,11 @@ that use `helm-comp-read'.  See `helm-M-x' for example."
         (remove-hook 'helm-after-update-hook 'helm-comp-read--move-to-first-real-candidate))
       ;; If `history' is a symbol save it.
       (when (and result history (symbolp history))
-        (set history (cons (substring-no-properties result)
-                           (delete result (symbol-value history)))))
+        (set history
+             (if (listp result)
+                 (delete-dups (append (mapcar #'substring-no-properties result) (symbol-value history)))
+               (cons (substring-no-properties result)
+                     (delete result (symbol-value history))))))
       (or result (helm-mode--keyboard-quit)))))
 
 


### PR DESCRIPTION
Hi,

When helm-comp-read-use-marked is true, result in helm-comp-read is a list - calling substring-no-properties on it yields an error.

Repro:
```
(let ((helm-comp-read-use-marked t))
  (helm-comp-read "Delete tag: " '("t1" "t2") :test nil :history 'magit-revision-history :reverse-history t :input-history 'magit-revision-history :must-match t :alistp nil :help-message 'helm-comp-read-help-message :name "magit-tag-delete" :requires-pattern 0 :nomark nil :candidates-in-buffer t :exec-when-only-one nil :fuzzy nil :buffer "*helm-mode-magit-tag-delete*" :default "t1" :initial-input nil))
```

I encountered the error when using `magit-tag-delete`.