### PR TITLE
Extend helm-grep-ag-1 to accept input

### DIFF
--- a/helm-grep.el
+++ b/helm-grep.el
@@ -1639,8 +1639,9 @@ returns if available with current AG version."
                  (assoc-default 'follow helm-source-grep-ag))
       (setf (slot-value source 'follow) it)))
 
-(defun helm-grep-ag-1 (directory &optional type)
-  "Start helm ag in DIRECTORY maybe searching in files of type TYPE."
+(defun helm-grep-ag-1 (directory &optional type input)
+  "Start helm ag in DIRECTORY maybe searching in files of type TYPE.
+If INPUT is provided, use it as the search string."
   (setq helm-source-grep-ag
         (helm-make-source (upcase (helm-grep--ag-command)) 'helm-grep-ag-class
           :header-name (lambda (name)
@@ -1652,6 +1653,7 @@ returns if available with current AG version."
   (helm :sources 'helm-source-grep-ag
         :keymap helm-grep-map
         :history 'helm-grep-ag-history
+        :input input
         :truncate-lines helm-grep-truncate-lines
         :buffer (format "*helm %s*" (helm-grep--ag-command))))
 


### PR DESCRIPTION
For example: `(helm-grep-ag-1 dir '("-t txt") "pattern")`.