### PR TITLE
Set "helm-pattern" to "input" to avoid the source conetent refreshed by "helm-resume"

### DIFF
--- a/helm-core.el
+++ b/helm-core.el
@@ -3894,7 +3894,8 @@ For PRESELECT RESUME KEYMAP DEFAULT HISTORY, see `helm'."
                 helm-execute-action-at-once-if-one)
       (helm-log "helm-quit-if-no-candidate = %S" helm-quit-if-no-candidate)
       (when (and src (helm-resume-p resume))
-        (helm-display-mode-line src))
+        (helm-display-mode-line src)
+        (setq helm-pattern input))
       ;; Reset `helm-pattern' and update
       ;; display if no result found with precedent value of `helm-pattern'
       ;; unless `helm-quit-if-no-candidate' is non-`nil', in this case


### PR DESCRIPTION
When using "helm-resume" to resume previous "helm-do-grep-ag", the grep content is always updated (re-executed) and previous selection is lost.
The problem is caused by that the "helm-pattern" is not reset to previous "input", and it causes "helm-check-new-input" check that it need to update the helm buffer.
