### PR TITLE
Fix arguments error on read-coding-system

### DIFF
--- a/helm-lib.el
+++ b/helm-lib.el
@@ -416,7 +416,9 @@ Like `this-command' but return the real command, and not
                ;; advice compiled resulting in byte-code,
                ;; ignore it (Bug#691).
                (symbolp fn)
-               (commandp fn)
+               (or (commandp fn)
+                   ;; is not interactive, but calls completing-read-default
+                   (eq fn 'read-coding-system))
                (not (memq fn helm-this-command-black-list)))
            return fn
            else


### PR DESCRIPTION
Hi,

`read-coding-system` calls `completing-read-default`, but is not interactive, and not recognized by `helm-this-command`.

If e.g. `write-region` calls `read-coding-system` due to incompatible bytes in the buffer, `helm-this-command` would recognize `write-region` further up the stack, and pick the associated `helm-read-file-name-handler-1` from `helm-completing-read-handlers-alist`, which fails due to wrong argument count:
`(wrong-number-of-arguments (8 . 8) 10)`

This change makes `helm-this-command` recognize `read-coding-system`, so the default helm handler is used.

Error reproduction:
```
(with-temp-buffer
  (set-buffer-file-coding-system 'utf-8)
  ;; insert some incompatible bytes from windows-1252 encoding
  (insert-byte #xE4 1) ;;ä
  (insert-byte #xF6 1) ;;ö
  (insert-byte #xFC 1) ;;ü
  (insert-byte #x80 1) ;;€
  (write-region nil nil (make-temp-file "test")))
```