### PR TITLE
include checking tab in helm-ff-last-expanded-candidate-regexp

### DIFF
--- a/helm-files.el
+++ b/helm-files.el
@@ -114,10 +114,10 @@
 
 ;;; Internal vars
 ;;
-(defvar helm-ff-last-expanded-candidate-regexp "^[[:multibyte:] ]*%s"
+(defvar helm-ff-last-expanded-candidate-regexp "^[[:multibyte:] \t]*%s"
   "Regexp that retrieve previous candidate when going up one level.
 The default value matching a multibyte char at bol allows
-prefixing candidate with an icon.  The format part will be
+prefixing candidate with an icon. The format part will be
 replaced by the display part of the candidate regexp quoted.
 This should be used for all preselection code for helm-find-files
 to handle icons.")


### PR DESCRIPTION
Hi,

I include the checking for a tab whitespace into `helm-ff-last-expanded-candidate-regexp`, since the icons produced by https://github.com/rainstormstudio/treemacs-nerd-icons are followed by a tab.

Please consider merging this PR.

Thanks!