### PR TITLE
Don't require entire packages if the autoloads.el exists

### DIFF
--- a/helm-command.el
+++ b/helm-command.el
@@ -19,10 +19,10 @@
 
 (require 'cl-lib)
 (require 'helm)
-(require 'helm-help)
-(require 'helm-mode)
-(require 'helm-elisp)
-
+(unless (require 'helm-autoloads nil t)
+  (require 'helm-help)
+  (require 'helm-mode)
+  (require 'helm-elisp))
 
 (defvar helm-M-x-map
   (let ((map (make-sparse-keymap)))

--- a/helm-mode.el
+++ b/helm-mode.el
@@ -20,8 +20,9 @@
 (require 'cl-lib)
 (require 'helm)
 (require 'helm-lib)
-(require 'helm-files)
-(require 'helm-misc)
+(unless (require 'helm-autoloads nil t)
+  (require 'helm-files)
+  (require 'helm-misc))
 
 (defvar crm-separator)
 (defvar ido-everywhere)


### PR DESCRIPTION
Hi,

When executing the `helm-M-x`, it will trigger full loading for the `helm-files` and `helm-miscs` ...,  extremely slow on my machine (an old machine).
This change will use the autoloads mechanism to improve the performance if the `helm-autoloads.el` was generated by the `package` manager in  installation.
I use it on my local for half of month, it works great.
Please help review and approve this patch. Thanks.