### PR TITLE
Fix update-directory-autoloads for Emacs 29+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ clean:
 # Make autoloads file
 autoloads:
 	$(EVAL) "(progn (setq generated-autoload-file (expand-file-name \"helm-autoloads.el\" \"$(PKGDIR)\")) \
-(setq backup-inhibited t) (update-directory-autoloads \"$(PKGDIR)\"))"
+(setq backup-inhibited t) (if (< emacs-major-version 29) (update-directory-autoloads \"$(PKGDIR)\") (loaddefs-generate \"$(PKGDIR)\" generated-autoload-file nil nil nil t)))"
 
 PREFIX=/usr/local/
 BIN=${PREFIX}bin/


### PR DESCRIPTION
In Emacs 29 the autoload system has been replaced with a new implementation where autoloads are generated using loaddefs-generate instead of update-directory-autoloads.

This commit add a check in the Makefile for the autoloads target for Emacs major version and if it is less than 29 the old function is used, otherwise loaddefs-generate is used.