### PR TITLE
do not try using tramp-file-name-unify if isn't there

### DIFF
--- a/helm-files.el
+++ b/helm-files.el
@@ -3221,7 +3221,8 @@ debugging purpose."
     (file-accessible-directory-p path)))
 
 (defvar helm-ff--file-accessible-directory-p-fn
-  (if (equal (func-arity 'tramp-file-name-unify) '(1 . 2))
+  ;; Handle the emacs-27 case, where `tramp-file-name-unify` isn't defined.
+  (if (and (fboundp 'tramp-file-name-unify) (equal (func-arity 'tramp-file-name-unify) '(1 . 2)))
       #'helm-ff--file-accessible-directory-p
     #'file-accessible-directory-p))
 


### PR DESCRIPTION
Solves issue #2544 by checking if `tramp-file-name-unify` is defined as a function before trying to use it.