### PR TITLE
Add helm-fd-mode-line-function customization

### DIFF
--- a/helm-fd.el
+++ b/helm-fd.el
@@ -1,6 +1,6 @@
 ;;; helm-fd.el --- helm interface for fd command line tool. -*- lexical-binding: t -*-
 
-;; Copyright (C) 2012 ~ 2021 Thierry Volpiatto 
+;; Copyright (C) 2012 ~ 2021 Thierry Volpiatto
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -28,6 +28,11 @@
 (defcustom helm-fd-switches '("--no-ignore" "--hidden" "--type" "f" "--type" "d" "--color" "always")
   "A list of options to pass to fd shell command."
   :type '(repeat string)
+  :group 'helm-files)
+
+(defcustom helm-fd-mode-line-function 'helm-fd-default-mode-line
+  "Function called when `fd' process is finished to format mode-line."
+  :type 'function
   :group 'helm-files)
 
 (defface helm-fd-finish
@@ -92,19 +97,24 @@
        proc (lambda (_process event)
               (if (string= event "finished\n")
                   (with-helm-window
-                    (setq mode-line-format
-                          `(" " mode-line-buffer-identification " "
-                            (:eval (format "L%s" (helm-candidate-number-at-point))) " "
-                            (:eval (propertize
-                                    (format
-                                     "[%s process finished in %.2fs - (%s results)] "
-                                     ,fd-version
-                                     ,(- (float-time) start-time)
-                                     (helm-get-candidate-number))
-                                    'face 'helm-fd-finish))))
-                    (force-mode-line-update))
+                    (when helm-fd-mode-line-function
+                      (funcall helm-fd-mode-line-function start-time fd-version)
+                      (force-mode-line-update)))
                 (helm-log "helm-fd-process sentinel" "Error: Fd %s"
                           (replace-regexp-in-string "\n" "" event))))))))
+
+(defun helm-fd-default-mode-line (start-time fd-version)
+  "Format mode-line with START-TIME and FD-VERSION, as well as `fd' results."
+  (setq mode-line-format
+        `(" " mode-line-buffer-identification " "
+          (:eval (format "L%s" (helm-candidate-number-at-point))) " "
+          (:eval (propertize
+                  (format
+                   "[%s process finished in %.2fs - (%s results)] "
+                   ,fd-version
+                   ,(- (float-time) start-time)
+                   (helm-get-candidate-number))
+                  'face 'helm-fd-finish)))))
 
 (defun helm-fd-fct (candidates _source)
   "The filtered-candidate-transformer function for helm-fd."


### PR DESCRIPTION
Add the `helm-fd-mode-line-function` customization with default `helm-fd-default-mode-line` which is the same behavior as before.

This is inspired by what `helm-ag` does with `helm-ag-show-status-function`.

It is also useful for `doom-modeline` as there is no other way to customize the mode-line with `helm-fd`.
See [seagle0128/doom-modeline#584](https://github.com/seagle0128/doom-modeline/issues/584)