### PR TITLE
Fix: `completing-read` does not pick the default item when `helm-patt…

### DIFF
--- a/helm-core.el
+++ b/helm-core.el
@@ -3611,8 +3611,6 @@ For RESUME INPUT DEFAULT and SOURCES see `helm'."
               'vertical 'horizontal))
     (setq helm--window-side-state
           (or helm-split-window-default-side 'below)))
-  ;; Call the init function for sources where appropriate
-  (helm-compute-attr-in-sources 'init sources)
   (setq helm-pattern (or (and helm-maybe-use-default-as-input
                               (or (if (listp default)
                                       (car default) default)
@@ -3620,6 +3618,8 @@ For RESUME INPUT DEFAULT and SOURCES see `helm'."
                                     (thing-at-point 'symbol))))
                          ""))
   (setq helm-input "")
+  ;; Call the init function for sources where appropriate
+  (helm-compute-attr-in-sources 'init sources)
   (clrhash helm-candidate-cache)
   (helm-create-helm-buffer)
   (helm-clear-visible-mark)


### PR DESCRIPTION
…ern` is not empty

* helm-core.el(helm-initial-setup): set `helm-pattern` before
`helm-compute-attr-in-sources` to prevent it from interfering the
`completing-read` pick the default item.

Steps to reproduce:

1. Evaluate following code:

```elisp
(progn
  (defun test-helm-completing-read ()
    (interactive)
    (completing-read "> " '("1" "2" "3") nil t nil nil "3"))

  ;; Simulate `M-x test-helm-completing-read RET'
  (minibuffer-with-setup-hook
      (lambda ()
        (let ((hook (make-symbol "hook")))
          (fset hook (lambda ()
                       (remove-hook 'post-command-hook hook)
                       (exit-minibuffer)))
          (add-hook 'post-command-hook hook)))
    (helm-M-x-read-extended-command obarray nil '("test-helm-completing-read"))))
```

2. Check the default selected item (expected "3", actual "1").

Another simpler way to reproduce:

```elisp
(let ((helm-pattern "not empty"))
  (completing-read "> " '("1" "2" "3") nil t nil nil "3"))
;; => 1
;;    2
;;    3

(let ((helm-pattern ""))
  (completing-read "> " '("1" "2" "3") nil t nil nil "3"))
;; => 3
;;    1
;;    2
```