### PR TITLE
Fix file-info tooltip on wrong monitor

### DIFF
--- a/helm-files.el
+++ b/helm-files.el
@@ -634,6 +634,14 @@ i.e. filtering filenames inside directory."
           (const :tag "size" size)
           (const :tag "extensions" ext)))
 
+(defcustom helm-ff-tooltip-horizontal-padding 0
+  "Specify amount of horizontal padding used by windowing system when
+rendering tooltips. The specified amount of padding is used to move the
+tooltip horizontally when Helm renders a file properties tool tip (`M-i'
+is pressed) to avoid the windowing system applied padding obscuring the
+end of the filename."
+  :type 'integer)
+
 (defcustom helm-ff-rotate-image-program "exiftran"
   "External program used to rotate images.
 When nil and `helm-ff-display-image-native' is enabled, fallback to
@@ -4086,11 +4094,17 @@ to avoid an unnecessary call to `file-truename'."
              (access             (cl-getf it :access-time))
              (ext                (helm-get-default-program-for-file candidate))
              (tooltip-hide-delay (or helm-tooltip-hide-delay tooltip-hide-delay))
+             (frame-params       (with-helm-window (frame-parameters)))
+             (frame-left         (cdr (assoc 'left frame-params)))
+             (frame-top          (cdr (assoc 'top  frame-params)))
              (posn (with-helm-window
                      (posn-at-point (save-excursion (end-of-visual-line) (point)))))
              (tooltip-frame-parameters (append tooltip-frame-parameters
-                                               `((left . ,(car (posn-x-y posn)))
-                                                 (top .  ,(cdr (posn-x-y posn)))))))
+                                               `((left . ,(+ frame-left
+                                                             helm-ff-tooltip-horizontal-padding
+                                                             (car (posn-x-y posn))))
+                                                 (top .  ,(+ frame-top
+                                                             (cdr (posn-x-y posn))))))))
         (if (and (display-graphic-p) tooltip-mode)
             (tooltip-show
              (concat
@@ -4117,9 +4131,9 @@ to avoid an unnecessary call to `file-truename'."
                         (helm-directory-size
                          candidate current-prefix-arg t)))
               (format "Modified: %s\n" modif)
-              (format "Accessed: %s\n" access)
+              (format "Accessed: %s" access)
               (and (stringp trash)
-                   (format "Trash: %s\n"
+                   (format "\nTrash: %s"
                            (abbreviate-file-name trash)))))
           (message dired-line) (sit-for 5)))
     (message "Permission denied, file not readable")))


### PR DESCRIPTION
Fix file-info tooltip always rendered on the leftmost (and perhaps also topmost) monitor in a multi-monitor setup. For instance, when having a multi-monitor setup (LEFT and RIGHT) where Emacs is running on the RIGHT monitor and you press 'M-i' in helm-find-files for a file, the toolip window is displayed on the LEFT monitor instead of the RIGHT monitor.

This is due to that the function posn-at-point always return an XY-coordinate in the *local* monitor and frame coordinate system and the function tooltip-show always render in the *global* coordinate system that spans across all monitors in the multi-monitor setup.

To correct this the frames left and top coordinates need to be added to the corresponding values returned from posn-at-point.

In addition to this, Gnome (at least as it is configured in stock Ubuntu 24.04) adds a thick border around the tooltip that is rendered *outside* of the actual tooltip area (to the left and above of the left and top coordinates given to tooltip-show indirectly via tooltip-frame-parameters). Emacs is not aware of this extra border around the tooltip (not sure if it is even theoretically possible for Emacs to find out the size of any such border-padding) and thus it can not compensate for it. The effect is that the extra border-padding covers the end of the file-name the tooltip shows meta-information about (couple of characters). To give the user a chance to compensate for any such window system behavior a new custom variable is introduced in this commit (helm-ff-tooltip-horizontal-padding) with default value 0. This variable is added to the x-coordinate of the tooltip in an attempt to allow the user to compensate for the possible padding employed by the window system.

Finally when the tooltip-content is prepared the last entry adds an extra new-line character that inserts an extra blank line at the end of the tooltip when it is rendered. This last new-line is removed by this commit.