### PR TITLE
fix(helm-files): outdated cache and errors when finding files in Docker

### DIFF
--- a/helm-files.el
+++ b/helm-files.el
@@ -1,6 +1,6 @@
 ;;; helm-files.el --- helm file browser and related. -*- lexical-binding: t -*-
 
-;; Copyright (C) 2012 ~ 2023 Thierry Volpiatto 
+;; Copyright (C) 2012 ~ 2023 Thierry Volpiatto
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -239,7 +239,7 @@ Should not be used among other sources.")
     (define-key map (kbd "C-c C-a")       'helm-ff-run-mail-attach-files)
     (define-key map (kbd "C-c p")         'helm-ff-run-print-file)
     (define-key map (kbd "C-c /")         'helm-ff-run-find-sh-command)
-    (define-key map (kbd "C-/")           'helm-ff-run-fd) 
+    (define-key map (kbd "C-/")           'helm-ff-run-fd)
     ;; Next 2 have no effect if candidate is not an image file.
     (define-key map (kbd "M-l")           'helm-ff-rotate-left-persistent)
     (define-key map (kbd "M-r")           'helm-ff-rotate-right-persistent)
@@ -1858,7 +1858,7 @@ this working."
                 (setq cmd-line (format command mapfiles)) ; See [1]
               (setq cmd-line (format "%s %s" command mapfiles)))
             (eshell-command cmd-line))
-        
+
         ;; Run eshell-command sequencially on EACH marked files.
         ;; To work with tramp handler we have to call
         ;; COMMAND on basename of each file, using
@@ -2137,7 +2137,7 @@ prefix arg shell buffer doesn't exists, create it and switch to it."
                when (file-directory-p r)
                ;; We can use this as long as this filtering function
                ;; is called after `helm-ff-fct' otherwise candidates
-               ;; may not be cons cell at first call [1]. 
+               ;; may not be cons cell at first call [1].
                collect (cons d r))
     candidates))
 
@@ -3607,7 +3607,7 @@ debugging purpose."
           ;; Check here if directory is accessible (not working on Windows).
           ((and (file-directory-p path) (not (file-readable-p path)))
            ;; Prefix error message with @@@@ for safety
-           ;; (some files may match file-error See bug#2400) 
+           ;; (some files may match file-error See bug#2400)
            (list (cons (format "@@@@file-error: Opening directory permission denied `%s'" path)
                        path)))
           ;; A fast expansion of PATH is made only if `helm-ff-auto-update-flag'
@@ -3785,7 +3785,7 @@ later in the transformer."
 ;; bug#2542.
 ;; Store here associations of (truename . symlink) when opening a
 ;; symlinked directory, then add the watch to the truename; When the
-;; watcher ring on the truename remove the symlinked directory from cache.  
+;; watcher ring on the truename remove the symlinked directory from cache.
 (defvar helm-ff--list-directory-links nil)
 
 (defun helm-ff-directory-files (directory &optional force-update)
@@ -3805,6 +3805,7 @@ in cache."
       (cl-pushnew (cons truename directory)
                   helm-ff--list-directory-links :test 'equal))
     (or (and (not force-update)
+             (not (file-remote-p directory))
              (gethash directory helm-ff--list-directory-cache))
         (let* (file-error
                (ls   (condition-case err
@@ -3818,7 +3819,7 @@ in cache."
                        (file-error
                         (prog1
                             ;; Prefix error message with @@@@ for safety
-                            ;; (some files may match file-error See bug#2400) 
+                            ;; (some files may match file-error See bug#2400)
                             (list (format "@@@@%s:%s"
                                           (car err)
                                           (mapconcat 'identity (cdr err) " ")))
@@ -3834,33 +3835,34 @@ in cache."
                                 when (helm-ff-filter-candidate-one-by-one f)
                                 collect it)
                        helm-ff--list-directory-cache)
-            ;; Put an inotify watcher to check directory modifications.
-            (unless (or (null helm-ff-use-notify)
-                        (member method helm-ff-inotify-unsupported-methods)
-                        (helm-aand (setq watcher (gethash
-                                                  directory
-                                                  helm-ff--file-notify-watchers))
-                                   ;; [1] If watcher is invalid enter
-                                   ;; next and delete it.
-                                   (file-notify-valid-p it)))
-              (condition-case-unless-debug err
-                  (let ((to-watch (or truename directory)))
-                    (when watcher
-                      ;; If watcher is still in cache and we are here,
-                      ;; that's mean test [1] above fails and watcher
-                      ;; is invalid, so delete it.
-                      (file-notify-rm-watch watcher)
-                      (remhash directory helm-ff--file-notify-watchers))
-                    ;; Keep adding DIRECTORY to
-                    ;; helm-ff--file-notify-watchers but watch on the
-                    ;; truename and not the symlink as before bug#2542.
-                    (puthash directory
-                             (file-notify-add-watch
-                              to-watch
-                              '(change attribute-change)
-                              (helm-ff--inotify-make-callback to-watch))
-                             helm-ff--file-notify-watchers))
-                (file-notify-error (user-error "Error: %S %S" (car err) (cdr err))))))))))
+            (ignore-errors
+              ;; Put an inotify watcher to check directory modifications.
+              (unless (or (null helm-ff-use-notify)
+                          (member method helm-ff-inotify-unsupported-methods)
+                          (helm-aand (setq watcher (gethash
+                                                    directory
+                                                    helm-ff--file-notify-watchers))
+                                     ;; [1] If watcher is invalid enter
+                                     ;; next and delete it.
+                                     (file-notify-valid-p it)))
+                (condition-case-unless-debug err
+                    (let ((to-watch (or truename directory)))
+                      (when watcher
+                        ;; If watcher is still in cache and we are here,
+                        ;; that's mean test [1] above fails and watcher
+                        ;; is invalid, so delete it.
+                        (file-notify-rm-watch watcher)
+                        (remhash directory helm-ff--file-notify-watchers))
+                      ;; Keep adding DIRECTORY to
+                      ;; helm-ff--file-notify-watchers but watch on the
+                      ;; truename and not the symlink as before bug#2542.
+                      (puthash directory
+                               (file-notify-add-watch
+                                to-watch
+                                '(change attribute-change)
+                                (helm-ff--inotify-make-callback to-watch))
+                               helm-ff--file-notify-watchers))
+                  (file-notify-error (user-error "Error: %S %S" (car err) (cdr err)))))))))))
 
 (defun helm-ff--inotify-make-callback (directory)
   "Return a callback for `file-notify-add-watch'."
@@ -3894,7 +3896,7 @@ Remove as well all related file-notify watchers.
 
 This is meant to run in `tramp-cleanup-connection-hook'."
   (cl-loop for key being the hash-keys in helm-ff--list-directory-cache
-           when (equal (file-remote-p key 'method) (cadr vec)) 
+           when (equal (file-remote-p key 'method) (cadr vec))
            do (remhash key helm-ff--list-directory-cache))
   (cl-loop for key being the hash-keys in helm-ff--file-notify-watchers
            when (equal (file-remote-p key 'method) (cadr vec))
@@ -4342,7 +4344,7 @@ If SKIP-BORING-CHECK is non nil don't filter boring files."
                        (file-error
                         ;; Possible error not happening during listing
                         ;; but when calling file-attributes see error
-                        ;; with sshfs bug#2405 
+                        ;; with sshfs bug#2405
                         (message "%s:%s" (car err) (cdr err)) nil)))
                (type (car attr))
                x-bit)
@@ -4667,7 +4669,7 @@ with `helm-ff-trash-list'."
 (cl-defun helm-ff-trash-list (&optional (trash-dir nil strash-dir))
   "Return an alist of trashed files basename and dest name.
 Assume the trash system in use is freedesktop compatible, see
-<http://freedesktop.org/wiki/Specifications/trash-spec> 
+<http://freedesktop.org/wiki/Specifications/trash-spec>
 This function is intended to be used from a trash directory i.e. it
 use `helm-ff-default-directory', but it may be used elsewhere by
 specifying the trash directory with TRASH-DIR arg."
@@ -4876,7 +4878,7 @@ This affects directly file CANDIDATE."
         (ext   (file-name-extension candidate)))
     (and file
          (or image (not (member ext helm-ff-follow-blacklist-file-exts))))))
-    
+
 (cl-defun helm-find-files-persistent-action-if (candidate)
   "Open subtree CANDIDATE without quitting helm.
 If CANDIDATE is not a directory expand CANDIDATE filename.
@@ -5253,7 +5255,7 @@ Special commands:
                      (cons disp img))
                    else collect (cons disp img))
         ;; Ensure this is done AFTER previous clause otherwise thumb files will
-        ;; never be created if they don't already exist. 
+        ;; never be created if they don't already exist.
         (cl-pushnew helm-ff-default-directory
                     helm-ff--thumbnailed-directories :test 'equal))
     candidates))
@@ -6105,7 +6107,7 @@ When `helm-trash-default-directory' is set use it as trash directory."
     ;; Just return nil if the Trash directory is not yet created. It will be
     ;; created later by `delete-directory'.
     (and (file-exists-p trash-files-dir) trash-files-dir)))
-      
+
 (cl-defun helm-ff-file-already-trashed (file &optional (trash-alist nil strash-alist))
   "Return FILE when it is already in trash.
 
@@ -6609,7 +6611,7 @@ be directories."
                         (dired-async--modeline-mode -1))
                       (run-with-idle-timer
                        0.1 nil
-                       (lambda ()                    
+                       (lambda ()
                          (dired-async-mode-line-message
                           "Mcp done, %s %s of %s done, %s files skipped"
                           'dired-async-message


### PR DESCRIPTION
Hi,

I notice that when finding files in a Docker container, new changes in its file system aren't notified back to Helm in the host machine, or some errors occur when the guest system tries to notify the changes.

I fixed this issue by ignoring the errors, so `helm-ff-directory-files` can still return the result.

I also added a condition to only use cached result on non-remote file system.

Can you help to review and merge this PR?

Thanks!