### PR TITLE
fix(#2669): exit-fun is not called with 'exact in helm-mode.el

### DIFF
--- a/helm-mode.el
+++ b/helm-mode.el
@@ -2714,11 +2714,10 @@ Can be used for `completion-in-region-function' by advicing it with an
         ;; really bad (see bug#2646).
         (when (and (stringp string) exit-fun)
           (funcall exit-fun string
-                   (helm-acase (try-completion initial-input collection predicate)
-                     ((guard (and (stringp it)
-                                  (string-match "/\\'" it)))
-                      'exact)
-                     (t 'finished))))
+                   (if (string-match "/\\'" string)
+                   'exact
+                   'finished)
+                   ))
         (remove-hook 'helm-before-action-hook 'helm-completion-in-region--selection)
         (customize-set-variable 'helm-completion-style old--helm-completion-style)
         (setq helm-completion--sorting-done nil)


### PR DESCRIPTION
Hi, 

As I reported in <https://github.com/emacs-helm/helm/issues/2669>, there seems undesired behavior in helm on shell mode. 

>Function is called with 'exact if the return value of
>        ;; `try-completion' is a string ending with / (possibly a directory
>        ;; Bug#2274),

I thought, for the purpose there is no need to call try-completion and to check selected string is enough.
I confirmed my modification works well in my environment.
Can you help to review and merge this PR?
