### PR TITLE
helm-grep: run ag from the current project root

### DIFF
--- a/helm-grep.el
+++ b/helm-grep.el
@@ -1857,9 +1857,15 @@ With prefix arg prompt for type if available with your AG version."
   (require 'helm-files)
   (require 'project)
   (helm-aif (project-current)
-      (let* ((project-root (expand-file-name (car (last it))))
-             (default-directory project-root))
-        (helm-grep-ag project-root arg))
+      (let* ((project-type (car it))
+             (project-root (cond ((equal project-type 'vc)
+                                  (car (last it)))
+                                 ((equal project-type 'projectile)
+                                  (cdr it))
+                                 (t default-directory)))
+             (project-root-abs (expand-file-name project-root))
+             (default-directory project-root-abs))
+        (helm-grep-ag project-root-abs arg))
     (message "Not in any project!")))
 
 ;;;###autoload


### PR DESCRIPTION
Hi,

I added a new function to run helm-grep-ag from the current project root.
Could you help to review it?

Thanks!