### PR TITLE
Generate lexical cooky in the adaptive-history file

### DIFF
--- a/helm-adaptive.el
+++ b/helm-adaptive.el
@@ -173,7 +173,7 @@ Returns nil if `helm-adaptive-history-file' doesn't exist."
   (when helm-adaptive-history-file
     (with-temp-buffer
       (insert
-       ";; -*- mode: emacs-lisp -*-\n"
+       ";; -*- mode: emacs-lisp; lexical-binding: t -*-\n"
        ";; History entries used for helm adaptive display.\n")
       (let (print-length print-level)
         (prin1 `(setq helm-adaptive-history ',helm-adaptive-history)


### PR DESCRIPTION
Can we possibly get a lexical-binding cookie generated when adaptive-history file is generated so we skip the annoying warnings in Emacs? If you want this patch or want it add it yourself, I would be happy with any.
