### PR TITLE
make helm-M-x-class's filtered-candidate-transformer customizable

### DIFF
--- a/helm-command.el
+++ b/helm-command.el
@@ -55,6 +55,12 @@ This value can be toggled with
 \\<helm-M-x-map>\\[helm-M-x-toggle-short-doc] while in helm-M-x session."
   :type 'boolean)
 
+(defcustom helm-M-x-filtered-candidate-transformer
+  #'helm-M-x-transformer
+  "The function to transform filtered candidates."
+  :group 'helm-command
+  :type 'function)
+
 
 ;;; Faces
 ;;
@@ -258,7 +264,7 @@ algorithm."
 (defclass helm-M-x-class (helm-source-in-buffer helm-type-command)
   ((requires-pattern :initform 0)
    (must-match :initform t)
-   (filtered-candidate-transformer :initform 'helm-M-x-transformer)
+   (filtered-candidate-transformer :initform (lambda (candidates _source) (funcall helm-M-x-filtered-candidate-transformer candidates _source)))
    (persistent-help :initform "Describe this command")
    (help-message :initform 'helm-M-x-help-message)
    (nomark :initform t)

--- a/helm-command.el
+++ b/helm-command.el
@@ -55,11 +55,9 @@ This value can be toggled with
 \\<helm-M-x-map>\\[helm-M-x-toggle-short-doc] while in helm-M-x session."
   :type 'boolean)
 
-(defcustom helm-M-x-filtered-candidate-transformer
-  #'helm-M-x-transformer
-  "The function to transform filtered candidates."
-  :group 'helm-command
-  :type 'function)
+(defcustom helm-M-x-history-transformer-sort t
+  "When nil, do not sort helm-M-x's commands history."
+  :type 'boolean)
 
 
 ;;; Faces
@@ -264,7 +262,7 @@ algorithm."
 (defclass helm-M-x-class (helm-source-in-buffer helm-type-command)
   ((requires-pattern :initform 0)
    (must-match :initform t)
-   (filtered-candidate-transformer :initform (lambda (candidates _source) (funcall helm-M-x-filtered-candidate-transformer candidates _source)))
+   (filtered-candidate-transformer :initform #'helm-M-x-transformer)
    (persistent-help :initform "Describe this command")
    (help-message :initform 'helm-M-x-help-message)
    (nomark :initform t)
@@ -293,9 +291,11 @@ Arg HISTORY default to `extended-command-history'."
   (setq helm--mode-line-display-prefarg t)
   (let* ((pred (or predicate #'commandp))
          (helm-fuzzy-sort-fn (lambda (candidates _source)
-                               ;; Sort on real candidate otherwise
-                               ;; "symbol (<binding>)" is used when sorting.
-                               (helm-fuzzy-matching-default-sort-fn-1 candidates t)))
+                               (if helm-M-x-history-transformer-sort
+                                   ;; Sort on real candidate otherwise
+                                   ;; "symbol (<binding>)" is used when sorting.
+                                   (helm-fuzzy-matching-default-sort-fn-1 candidates t)
+                                 candidates)))
          (sources `(,(helm-make-source "Emacs Commands history" 'helm-M-x-class
                        :data (lambda ()
                                (helm-comp-read-get-candidates
@@ -307,6 +307,10 @@ Arg HISTORY default to `extended-command-history'."
                                 ;; Ensure using empty string to
                                 ;; not defeat helm matching fns [1]
                                 pred nil nil ""))
+                       :filtered-candidate-transformer
+                       (if helm-M-x-history-transformer-sort
+                           #'helm-M-x-transformer
+                         #'helm-M-x-transformer-no-sort)
                        :fuzzy-match helm-M-x-fuzzy-match)
                     ,(helm-make-source "Emacs Commands" 'helm-M-x-class
                        :data (lambda ()


### PR DESCRIPTION
It seems `filtered-candidate-transformer` should be a function, as it's used in `(apply f ..)` form. So I use a lambda.