### PR TITLE
Fix helm-completion--initial-filter for candidates with no affixation

### DIFF
--- a/helm-mode.el
+++ b/helm-mode.el
@@ -2236,6 +2236,7 @@ When AFUN, AFIX are nil and CATEGORY is not file return COMPS unmodified."
                 (if (functionp affixations)
                     (cl-loop for comp in comps
                              for cand = (funcall affixations comp)
+                             when cand
                              collect (cons (propertize (concat (nth 1 cand) ;prefix
                                                                (nth 0 cand) ;comp
                                                                (nth 2 cand)) ;suffix


### PR DESCRIPTION
For cases such as [helm-completion-library-affixation](https://github.com/emacs-helm/helm/blob/e9cc7a80d0c01d6714400e662136733af7ddeee3/helm-mode.el#L1302) which can return nil.
