### PR TITLE
Add prefix to denote buffers in info-display-manual affixation

### DIFF
--- a/helm-mode.el
+++ b/helm-mode.el
@@ -1425,6 +1425,7 @@ is used."
   (require 'helm-info)
   (lambda (comp)
     (let* ((sep (helm-make-separator comp))
+           (prefix "")
            (file (or
                   ;; The `info-display-manual' favours `Info-mode'
                   ;; buffers. However, each buffer like that may be opened from
@@ -1440,10 +1441,11 @@ is used."
                     (cl-loop for buffer in (buffer-list) thereis
                              (with-current-buffer buffer
                                (when (and (derived-mode-p 'Info-mode)
-		                          (stringp Info-current-file)
-		                          (string-match
+		                                  (stringp Info-current-file)
+		                                  (string-match
                                            manual-re Info-current-file))
-	                         Info-current-file))))
+                                 (setq prefix "*")
+	                             Info-current-file))))
                   (assoc-default comp helm-info--files-cache)
                   (helm-aif (Info-find-file comp t)
                       (prog1 it (push (cons comp it) helm-info--files-cache)))))
@@ -1451,7 +1453,8 @@ is used."
                         (puthash file (helm-info-file-doc file)
                                  helm-info--files-doc-cache))))
       (list comp
-            ""
+            (helm-aand (propertize prefix 'face 'helm-completions-detailed)
+                       (propertize " " 'display (format "%-2s" it)))
             (helm-aand (propertize summary 'face 'helm-completions-detailed)
                        (propertize " " 'display (concat sep it)))))))
 


### PR DESCRIPTION
Following up on #2698, a small idea to give a visual indicator in
`info-display-manual` when a candidate is a buffer.

I have only thought about it when writing the most recent explanation. Let me
know if this is something worth having.