### PR TITLE
Fix CRM insertion with regexp separators

### DIFF
--- a/helm-mode.el
+++ b/helm-mode.el
@@ -3135,7 +3135,9 @@ Be sure to know what you are doing when modifying this.")
                          crm-separator)
                         (and (stringp crm-separator)
                              (or (get-text-property 0 'separator crm-separator)
-                                 (string-replace "[ \t]*" "" crm-separator)))
+                                 (let ((sep (string-replace
+                                             "[ \t]*" "" crm-separator)))
+                                   (and (eq (length sep) 1) sep))))
                         helm-crm-default-separator)))
            ;; Try to find a default separator. If `crm-separator' is a
            ;; regexp use the string the regexp is matching.

--- a/test/helm-mode-tests.el
+++ b/test/helm-mode-tests.el
@@ -1,0 +1,58 @@
+;;; helm-mode-tests.el --- Tests for Helm mode -*- lexical-binding: t -*-
+
+;; Copyright (C) 2012 ~ 2026 Thierry Volpiatto
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Tests for helm-mode.el.
+
+;;; Code:
+
+(require 'ert)
+(require 'helm-mode)
+
+(defvar crm-separator)
+
+(ert-deftest helm-mode-test-crm-regexp-separator-is-not-inserted ()
+  (with-temp-buffer
+    (insert "Range: ")
+    (let ((crm-separator "\\.\\.\\.\\?")
+          (helm-crm-default-separator nil))
+      (helm-completion-in-region--insert-result
+       (list "some-string")
+       1 (point) (point) 0)
+      (should (equal (buffer-string) "some-string")))))
+
+(ert-deftest helm-mode-test-crm-text-property-separator-is-inserted ()
+  (with-temp-buffer
+    (insert "Range: ")
+    (let ((crm-separator (propertize "\\.\\.\\.\\?" 'separator "..."))
+          (helm-crm-default-separator nil))
+      (helm-completion-in-region--insert-result
+       (list "some-string")
+       1 (point) (point) 0)
+      (should (equal (buffer-string) "some-string...")))))
+
+(ert-deftest helm-mode-test-crm-regexp-derived-separator-is-inserted ()
+  (with-temp-buffer
+    (insert "Prompt ")
+    (let ((crm-separator "[ \t]*:[ \t]*")
+          (helm-crm-default-separator ","))
+      (helm-completion-in-region--insert-result
+       (list "my-branch")
+       1 (point) (point) 0)
+      (should (equal (buffer-string) "my-branch:")))))
+
+;;; helm-mode-tests.el ends here


### PR DESCRIPTION
When completing CRM candidates, Helm may need to infer the literal
separator to append from `crm-separator`.

Commit 52e1a7f9 added this for cases such as `[ \t]*:[ \t]*`, where
stripping optional whitespace from the regexp gives the literal `:`
separator and avoids falling back to `,`.

That heuristic also applied to arbitrary regexp separators.  Callers
such as Magit use `\\.\\.\\.\\?` to read revision ranges, where the
regexp describes accepted input but is not itself a literal separator
to insert.  In that case Helm inserted the escaped regexp text after a
candidate.

This keeps the 52e1a7f9 behavior when stripping optional whitespace
leaves a single literal character, but otherwise uses only an explicit
`separator` text property or `helm-crm-default-separator`.

Verification:
- `emacs -q -batch -L . -L ../build/async -l ./helm-mode.el -l ./test/helm-mode-tests.el -f ert-run-tests-batch-and-exit`
- `make STRAIGHT_DIR=../build all`
