### PR TITLE
use a more specialized face for key binding information

### DIFF
--- a/helm-mode.el
+++ b/helm-mode.el
@@ -1295,7 +1295,7 @@ is used."
     (let* ((key     (and (commandp sym) (where-is-internal sym nil 'first-only)))
            (binding (and key (key-description key))))
       (when binding
-        (propertize (format " (%s)" binding) 'face 'shadow)))))
+        (propertize (format " (%s)" binding) 'face 'help-key-binding)))))
 
 (defun helm-completion-package-affixation (_completions)
   (lambda (comp)


### PR DESCRIPTION
Hi,

This is a minor patch to use the `help-key-binding` face to make the key binding information in Helm more distinguishable.

![helm-keys](https://github.com/user-attachments/assets/f4431892-9022-4221-be1b-e57af49c2562)
