### PR TITLE
Cygwin compatibility for helm-open-file-with-default-tool

### DIFF
--- a/helm-utils.el
+++ b/helm-utils.el
@@ -1071,7 +1071,9 @@ Assume regexp is a pcre based regexp."
                             "xdg-open")
                            ((or (eq system-type 'darwin) ;; Mac OS X
                                 (eq system-type 'macos)) ;; Mac OS 9
-                            "open"))
+                            "open")
+			   ((eq system-type 'cygwin)
+			    "cygstart"))
                      file))))
 
 (defun helm-open-dired (file)


### PR DESCRIPTION
Fixes #2619

Cygwin also provides an xdg-open(1) (from xdg-utils in X11) but
cygstart(1) (from cygutils in Base) is more likely to be installed.
