### PR TITLE
* helm-core.el (helm-exit-and-execute-action): Works with Emacs30 lambda changes

### DIFF
--- a/helm-core.el
+++ b/helm-core.el
@@ -2492,12 +2492,12 @@ i.e. functions called with RET."
   (let ((actions (helm-get-actions-from-current-source)))
     (when actions
       (cl-assert (or (eq action actions)
+                     ;; Lambdas
+                     (functionp action)
                      ;; Compiled lambdas
                      (byte-code-function-p action)
                      ;; Natively compiled (libgccjit)
                      (helm-subr-native-elisp-p action)
-                     ;; Lambdas
-                     (and (listp action) (functionp action))
                      ;; One of current actions.
                      (rassq action actions))
                  nil "No such action `%s' for this source" action)))


### PR DESCRIPTION
Hi,
An error happened and helm discontinued:
> cl--assertion-failed: No such action ‘#[(candidate) ((spacemacs//helm-open-buffers-in-windows (helm-marked-candidates))) nil]’ for this source

The assert failed on `(and (listp action) (functionp action))` for the `action` is a `lambda`.
It caused by the latest Emacs had changed the `lambda` function to `interpreted-function`:
> Evaluating a 'lambda' returns an object of type 'interpreted-function'.

https://github.com/emacsmirror/emacs/commit/f2bccae22bd47a2e7e0937b78ea06131711b935a#diff-731c852b7c27c6ee90c44c871e2988ecfc2d225bc720156d7a47c1d563c2683a

This PR will fix the error. 
Please help review the changes. Thanks.