### PR TITLE
Don't let an unreadable file abort helm-highlight-files

### DIFF
--- a/helm-for-files.el
+++ b/helm-for-files.el
@@ -199,7 +199,14 @@ Colorize only symlinks, directories and files."
            for type = (and (or (null isremote)
                                (and (null helm-for-files-tramp-not-fancy)
                                     (file-remote-p i nil t)))
-                           (car (file-attributes i)))
+                           ;; Don't let an unreadable file (e.g. under a
+                           ;; directory whose permissions were revoked) signal a
+                           ;; file-error and abort highlighting the whole list;
+                           ;; treat it as a plain file.  Same guard as in
+                           ;; `helm-ff-filter-candidate-one-by-one' (bug#2405).
+                           (car (condition-case nil
+                                    (file-attributes i)
+                                  (file-error nil))))
            collect
            (cond (;; No fancy display on remote files with basic predicates.
                   (and (null type) isremote) (cons disp i))


### PR DESCRIPTION
## Problem

With sources that route file lists through `helm-highlight-files` (`helm-mini`, `helm-recentf`, …), a single candidate under a directory whose permissions were revoked (`chmod 000`) aborts the **entire** source — `helm-highlight-files: Getting attributes: Permission denied` — leaving an empty helm buffer.

## Cause

`helm-highlight-files` calls `(car (file-attributes i))` on every candidate with no guard. `file-attributes` signals a `file-error` for an unreadable path, and that propagates out of the `cl-loop`, aborting construction of the whole buffer.

## Fix

Wrap the `file-attributes` call in a `condition-case` that yields `nil` on `file-error`, so an unreadable file is treated as a plain file (`type` nil) instead of aborting the source. This mirrors the guard helm already uses in `helm-ff-filter-candidate-one-by-one` (bug#2405).

## Testing

In a live Emacs, create a file under a `chmod 000` directory and pass it to `helm-highlight-files`:

- **before:** aborts with `file-error` (Permission denied)
- **after:** returns the full candidate list; the unreadable file falls back to the plain file face.