### PR TITLE
When creating a new buffer, also use "major-mode-remap-alist" to determine the major mode

### DIFF
--- a/helm-buffers.el
+++ b/helm-buffers.el
@@ -327,13 +327,13 @@ Note that this variable is buffer-local.")
    (help-message :initform 'helm-buffer-help-message)))
 
 (cl-defun helm-buffers-create-new-buffer-1 (candidate &optional (display-func 'switch-to-buffer))
-  (let ((mjm (or (and helm-current-prefix-arg
-                      (intern-soft (helm-comp-read
-                                    "Major-mode: "
-                                    helm-buffers-favorite-modes)))
-                 (cl-loop for (r . m) in auto-mode-alist
-                          when (string-match r candidate)
-                          return m)))
+  (let ((mjm (major-mode-remap
+              (or (and helm-current-prefix-arg
+                       (intern-soft (helm-comp-read
+                                     "Major-mode: "
+                                     helm-buffers-favorite-modes)))
+                  (alist-get candidate auto-mode-alist nil nil #'string-match)
+                  )))
         (buffer (get-buffer-create candidate)))
     (if mjm
         (with-current-buffer buffer (funcall mjm))


### PR DESCRIPTION
When enabling "*-ts-mode" by default, normally it can add a new association to "major-mode-remap-alist", such as, 

`    (add-to-list 'major-mode-remap-alist '(c++-mode . c++-ts-mode))
`

When helm creating a new buffer, it needs to consider both the auto-mode-alist and the related remap alists.