### PR TITLE
Helm-find-library-at-point: fix for general text

### DIFF
--- a/helm-files.el
+++ b/helm-files.el
@@ -5257,7 +5257,7 @@ source is `helm-source-find-files'."
 Find inside `require' and `declare-function' sexp."
   (require 'find-func)
   (let* ((beg-sexp (save-excursion (search-backward "(" (point-at-bol) t)))
-         (end-sexp (save-excursion (end-of-defun) (point)))
+         (end-sexp (save-excursion (ignore-error (end-of-defun)) (point)))
          (sexp     (and beg-sexp end-sexp
                         (buffer-substring-no-properties
                          (1+ beg-sexp) (1- end-sexp)))))


### PR DESCRIPTION
In text files, sometimes `(end-of-defun)` exits with error "can not move further" which makes the function stops instead of gracefully exit and continuing with the other find-files functionality.

Example (org-mode):
```
|
* Hello
```
Having the cursor in | and calling `C-x C-f` ends with an error. 