### PR TITLE
Strip symbol wrappers

### DIFF
--- a/helm-elisp.el
+++ b/helm-elisp.el
@@ -797,6 +797,10 @@ is only used to test DEFAULT."
                          (helm-get-current-source)))))
 
 (defun helm-apropos-get-default ()
+  "Return the default symbol name at point.
+In Org derived modes, strip the tilde (`~') or equal (`=') characters
+before returning the symbol name. Otherwise, return the symbol name as
+it is. Return the symbol name as a string, or nil if no symbol is found."
   (with-syntax-table emacs-lisp-mode-syntax-table
     (let* ((symbol (thing-at-point 'symbol t))
            (symbol-string (and symbol (substring-no-properties symbol)))

--- a/helm-elisp.el
+++ b/helm-elisp.el
@@ -812,6 +812,21 @@ it is. Return the symbol name as a string, or nil if no symbol is found."
           (match-string 2 symbol-string)
         (symbol-name (intern-soft symbol-string))))))
 
+(defun helm-apropos-get-default ()
+  "Return the default symbol name at point.
+In Org derived modes, strip the tilde (`~') or equal (`=') characters
+before returning the symbol name. Otherwise, return the symbol name as
+it is. Return the symbol name as a string, or nil if no symbol is found."
+  (with-syntax-table emacs-lisp-mode-syntax-table
+    (let* ((symbol (thing-at-point 'symbol t))
+           (symbol-string (and symbol (substring-no-properties symbol))))
+      (if (and symbol-string (derived-mode-p 'org-mode))
+          (let ((regexp "\\`[~=]?\\(.*?\\)[~=]\\'"))
+            (if (string-match regexp symbol-string)
+                (match-string 1 symbol-string)
+              symbol-string))
+        (symbol-name (intern-soft symbol-string))))))
+
 ;;;###autoload
 (defun helm-apropos (default)
   "Preconfigured Helm to describe commands, functions, variables and faces.

--- a/helm-elisp.el
+++ b/helm-elisp.el
@@ -798,7 +798,15 @@ is only used to test DEFAULT."
 
 (defun helm-apropos-get-default ()
   (with-syntax-table emacs-lisp-mode-syntax-table
-    (symbol-name (intern-soft (thing-at-point 'symbol)))))
+    (let* ((symbol (thing-at-point 'symbol t))
+           (symbol-string (and symbol (substring-no-properties symbol)))
+           (regexp "^\\(~\\|=\\)?\\(.*?\\)\\(~\\|=\\)$")
+           (wrapped-symbol (and symbol-string
+                                (string-match regexp symbol-string))))
+      (if (and (derived-mode-p 'org-mode)
+               wrapped-symbol)
+          (match-string 2 symbol-string)
+        (symbol-name (intern-soft symbol-string))))))
 
 ;;;###autoload
 (defun helm-apropos (default)


### PR DESCRIPTION
M-x helm-apropos fails to preselect the correct symbol at point when wrapped with the = or ~ characters. This patch makes helm-apropos smarter in Org derived modes by stripping the wrappers before returning the symbol name. Some examples:

```
mu4e-mailing-lists  =>  mu4e-mailing-lists 
~mu4e-mailing-lists~  =>  mu4e-mailing-lists
=mu4e-mailing-lists=  =>  mu4e-mailing-lists
mu4e~headers-mark   =>  mu4e~headers-mark
~mu4e~headers-mark~  =>  mu4e~headers-mark
~M-x mu4e-quit~    =>  mu4e-quit
=M-x mu4e-quit=   =>  mu4e-quit
```