### PR TITLE
Replace split-string with split-string-shell-command to prevent spaces inside quotes from being considered as separators

### DIFF
--- a/helm-fd.el
+++ b/helm-fd.el
@@ -83,7 +83,9 @@
 (defun helm-fd-process ()
   "Initialize fd process in an helm async source."
   (let* (process-connection-type
-         (cmd (append helm-fd-switches (split-string-shell-command helm-pattern)))
+         (cmd (append helm-fd-switches
+                      (or (and (fboundp #'split-string-shell-command) (split-string-shell-command helm-pattern))
+                          (split-string helm-pattern))))
          (proc (apply #'start-process "fd" nil helm-fd-executable cmd))
          (start-time (float-time))
          (fd-version (replace-regexp-in-string

--- a/helm-fd.el
+++ b/helm-fd.el
@@ -83,7 +83,7 @@
 (defun helm-fd-process ()
   "Initialize fd process in an helm async source."
   (let* (process-connection-type
-         (cmd (append helm-fd-switches (split-string helm-pattern " ")))
+         (cmd (append helm-fd-switches (split-string-shell-command helm-pattern)))
          (proc (apply #'start-process "fd" nil helm-fd-executable cmd))
          (start-time (float-time))
          (fd-version (replace-regexp-in-string


### PR DESCRIPTION
I sometimes use helm-fd with additional arguments and whenever there is a space between quotes the call to fd returns an error.
The function `split-string-shell-command` corrects the behavior.