### PR TITLE
fix in helm--run-init-hooks for funcall when hv is list

### DIFF
--- a/helm-core.el
+++ b/helm-core.el
@@ -3719,9 +3719,10 @@ For RESUME INPUT DEFAULT and SOURCES see `helm'."
 See :after-init-hook and :before-init-hook in `helm-source'."
   (cl-loop for s in sources
            for hv = (assoc-default hook s)
-           if (and hv (not (symbolp hv))) ; A lambda.
-           do (funcall hv) ; Should raise an error with a list of lambdas.
-           else do (helm-log-run-hook hv)))
+           do (cl-typecase hv
+                (function (funcall hv))
+                (list (when (= (length hv) 1) (funcall (car hv))))
+                (t (helm-log-run-hook hv)))))
 
 (defun helm-restore-position-on-quit ()
   "Restore position in `helm-current-buffer' when quitting."


### PR DESCRIPTION
this PR is just [the snippet proposed in this issue](https://github.com/emacs-helm/helm/issues/2537) in case it suits (the `when` swallows the case of `hv` being `nil` vs passing that too into `helm-log-run-hook`)