### PR TITLE
Remove whitespace in helm-M-x

### DIFF
--- a/helm-command.el
+++ b/helm-command.el
@@ -155,21 +155,21 @@ algorithm."
              unless (and (null ignore-props) (or (get sym 'helm-only) (get sym 'no-helm-mx)))
              collect
              (cons (cond ((and (string-match "^M-x" key) local-key)
-                          (format "%s %s %s %s"
+                          (format "%s%s%s %s"
                                   disp
-                                  (if doc (make-string (+ 2 (- max-len (+ (length cand)))) ? ) "")
+                                  (if doc (make-string (+ 4 (- max-len (+ (length cand)))) ? ) "")
                                   (if doc (propertize doc 'face 'helm-M-x-short-doc) "")
                                   (propertize
                                    " " 'display
                                    (propertize local-key 'face 'helm-M-x-key))))
                          ((string-match "^M-x" key)
-                          (format "%s %s %s"
+                          (format "%s%s%s"
                                   disp
-                                  (if doc (make-string (+ 2 (- max-len (+ (length cand)))) ? ) "")
+                                  (if doc (make-string (+ 4 (- max-len (+ (length cand)))) ? ) "")
                                   (if doc (propertize doc 'face 'helm-M-x-short-doc) "")))
-                         (t (format "%s %s %s %s"
+                         (t (format "%s%s%s %s"
                                     disp
-                                    (if doc (make-string (+ 2 (- max-len (+ (length cand)))) ? ) "")
+                                    (if doc (make-string (+ 4 (- max-len (+ (length cand)))) ? ) "")
                                     (if doc (propertize doc 'face 'helm-M-x-short-doc) "")
                                     (propertize
                                      " " 'display


### PR DESCRIPTION
If show-trailing-whitespace is set to true globally, it leads to an ugly
completion buffer.