### PR TITLE
fix: exception occurring when trimming empty summary string

### DIFF
--- a/helm-lib.el
+++ b/helm-lib.el
@@ -2024,11 +2024,9 @@ Directories expansion is not supported."
       (goto-char (point-min))
       (when (re-search-forward "^;;;?\\(.*\\) ---? \\(.*\\)" (pos-eol) t)
         (setq desc (match-string-no-properties 2)))
-      (if-let ((_ (and desc (length> desc 0)))
-               (summary (car (split-string desc "-\\*-" nil)))
-               (_ (length> summary 0)))
-          (string-trim summary "[ \t\n\r-]+" "[ \t\n\r-]+")
-        "Not documented"))))
+      (if (or (null desc) (string= "" desc) (string-match "\\`-*-" desc))
+          "Not documented"
+        (car (split-string desc "-\\*-" nil "[ \t\n\r-]+"))))))
 
 (defun helm-local-directory-files (directory &rest args)
   "Run `directory-files' without tramp file name handlers.

--- a/helm-lib.el
+++ b/helm-lib.el
@@ -2024,7 +2024,7 @@ Directories expansion is not supported."
       (goto-char (point-min))
       (when (re-search-forward "^;;;?\\(.*\\) ---? \\(.*\\)" (pos-eol) t)
         (setq desc (match-string-no-properties 2)))
-      (if (or (null desc) (string= "" desc) (string-match "\\`-*-" desc))
+      (if (or (null desc) (string= "" desc) (string-match "\\`-\\*-" desc))
           "Not documented"
         (car (split-string desc "-\\*-" nil "[ \t\n\r-]+"))))))
 

--- a/helm-lib.el
+++ b/helm-lib.el
@@ -2024,9 +2024,11 @@ Directories expansion is not supported."
       (goto-char (point-min))
       (when (re-search-forward "^;;;?\\(.*\\) ---? \\(.*\\)" (pos-eol) t)
         (setq desc (match-string-no-properties 2)))
-      (if (or (null desc) (string= "" desc))
-          "Not documented"
-        (car (split-string desc "-\\*-" nil "[ \t\n\r-]+"))))))
+      (if-let ((_ (and desc (length> desc 0)))
+               (summary (car (split-string desc "-\\*-" nil)))
+               (_ (length> summary 0)))
+          (string-trim summary "[ \t\n\r-]+" "[ \t\n\r-]+")
+        "Not documented"))))
 
 (defun helm-local-directory-files (directory &rest args)
   "Run `directory-files' without tramp file name handlers.


### PR DESCRIPTION
Hi,

This PR fixes the exception when Helm tries to get the summary of libraries whose summary strings are empty.

Example: the library [haskell-c2hs.el](https://github.com/haskell/haskell-mode/blob/master/haskell-c2hs.el) has empty summary string: the content between `---` and `-*-` is empty.

```emacs-lisp
;; haskell-c2hs.el --- -*- lexical-binding: t; -*-
```

This causes Helm to throw an exception when running `find-library`. The main culprit function that throws the exception is `split-string`, when it attempts to trim the string `"[ \11\n\15-]+"` from an empty summary .

```emacs-lisp
Debugger entered--Lisp error: (args-out-of-range "-*- lexical-binding: t; -*-" 1 0)
  split-string("-*- lexical-binding: t; -*-" "-\\*-" nil "[ \11\n\15-]+")
  helm-locate-lib-get-summary("/home/trung/.config/emacs/.local/straight/build-31.0.50/haskell-mode/haskell-c2hs.el")
  #<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_48>("haskell-c2hs")
  helm-completion--decorate(("haskell" "hashcash"  ...))
  ....
 ```

There might be other libraries that contain similar issues.

I fixed this bug by checking if the summary string is non-empty before trimming it.

Please consider merging this PR.

Thanks!
