### PR TITLE
show all blocks if necessary when go to char

### DIFF
--- a/helm-utils.el
+++ b/helm-utils.el
@@ -1,6 +1,6 @@
 ;;; helm-utils.el --- Utilities Functions for helm. -*- lexical-binding: t -*-
 
-;; Copyright (C) 2012 ~ 2023 Thierry Volpiatto 
+;; Copyright (C) 2012 ~ 2023 Thierry Volpiatto
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -506,7 +506,7 @@ Default is `helm-current-buffer'."
                    #'outline-show-subtree)
                   ((and (boundp 'hs-minor-mode)
                     hs-minor-mode)
-                   #'hs-show-block)
+                   #'hs-show-all)
                   ((and (boundp 'markdown-mode-map)
                         (derived-mode-p 'markdown-mode))
                    #'markdown-show-entry)))


### PR DESCRIPTION
Hi,

Currently, `helm-goto-char` only show the current hidden block (when `hideshow` mode is enabled), which might make it incorrectly jump to a location, if more blocks are hidden.

I fix this issue by calling `hs-show-all` instead.

Can you check and consider merging this PR?

Thanks!