### PR TITLE
support case when `HIST` is `t` in completing-read

### DIFF
--- a/helm-mode.el
+++ b/helm-mode.el
@@ -883,8 +883,8 @@ that use `helm-comp-read'.  See `helm-M-x' for example."
                          :history (and (symbolp input-history) input-history)
                          :buffer buffer))
         (remove-hook 'helm-after-update-hook 'helm-comp-read--move-to-first-real-candidate))
-      ;; If `history' is a symbol save it. but when `history' is t, meaning not to remember history.
-      (when (and result history (symbolp history) (not (eq history 't)))
+      ;; If `history' is a symbol save it, except when it is t.
+      (when (and result history (symbolp history) (not (eq history t)))
         (set history
              ;; RESULT may be a a string or a list of strings bug #2461.
              (delete-dups (append (mapcar #'substring-no-properties (helm-mklist result))

--- a/helm-mode.el
+++ b/helm-mode.el
@@ -883,8 +883,8 @@ that use `helm-comp-read'.  See `helm-M-x' for example."
                          :history (and (symbolp input-history) input-history)
                          :buffer buffer))
         (remove-hook 'helm-after-update-hook 'helm-comp-read--move-to-first-real-candidate))
-      ;; If `history' is a symbol save it.
-      (when (and result history (symbolp history))
+      ;; If `history' is a symbol save it. but when `history' is t, meaning not to remember history.
+      (when (and result history (symbolp history) (not (eq history 't)))
         (set history
              ;; RESULT may be a a string or a list of strings bug #2461.
              (delete-dups (append (mapcar #'substring-no-properties (helm-mklist result))


### PR DESCRIPTION
from emacs's documentation, when `HIST` is `t`, history is not recorded. while `delete-dups` is expecting a list

```
HIST, if non-nil, specifies a history list and optionally the initial
  position in the list.  It can be a symbol, which is the history list
  variable to use, or it can be a cons cell (HISTVAR . HISTPOS).  In
  that case, HISTVAR is the history list variable to use, and HISTPOS
  is the initial position (the position in the list used by the
  minibuffer history commands).  For consistency, you should also
  specify that element of the history as the value of INITIAL-INPUT.
  (This is the only case in which you should use INITIAL-INPUT instead
  of DEF.)  Positions are counted starting from 1 at the beginning of
  the list.  The variable ‘history-length’ controls the maximum length
  of a history list.  If HIST is t, history is not recorded. ;; <== here

```