### PR TITLE
Update helm-this-command for emacs-28

### DIFF
--- a/helm-lib.el
+++ b/helm-lib.el
@@ -425,6 +425,9 @@ Like `this-command' but return the real command, and not
            else
            if (and (eq fn 'call-interactively)
                    (> (length btf) 2))
+           return (cadr (cdr btf))
+           if (and (eq fn 'command-execute)
+                   (> (length btf) 2))
            return (cadr (cdr btf))))
 
 

--- a/helm-lib.el
+++ b/helm-lib.el
@@ -404,8 +404,7 @@ available APPEND is ignored."
   '(helm-maybe-exit-minibuffer
     helm-confirm-and-exit-minibuffer
     helm-exit-minibuffer
-    exit-minibuffer
-    helm-M-x))
+    exit-minibuffer))
 
 (defun helm-this-command ()
   "Return the actual command in action.


### PR DESCRIPTION
Before emacs-28, `backtrace-frames` in `interactive` form looks like:
```
...
(descriptor of interactive form)
call-interactively(command)
command-execute(command)
...
```
In emacs-28, `backtrace-frame` of `call-interactively` does not exist.
This causes `helm-this-command` returns a wrong command.

I am not sure why `call-interactively` is missing between the `interactive` descriptor and `command-execute`, but anyway, we can obtain the command by the frame of `command-execute`.
Thus, `helm-this-command` is updated to check the `backtrace-frame` of `command-execute` and return the right command even while it is called in `interactive` form on emacs-28.

This update resolves problems on looking up `helm-mode` handler for the command invoked via `execute-extended-command` and other `M-x` commands as well as `helm-M-x`.