### PR TITLE
Where to compress input files to

### DIFF
--- a/helm-files.el
+++ b/helm-files.el
@@ -1255,13 +1255,15 @@ ACTION can be `rsync' or any action supported by `helm-dired-action'."
                                              (regexp-quote
                                               (if helm-ff-transformer-show-only-basename
                                                   (helm-basename cand) cand))))
-                        :initial-input (helm-dwim-target-directory)
+                        :initial-input (if (eq action 'compress)
+                                           (helm-common-dir ifiles)
+                                           (helm-dwim-target-directory))
                         :default (when (eq action 'compress)
                                    (expand-file-name
                                     (format "%s.tar.gz" (if cand
                                                             (helm-basename cand)
                                                           "new_archive"))
-                                    helm-ff-default-directory))
+                                    (helm-common-dir ifiles)))
                         :history (helm-find-files-history nil :comp-read nil))))))
          (dest-dir-p (file-directory-p dest))
          (dest-dir   (if dest-dir-p dest (helm-basedir dest))))

--- a/helm-files.el
+++ b/helm-files.el
@@ -1239,32 +1239,44 @@ ACTION can be `rsync' or any action supported by `helm-dired-action'."
          (helm-actions-inherit-frame-settings t)
          helm-use-frame-when-more-than-two-windows
          (dest (or target
-                   (with-helm-display-marked-candidates
-                     helm-marked-buffer-name
-                     (if (eq action 'compress)
-                         (mapcar
-                          (lambda (f)
-                            (file-relative-name f (helm-common-dir ifiles)))
-                          ifiles)
-                       (helm-ff--count-and-collect-dups ifiles))
-                     (with-helm-current-buffer
-                       (helm-read-file-name
-                        prompt
-                        :preselect (when cand
-                                     (format helm-ff-last-expanded-candidate-regexp
-                                             (regexp-quote
-                                              (if helm-ff-transformer-show-only-basename
-                                                  (helm-basename cand) cand))))
-                        :initial-input (if (eq action 'compress)
-                                           (helm-common-dir ifiles)
-                                           (helm-dwim-target-directory))
-                        :default (when (eq action 'compress)
-                                   (expand-file-name
-                                    (format "%s.tar.gz" (if cand
-                                                            (helm-basename cand)
-                                                          "new_archive"))
-                                    (helm-common-dir ifiles)))
-                        :history (helm-find-files-history nil :comp-read nil))))))
+                   (if (eq action 'compress)
+                       (let ((cdir (helm-common-dir ifiles)))
+                         (with-helm-display-marked-candidates
+                           helm-marked-buffer-name
+                           (mapcar
+                            (lambda (f)
+                              (file-relative-name f cdir))
+                            ifiles)
+                           (with-helm-current-buffer
+                             (helm-read-file-name
+                              prompt
+                              :preselect
+                              (when cand
+                                (format helm-ff-last-expanded-candidate-regexp
+                                        (regexp-quote
+                                         (if helm-ff-transformer-show-only-basename
+                                             (helm-basename cand) cand))))
+                              :initial-input cdir
+                              :default (expand-file-name
+                                        (format "%s.tar.gz" (if cand
+                                                                (helm-basename cand)
+                                                              "new_archive"))
+                                        cdir)
+                              :history (helm-find-files-history nil :comp-read nil)))))
+                     (with-helm-display-marked-candidates
+                       helm-marked-buffer-name
+                       (helm-ff--count-and-collect-dups ifiles)
+                       (with-helm-current-buffer
+                         (helm-read-file-name
+                          prompt
+                          :preselect
+                          (when cand
+                            (format helm-ff-last-expanded-candidate-regexp
+                                    (regexp-quote
+                                     (if helm-ff-transformer-show-only-basename
+                                         (helm-basename cand) cand))))
+                          :initial-input (helm-dwim-target-directory)
+                          :history (helm-find-files-history nil :comp-read nil)))))))
          (dest-dir-p (file-directory-p dest))
          (dest-dir   (if dest-dir-p dest (helm-basedir dest))))
     ;; We still need to handle directory creation for Emacs version < 27.1 that


### PR DESCRIPTION
When `helm-find-files-compress-to` compresses files in different directory layers, it is more convenient to set location of the archive file to be the common directory of the input files.