### PR TITLE
Add affixations for Info files

### DIFF
--- a/helm-info.el
+++ b/helm-info.el
@@ -144,6 +144,7 @@ If line have a node use the node, otherwise use directly first name found."
    (filtered-candidate-transformer
     :initform
     (lambda (candidates _source)
+      (require 'helm-mode)
       (cl-loop for line in candidates
                when (string-match helm-info--node-regexp line)
                do (progn
@@ -153,7 +154,7 @@ If line have a node use the node, otherwise use directly first name found."
                      nil line)
                     (helm-add-face-text-properties
                      (match-beginning 2) (match-end 2)
-                     'font-lock-warning-face
+                     'helm-completions-detailed
                      nil line))
                collect line)))
    (display-to-real :initform #'helm-info-display-to-real)

--- a/helm-info.el
+++ b/helm-info.el
@@ -331,7 +331,13 @@ nil, a description of Info files is provided.  The Info files are
 partially cached in the variables `helm-info--files-cache' and
 `helm-info--files-docs-cache'.  TIP: You can make these vars
 persistent for faster start with the psession package, using
-\\[psession-make-persistent-variable]."
+\\[psession-make-persistent-variable].
+
+NOTE: The caches affect as well `info-dislpay-manual' when
+`helm-mode' is enabled and `completions-detailed' is non nil.
+When new Info files are installed, for example a library update
+changed Info dir node entry, you can reset the caches with
+a prefix arg."
   (interactive "P")
   (let ((default (unless (ring-empty-p helm-info-searched)
                    (ring-ref helm-info-searched 0))))

--- a/helm-info.el
+++ b/helm-info.el
@@ -250,17 +250,10 @@ helm-info-<CANDIDATE>."
    (with-temp-buffer
      (ignore-errors (info-insert-file-contents file))
      (goto-char (point-min))
-     (when (re-search-forward (rx line-start "START-INFO-DIR-ENTRY" line-end)
-                              nil t)
+     (when (re-search-forward "^START-INFO-DIR-ENTRY$" nil t)
        (forward-line 1)
        (when (re-search-forward
-              (rx line-start
-                  "*" (one-or-more whitespace)
-                  (group (one-or-more (not ":")))
-                  ":" (one-or-more whitespace)
-                  "(" (one-or-more (not ")"))
-                  ")." (one-or-more whitespace)
-                  (group (one-or-more any)))
+              "^\\*[[:space:]]+\\([^:]+\\):[[:space:]]+([^)]+)\\.[[:space:]]+\\(.+\\)"
               (pos-eol) t)
          (format "%s: %s"
                  (match-string 1) (match-string 2)))))

--- a/helm-info.el
+++ b/helm-info.el
@@ -279,9 +279,10 @@ helm-info-<CANDIDATE>."
                  for sep = (helm-make-separator c longest)
                  for file = (or
                              (assoc-default c helm-info--files-cache)
-                             (let ((file (Info-find-file c)))
-                               (push (cons c file) helm-info--files-cache)
-                               file))
+                             (let ((file (Info-find-file c t)))
+                               (when file
+                                 (push (cons c file) helm-info--files-cache)
+                                 file)))
                  for doc = (and file
                                 (or completions-detailed helm-completions-detailed)
                                 (or (gethash file helm-info--files-doc-cache)

--- a/helm-mode.el
+++ b/helm-mode.el
@@ -1447,9 +1447,10 @@ is used."
                                 blist nil))))
                     found)
                   (assoc-default comp helm-info--files-cache)
-                  (let ((file (Info-find-file comp)))
-                    (push (cons comp file) helm-info--files-cache)
-                    file)))
+                  (let ((file (Info-find-file comp t)))
+                    (when file
+                      (push (cons comp file) helm-info--files-cache)
+                      file))))
            (summary (or (gethash file helm-info--files-doc-cache)
                         (puthash file (helm-info-file-doc file)
                                  helm-info--files-doc-cache))))

--- a/helm-mode.el
+++ b/helm-mode.el
@@ -1435,10 +1435,7 @@ is used."
                   ;; wrong file. For example, the latter can happen after a
                   ;; development version of info file has been opened.
                   (let ((blist (buffer-list))
-                           (manual-re (rx-to-string `(seq (or "/" string-start)
-                                                          ,comp
-                                                          (or "." string-end))
-                                                    t))
+                           (manual-re (concat "/\\|\\`" comp "\\.\\|\\'"))
                            (case-fold-search t)
                            found)
                     (dolist (buffer blist)


### PR DESCRIPTION
I've taken a liberty to create this PR to provide similar functionality to what
`helm` already provides for `helm-locate-library` and `find-library`
commands. I've taken a very similar approach here by scanning files to get a
nice Info file description, based on the Info dir entry.

I've also used this opportunity to update affixations' face in
`helm-info-at-point`.

I've tried to split the work into logical parts into separate commits. Please
let me know if you have any suggestions.