### PR TITLE
Fix qoutes in Info files affixation

### DIFF
--- a/helm-info.el
+++ b/helm-info.el
@@ -255,7 +255,7 @@ helm-info-<CANDIDATE>."
        (when (re-search-forward
               "^\\*[[:space:]]+\\([^:]+\\):[[:space:]]+([^)]+)\\.[[:space:]]+\\(.+\\)"
               (pos-eol) t)
-         (format "%s: %s"
+         (format-message "%s: %s"
                  (match-string 1) (match-string 2)))))
    "No summary"))
 


### PR DESCRIPTION
Some Info files use fancy quotes in their Info dir entry. When pushing such a
text through regular `format` it will end up rendering them poorly. Use
`format-message` to follow user `text-quoting-style` settings.

Example of such poorly rendering affixation: `gawkworkflow`.