### PR TITLE
helm-frame-alpha: Set default value to actual value used if nil

### DIFF
--- a/helm-core.el
+++ b/helm-core.el
@@ -1080,7 +1080,7 @@ Fallback to default face foreground when nil"
   :group 'helm
   :type 'string)
 
-(defcustom helm-frame-alpha nil
+(defcustom helm-frame-alpha 100
   "Alpha parameter for Helm frames, an integer.
 Fallback to 100 when nil."
   :group 'helm


### PR DESCRIPTION
The default value of `helm-frame-alpha' didn't match the specified
custom type. Since the default value which is in use if nil is 100
setting it to 100 is the best choice as it doesn't break any existing
code where setting to nil is used to set it to the default value of
100.