### PR TITLE
* helm-x-icons: Fix "all-the-icons-mode-icon-alist" variable is void

### DIFF
--- a/helm-x-icons.el
+++ b/helm-x-icons.el
@@ -52,9 +52,10 @@ The returned alist is computed according to `helm-x-icons-provider'."
                       (regexp "regexp-icon-alist")
                       (dir "dir-icon-alist")
                       (url "url-alist")
-                      (mode "mode-icon-alist"))))
-    (symbol-value
-     (intern-soft (concat provider-name "-" alist-name)))))
+                      (mode "mode-icon-alist")))
+         (sym (intern-soft (concat provider-name "-" alist-name))))
+    (when (boundp sym)
+      (symbol-value sym))))
 
 (defun helm-x-icons-icon-for-file (&rest args)
   "Compatibility function for `*-icon-for-file'."


### PR DESCRIPTION
Fix the https://github.com/syl20bnr/spacemacs/issues/17061 in which there is an error message:
> helm-buffer--show-details: Symbol’s value as variable is void: all-the-icons-mode-icon-alist

The issue is consistently reproducible on the Spacemacs for it caused by the detecting symbol exists or not with `intern-soft` is not reliable (or, intern-soft can not detect the symbol exists or not).  This PR will fix the issue.

Please help review it. Thank you !