### PR TITLE
Fix helm-occur when previous mark is outside active region

### DIFF
--- a/helm-occur.el
+++ b/helm-occur.el
@@ -211,11 +211,15 @@ engine beeing completely different and also much faster."
         ;; When user mark defun with `mark-defun' with intention of
         ;; using helm-occur on this region, it is relevant to use the
         ;; thing-at-point located at previous position which have been
-        ;; pushed to `mark-ring'.
-        (setq def (save-excursion
-                    (goto-char (setq pos (car mark-ring)))
-                    (helm-aif (thing-at-point 'symbol) (regexp-quote it))))
-        (narrow-to-region (region-beginning) (region-end)))
+        ;; pushed to `mark-ring', if it's within the active region.
+        (let ((beg (region-beginning))
+              (end (region-end))
+              (prev-pos (car mark-ring)))
+          (when (and prev-pos (>= prev-pos beg) (< prev-pos end))
+            (setq def (save-excursion
+                        (goto-char (setq pos prev-pos))
+                        (helm-aif (thing-at-point 'symbol) (regexp-quote it)))))
+          (narrow-to-region beg end)))
       (unwind-protect
            (helm :sources 'helm-source-occur
                  :buffer "*helm occur*"


### PR DESCRIPTION
The previous mark, i.e. `(car mark-ring)`, is not always within the active region. A common example would be if the user just shift-selected something.

This PR only fixes the bug. 

I would further suggest using some kind of heuristic (customizable or not) to determine if `helm-occur` should really narrow to the active region or not. 

Consider the case where the user just selected some small piece of text and wants to "`occur`" it:

Instead of `narrow-to-region`, `helm-occur` could use the region text itself for `(helm)` `:default`. 

A quick heuristic would be `(when (> (- end beg) 500) (narrow-to-region beg end))`.