### PR TITLE
ensure that vc-deduce-backend works correctly in all cases

### DIFF
--- a/helm-files.el
+++ b/helm-files.el
@@ -116,6 +116,7 @@
 (defvar wfnames-buffer)
 (defvar Info-current-file)
 (defvar generated-autoload-file)
+(defvar vc-deduce-backend-nonvc-modes)
 
 ;;; Internal vars
 ;;
@@ -7132,6 +7133,7 @@ and
                                     (fboundp 'helm-hg-root)
                                     (helm-hg-root))
                          it))
+         (vc-deduce-backend-nonvc-modes t)
          (project-type (vc-deduce-backend)))
     (cl-flet ((push-to-hist (root)
                 (setq helm-browse-project-history


### PR DESCRIPTION
Hi,

This is a small fix to ensure that the setting `(setq vc-deduce-backend-nonvc-modes t)` in your comment is always met.

https://github.com/emacs-helm/helm/pull/2732#issuecomment-3093228690