### PR TITLE
"while-no-input" on/off by defcustom "helm-update-edebug" for edebug.

### DIFF
--- a/helm-core.el
+++ b/helm-core.el
@@ -1122,6 +1122,14 @@ You can toggle later `truncate-lines' with
 Set this to an empty string if you don't want prefix in margin when marking."
   :group 'helm
   :type 'string)
+
+(defcustom helm-update-edebug nil
+  "Development feature.
+If set to true then all functions invoked after `helm-update' can be instrumented by
+`edebug' for stepping. `helm--maybe-use-while-no-input' then doesn't use `while-no-input',
+because `while-no-input' throws on `edebug' command key input."
+  :group 'helm
+  :type 'boolean)
 
 ;;; Faces
 ;;
@@ -4959,8 +4967,9 @@ Unlike `while-no-input' this macro ensure to not returns `t'."
 (defmacro helm--maybe-use-while-no-input (&rest body)
   "Wrap BODY in `helm-while-no-input' unless initializing a remote connection."
   `(progn
-     (if (and (file-remote-p helm-pattern)
-              (not (file-remote-p helm-pattern nil t)))
+     (if (or (and (file-remote-p helm-pattern)
+                  (not (file-remote-p helm-pattern nil t)))
+             helm-update-edebug)
          ;; Tramp will ask for passwd, don't use `helm-while-no-input'.
          ,@body
        (helm-log "helm--maybe-use-while-no-input"

--- a/helm-core.el
+++ b/helm-core.el
@@ -1122,14 +1122,6 @@ You can toggle later `truncate-lines' with
 Set this to an empty string if you don't want prefix in margin when marking."
   :group 'helm
   :type 'string)
-
-(defcustom helm-update-edebug nil
-  "Development feature.
-If set to true then all functions invoked after `helm-update' can be instrumented by
-`edebug' for stepping. `helm--maybe-use-while-no-input' then doesn't use `while-no-input',
-because `while-no-input' throws on `edebug' command key input."
-  :group 'helm
-  :type 'boolean)
 
 ;;; Faces
 ;;
@@ -4963,6 +4955,12 @@ Unlike `while-no-input' this macro ensure to not returns `t'."
                   (setq quit-flag nil))
                  (quit-flag nil)
                  (t val)))))))
+
+(defvar helm-update-edebug nil
+  "Development feature.
+If set to true then all functions invoked after `helm-update' can be instrumented by
+`edebug' for stepping. `helm--maybe-use-while-no-input' then doesn't use `while-no-input',
+because `while-no-input' throws on `edebug' command key input.")
 
 (defmacro helm--maybe-use-while-no-input (&rest body)
   "Wrap BODY in `helm-while-no-input' unless initializing a remote connection."


### PR DESCRIPTION
Copied from opened issue:

Helm uses `while-no-input` Emacs' macro to wrap computation of current candidates that are discarded each time when new keyboard input occurs during its evaluation, in order to recompute candidate matches anew and refill Helm buffer.
That macro throws up a call stack to `helm--collect-matches`(invoked in `helm-update`), so any function called by code after `helm-update` is not debuggable by instrumenting with edebug for stepping. Pressing space key to step forward in `edebug` is caught as input by `while-no-input` and thrown up to `helm--collect-matches`.

Helm disables `while-no-input` for remote files in a `helm--maybe-use-while-no-input`, and this conditional can be augmented by a new boolean defcustom "helm-update-edebug" that when set also disables `while-no-input` and all the code in sources/filters/formatters becomes debuggable.