### PR TITLE
fix base may be nil on Windows in helm-common-dir

### DIFF
--- a/helm-files.el
+++ b/helm-files.el
@@ -6006,8 +6006,9 @@ and `dired-compress-files-alist'."
   "Return the longest common directory path of FILES list"
   (cl-loop with base = (car files)
            for file in files
+           while base
            do (setq base (fill-common-string-prefix base file))
-           finally return (file-name-directory base)))
+           finally return (when base (file-name-directory base))))
 
 (defun helm-ff--dired-compress-file (file)
   ;; `dired-compress-file' doesn't take care of binding `default-directory' when


### PR DESCRIPTION
On windows, files may be in different partitions, like c:/f1, d:/f2. In this case, they don't have common directory, and helm-common-dir will fail with error "(wrong-type-argument stringp nil)" as `base` is nil. 