### PR TITLE
Let dabbrev complete function names from PHP function calls

### DIFF
--- a/helm-dabbrev.el
+++ b/helm-dabbrev.el
@@ -1,6 +1,6 @@
 ;;; helm-dabbrev.el --- Helm implementation of dabbrev. -*- lexical-binding: t -*-
 
-;; Copyright (C) 2012 ~ 2021 Thierry Volpiatto 
+;; Copyright (C) 2012 ~ 2021 Thierry Volpiatto
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -105,7 +105,7 @@ initial search for all candidates in buffer(s)."
                         'helm-dabbrev-separator-regexp "2.8.3")
 ;; Check for beginning of line should happen last (^\n\\|^).
 (defvar helm-dabbrev-separator-regexp
-  "\\s-\\|\t\\|[(\\[\\{\"'`=<$;,@.#+]\\|\\s\\\\|^\n\\|^"
+  "\\s-\\|\t\\|[(\\[\\{\"'`=<>$;,@.#+]\\|\\s\\\\|^\n\\|^"
   "Regexp matching the start of a dabbrev candidate.")
 
 


### PR DESCRIPTION
Function calls in PHP are chained with "->":

    $this->someFunc()->someOtherFunc()->varname

helm-dabbrev does not complete such function names.
When typing "someF" and invoking helm-dabbrev, nothing gets completed.

The solution is to add ">" to the regex definining the
start of an expansion.

I hope this does not break other languages.